### PR TITLE
[DYOD] Team 3 - Sprint 4

### DIFF
--- a/src/lib/storage/table_column_definition.cpp
+++ b/src/lib/storage/table_column_definition.cpp
@@ -16,11 +16,4 @@ size_t TableColumnDefinition::hash() const {
   boost::hash_combine(hash, nullable);
   return hash;
 }
-
-TableColumnDefinitions concatenated(const TableColumnDefinitions& lhs, const TableColumnDefinitions& rhs) {
-  auto column_definitions = lhs;
-  column_definitions.insert(column_definitions.end(), rhs.begin(), rhs.end());
-  return column_definitions;
-}
-
 }  // namespace hyrise

--- a/src/lib/storage/table_column_definition.hpp
+++ b/src/lib/storage/table_column_definition.hpp
@@ -27,6 +27,4 @@ inline std::ostream& operator<<(std::ostream& stream, const TableColumnDefinitio
 
 using TableColumnDefinitions = std::vector<TableColumnDefinition>;
 
-TableColumnDefinitions concatenated(const TableColumnDefinitions& lhs, const TableColumnDefinitions& rhs);
-
 }  // namespace hyrise

--- a/src/test/lib/operators/difference_test.cpp
+++ b/src/test/lib/operators/difference_test.cpp
@@ -46,6 +46,14 @@ TEST_F(OperatorsDifferenceTest, DifferenceOnValueTables) {
   EXPECT_TABLE_EQ_UNORDERED(difference->get_output(), expected_result);
 }
 
+TEST_F(OperatorsDifferenceTest, GetName) {
+  std::shared_ptr<Table> expected_result =
+      load_table("resources/test_data/tbl/int_float_filtered2.tbl", ChunkOffset{2});
+
+  auto difference = std::make_shared<Difference>(_table_wrapper_a, _table_wrapper_b);
+  EXPECT_EQ(difference->name(), "Difference");
+}
+
 TEST_F(OperatorsDifferenceTest, DifferneceOnReferenceTables) {
   std::shared_ptr<Table> expected_result =
       load_table("resources/test_data/tbl/int_float_filtered2.tbl", ChunkOffset{2});

--- a/src/test/lib/operators/difference_test.cpp
+++ b/src/test/lib/operators/difference_test.cpp
@@ -40,7 +40,8 @@ TEST_F(OperatorsDifferenceTest, DifferenceOnValueTables) {
   const auto difference = std::make_shared<Difference>(_table_wrapper_a, _table_wrapper_b);
   difference->execute();
 
-  EXPECT_TABLE_EQ_UNORDERED(difference->get_output(), load_table("resources/test_data/tbl/int_float_filtered2.tbl", ChunkOffset{2}));
+  EXPECT_TABLE_EQ_UNORDERED(difference->get_output(),
+                            load_table("resources/test_data/tbl/int_float_filtered2.tbl", ChunkOffset{2}));
 }
 
 TEST_F(OperatorsDifferenceTest, GetName) {

--- a/src/test/lib/operators/difference_test.cpp
+++ b/src/test/lib/operators/difference_test.cpp
@@ -37,13 +37,10 @@ class OperatorsDifferenceTest : public BaseTest {
 };
 
 TEST_F(OperatorsDifferenceTest, DifferenceOnValueTables) {
-  std::shared_ptr<Table> expected_result =
-      load_table("resources/test_data/tbl/int_float_filtered2.tbl", ChunkOffset{2});
-
   auto difference = std::make_shared<Difference>(_table_wrapper_a, _table_wrapper_b);
   difference->execute();
 
-  EXPECT_TABLE_EQ_UNORDERED(difference->get_output(), expected_result);
+  EXPECT_TABLE_EQ_UNORDERED(difference->get_output(), load_table("resources/test_data/tbl/int_float_filtered2.tbl", ChunkOffset{2}));
 }
 
 TEST_F(OperatorsDifferenceTest, GetName) {

--- a/src/test/lib/operators/difference_test.cpp
+++ b/src/test/lib/operators/difference_test.cpp
@@ -45,8 +45,6 @@ TEST_F(OperatorsDifferenceTest, DifferenceOnValueTables) {
 }
 
 TEST_F(OperatorsDifferenceTest, GetName) {
-  auto expected_result = load_table("resources/test_data/tbl/int_float_filtered2.tbl", ChunkOffset{2});
-
   const auto difference = std::make_shared<Difference>(_table_wrapper_a, _table_wrapper_b);
   EXPECT_EQ(difference->name(), "Difference");
 }

--- a/src/test/lib/operators/difference_test.cpp
+++ b/src/test/lib/operators/difference_test.cpp
@@ -47,10 +47,9 @@ TEST_F(OperatorsDifferenceTest, DifferenceOnValueTables) {
 }
 
 TEST_F(OperatorsDifferenceTest, GetName) {
-  std::shared_ptr<Table> expected_result =
-      load_table("resources/test_data/tbl/int_float_filtered2.tbl", ChunkOffset{2});
+  auto expected_result = load_table("resources/test_data/tbl/int_float_filtered2.tbl", ChunkOffset{2});
 
-  auto difference = std::make_shared<Difference>(_table_wrapper_a, _table_wrapper_b);
+  const auto difference = std::make_shared<Difference>(_table_wrapper_a, _table_wrapper_b);
   EXPECT_EQ(difference->name(), "Difference");
 }
 

--- a/src/test/lib/operators/difference_test.cpp
+++ b/src/test/lib/operators/difference_test.cpp
@@ -37,7 +37,7 @@ class OperatorsDifferenceTest : public BaseTest {
 };
 
 TEST_F(OperatorsDifferenceTest, DifferenceOnValueTables) {
-  auto difference = std::make_shared<Difference>(_table_wrapper_a, _table_wrapper_b);
+  const auto difference = std::make_shared<Difference>(_table_wrapper_a, _table_wrapper_b);
   difference->execute();
 
   EXPECT_TABLE_EQ_UNORDERED(difference->get_output(), load_table("resources/test_data/tbl/int_float_filtered2.tbl", ChunkOffset{2}));

--- a/src/test/lib/operators/operator_scan_predicate_test.cpp
+++ b/src/test/lib/operators/operator_scan_predicate_test.cpp
@@ -83,6 +83,46 @@ TEST_F(OperatorScanPredicateTest, FromExpressionColumnRight) {
   EXPECT_EQ(operator_predicate_a.value, AllParameterVariant{5});
 }
 
+TEST_F(OperatorScanPredicateTest, OutputToStream) {
+    auto actual = std::stringstream{};
+    const auto operator_predicates_a = OperatorScanPredicate::from_expression(*between_inclusive_(5, a, b), *node);
+    const auto operator_predicates_b = OperatorScanPredicate::from_expression(*greater_than_(a, 5), *node);
+    const auto operator_predicates_c = OperatorScanPredicate::from_expression(*less_than_(a, 5), *node);
+    const auto operator_predicates_d = OperatorScanPredicate::from_expression(*greater_than_(a, b), *node);
+
+    ASSERT_TRUE(operator_predicates_a);
+    ASSERT_TRUE(operator_predicates_b);
+    ASSERT_TRUE(operator_predicates_c);
+    ASSERT_TRUE(operator_predicates_d);
+
+    for (const auto& predicate : *operator_predicates_a) {
+        actual << predicate << '\n';
+    }
+    std::string expected_output = "Column #0 <=5\nColumn #1 >=5\n";
+    ASSERT_EQ(actual.str(), expected_output);
+
+    actual.str("");
+    for (const auto& predicate : *operator_predicates_b) {
+        actual << predicate << '\n';
+    }
+    expected_output = "Column #0 >5\n";
+    ASSERT_EQ(actual.str(), expected_output);
+
+    actual.str("");
+    for (const auto& predicate : *operator_predicates_c) {
+        actual << predicate << '\n';
+    }
+    expected_output = "Column #0 <5\n";
+    ASSERT_EQ(actual.str(), expected_output);
+
+    actual.str("");
+    for (const auto& predicate : *operator_predicates_d) {
+        actual << predicate << '\n';
+    }
+    expected_output = "Column #0 >Column #1\n";
+    ASSERT_EQ(actual.str(), expected_output);
+}
+
 TEST_F(OperatorScanPredicateTest, SimpleBetween) {
   for (const auto predicate_condition :
        {PredicateCondition::BetweenInclusive, PredicateCondition::BetweenLowerExclusive,

--- a/src/test/lib/operators/operator_scan_predicate_test.cpp
+++ b/src/test/lib/operators/operator_scan_predicate_test.cpp
@@ -1,5 +1,6 @@
 #include "base_test.hpp"
 
+#include <tuple>
 #include "expression/expression_functional.hpp"
 #include "logical_query_plan/mock_node.hpp"
 #include "operators/operator_scan_predicate.hpp"
@@ -84,43 +85,25 @@ TEST_F(OperatorScanPredicateTest, FromExpressionColumnRight) {
 }
 
 TEST_F(OperatorScanPredicateTest, OutputToStream) {
-    auto actual = std::stringstream{};
-    const auto operator_predicates_a = OperatorScanPredicate::from_expression(*between_inclusive_(5, a, b), *node);
-    const auto operator_predicates_b = OperatorScanPredicate::from_expression(*greater_than_(a, 5), *node);
-    const auto operator_predicates_c = OperatorScanPredicate::from_expression(*less_than_(a, 5), *node);
-    const auto operator_predicates_d = OperatorScanPredicate::from_expression(*greater_than_(a, b), *node);
+  auto test_cases = std::vector<std::tuple<std::optional<std::vector<OperatorScanPredicate>>, std::string>>();
+  test_cases.push_back(make_tuple(OperatorScanPredicate::from_expression(*between_inclusive_(5, a, b), *node),
+                                  "Column #0 <=5\nColumn #1 >=5\n"));
+  test_cases.push_back(
+      make_tuple(OperatorScanPredicate::from_expression(*greater_than_(a, 5), *node), "Column #0 >5\n"));
+  test_cases.push_back(make_tuple(OperatorScanPredicate::from_expression(*less_than_(a, 5), *node), "Column #0 <5\n"));
+  test_cases.push_back(
+      make_tuple(OperatorScanPredicate::from_expression(*greater_than_(a, b), *node), "Column #0 >Column #1\n"));
 
-    ASSERT_TRUE(operator_predicates_a);
-    ASSERT_TRUE(operator_predicates_b);
-    ASSERT_TRUE(operator_predicates_c);
-    ASSERT_TRUE(operator_predicates_d);
+  auto actual = std::stringstream{};
 
-    for (const auto& predicate : *operator_predicates_a) {
-        actual << predicate << '\n';
+  for (auto [operator_predicates, expected] : test_cases) {
+    ASSERT_TRUE(operator_predicates);
+    for (const auto& predicate : *operator_predicates) {
+      actual << predicate << '\n';
     }
-    std::string expected_output = "Column #0 <=5\nColumn #1 >=5\n";
-    ASSERT_EQ(actual.str(), expected_output);
-
+    ASSERT_EQ(actual.str(), expected);
     actual.str("");
-    for (const auto& predicate : *operator_predicates_b) {
-        actual << predicate << '\n';
-    }
-    expected_output = "Column #0 >5\n";
-    ASSERT_EQ(actual.str(), expected_output);
-
-    actual.str("");
-    for (const auto& predicate : *operator_predicates_c) {
-        actual << predicate << '\n';
-    }
-    expected_output = "Column #0 <5\n";
-    ASSERT_EQ(actual.str(), expected_output);
-
-    actual.str("");
-    for (const auto& predicate : *operator_predicates_d) {
-        actual << predicate << '\n';
-    }
-    expected_output = "Column #0 >Column #1\n";
-    ASSERT_EQ(actual.str(), expected_output);
+  }
 }
 
 TEST_F(OperatorScanPredicateTest, SimpleBetween) {

--- a/src/test/lib/operators/operator_scan_predicate_test.cpp
+++ b/src/test/lib/operators/operator_scan_predicate_test.cpp
@@ -85,14 +85,13 @@ TEST_F(OperatorScanPredicateTest, FromExpressionColumnRight) {
 }
 
 TEST_F(OperatorScanPredicateTest, OutputToStream) {
-  auto test_cases = std::vector<std::tuple<std::optional<std::vector<OperatorScanPredicate>>, std::string>>();
-  test_cases.push_back(make_tuple(OperatorScanPredicate::from_expression(*between_inclusive_(5, a, b), *node),
-                                  "Column #0 <=5\nColumn #1 >=5\n"));
-  test_cases.push_back(
-      make_tuple(OperatorScanPredicate::from_expression(*greater_than_(a, 5), *node), "Column #0 >5\n"));
-  test_cases.push_back(make_tuple(OperatorScanPredicate::from_expression(*less_than_(a, 5), *node), "Column #0 <5\n"));
-  test_cases.push_back(
-      make_tuple(OperatorScanPredicate::from_expression(*greater_than_(a, b), *node), "Column #0 >Column #1\n"));
+  auto test_cases = std::vector<std::pair<std::optional<std::vector<OperatorScanPredicate>>, std::string>>({
+    {OperatorScanPredicate::from_expression(*between_inclusive_(5, a, b), *node),
+     "Column #0 <=5\nColumn #1 >=5\n"},
+    {OperatorScanPredicate::from_expression(*greater_than_(a, 5), *node), "Column #0 >5\n"},
+    {OperatorScanPredicate::from_expression(*greater_than_(a, 5), *node), "Column #0 >5\n"},
+    {OperatorScanPredicate::from_expression(*greater_than_(a, b), *node), "Column #0 >Column #1\n"}
+  });
 
   auto actual = std::stringstream{};
 

--- a/src/test/lib/operators/operator_scan_predicate_test.cpp
+++ b/src/test/lib/operators/operator_scan_predicate_test.cpp
@@ -1,5 +1,3 @@
-#include <tuple>
-
 #include "base_test.hpp"
 
 #include "expression/expression_functional.hpp"
@@ -93,7 +91,6 @@ TEST_F(OperatorScanPredicateTest, OutputToStream) {
        {greater_than_(a, b), "Column #0 >Column #1\n"}});
 
   auto actual = std::stringstream{};
-
   for (const auto& [expression, expected] : test_cases) {
     const auto operator_predicates = OperatorScanPredicate::from_expression(*expression, *node);
     ASSERT_TRUE(operator_predicates);

--- a/src/test/lib/operators/operator_scan_predicate_test.cpp
+++ b/src/test/lib/operators/operator_scan_predicate_test.cpp
@@ -1,6 +1,7 @@
+#include <tuple>
+
 #include "base_test.hpp"
 
-#include <tuple>
 #include "expression/expression_functional.hpp"
 #include "logical_query_plan/mock_node.hpp"
 #include "operators/operator_scan_predicate.hpp"
@@ -85,13 +86,11 @@ TEST_F(OperatorScanPredicateTest, FromExpressionColumnRight) {
 }
 
 TEST_F(OperatorScanPredicateTest, OutputToStream) {
-  auto test_cases = std::vector<std::pair<std::optional<std::vector<OperatorScanPredicate>>, std::string>>({
-    {OperatorScanPredicate::from_expression(*between_inclusive_(5, a, b), *node),
-     "Column #0 <=5\nColumn #1 >=5\n"},
-    {OperatorScanPredicate::from_expression(*greater_than_(a, 5), *node), "Column #0 >5\n"},
-    {OperatorScanPredicate::from_expression(*greater_than_(a, 5), *node), "Column #0 >5\n"},
-    {OperatorScanPredicate::from_expression(*greater_than_(a, b), *node), "Column #0 >Column #1\n"}
-  });
+  const auto test_cases = std::vector<std::pair<std::optional<std::vector<OperatorScanPredicate>>, std::string>>(
+      {{OperatorScanPredicate::from_expression(*between_inclusive_(5, a, b), *node), "Column #0 <=5\nColumn #1 >=5\n"},
+       {OperatorScanPredicate::from_expression(*greater_than_(a, 5), *node), "Column #0 >5\n"},
+       {OperatorScanPredicate::from_expression(*greater_than_(a, 5), *node), "Column #0 >5\n"},
+       {OperatorScanPredicate::from_expression(*greater_than_(a, b), *node), "Column #0 >Column #1\n"}});
 
   auto actual = std::stringstream{};
 

--- a/src/test/lib/operators/operator_scan_predicate_test.cpp
+++ b/src/test/lib/operators/operator_scan_predicate_test.cpp
@@ -97,7 +97,7 @@ TEST_F(OperatorScanPredicateTest, OutputToStream) {
     for (const auto& predicate : *operator_predicates) {
       actual << predicate << '\n';
     }
-    ASSERT_EQ(actual.str(), expected);
+    EXPECT_EQ(actual.str(), expected);
     actual.str("");
   }
 }

--- a/src/test/lib/operators/operator_scan_predicate_test.cpp
+++ b/src/test/lib/operators/operator_scan_predicate_test.cpp
@@ -86,15 +86,19 @@ TEST_F(OperatorScanPredicateTest, FromExpressionColumnRight) {
 }
 
 TEST_F(OperatorScanPredicateTest, OutputToStream) {
-  const auto test_cases = std::vector<std::pair<std::optional<std::vector<OperatorScanPredicate>>, std::string>>(
-      {{OperatorScanPredicate::from_expression(*between_inclusive_(5, a, b), *node), "Column #0 <=5\nColumn #1 >=5\n"},
-       {OperatorScanPredicate::from_expression(*greater_than_(a, 5), *node), "Column #0 >5\n"},
-       {OperatorScanPredicate::from_expression(*greater_than_(a, 5), *node), "Column #0 >5\n"},
-       {OperatorScanPredicate::from_expression(*greater_than_(a, b), *node), "Column #0 >Column #1\n"}});
+  const auto test_cases = std::vector<std::pair<std::shared_ptr<AbstractExpression>, std::string>>(
+  {
+    {between_inclusive_(5, a, b),
+            "Column #0 <=5\nColumn #1 >=5\n"},
+    {greater_than_(a, 5), "Column #0 >5\n"},
+    {less_than_(a, 5),    "Column #0 <5\n"},
+    {greater_than_(a, b), "Column #0 >Column #1\n"}
+  });
 
   auto actual = std::stringstream{};
 
-  for (auto [operator_predicates, expected] : test_cases) {
+  for (const auto& [expression, expected] : test_cases) {
+    auto operator_predicates = OperatorScanPredicate::from_expression(*expression, *node);
     ASSERT_TRUE(operator_predicates);
     for (const auto& predicate : *operator_predicates) {
       actual << predicate << '\n';

--- a/src/test/lib/operators/operator_scan_predicate_test.cpp
+++ b/src/test/lib/operators/operator_scan_predicate_test.cpp
@@ -87,13 +87,10 @@ TEST_F(OperatorScanPredicateTest, FromExpressionColumnRight) {
 
 TEST_F(OperatorScanPredicateTest, OutputToStream) {
   const auto test_cases = std::vector<std::pair<std::shared_ptr<AbstractExpression>, std::string>>(
-  {
-    {between_inclusive_(5, a, b),
-            "Column #0 <=5\nColumn #1 >=5\n"},
-    {greater_than_(a, 5), "Column #0 >5\n"},
-    {less_than_(a, 5),    "Column #0 <5\n"},
-    {greater_than_(a, b), "Column #0 >Column #1\n"}
-  });
+      {{between_inclusive_(5, a, b), "Column #0 <=5\nColumn #1 >=5\n"},
+       {greater_than_(a, 5), "Column #0 >5\n"},
+       {less_than_(a, 5), "Column #0 <5\n"},
+       {greater_than_(a, b), "Column #0 >Column #1\n"}});
 
   auto actual = std::stringstream{};
 

--- a/src/test/lib/operators/operator_scan_predicate_test.cpp
+++ b/src/test/lib/operators/operator_scan_predicate_test.cpp
@@ -86,7 +86,7 @@ TEST_F(OperatorScanPredicateTest, FromExpressionColumnRight) {
 }
 
 TEST_F(OperatorScanPredicateTest, OutputToStream) {
-  const auto test_cases = std::vector<std::pair<std::shared_ptr<AbstractExpression>, std::string>>(
+  const auto test_cases = std::vector<std::pair<std::shared_ptr<AbstractPredicateExpression>, std::string>>(
       {{between_inclusive_(5, a, b), "Column #0 <=5\nColumn #1 >=5\n"},
        {greater_than_(a, 5), "Column #0 >5\n"},
        {less_than_(a, 5), "Column #0 <5\n"},
@@ -95,7 +95,7 @@ TEST_F(OperatorScanPredicateTest, OutputToStream) {
   auto actual = std::stringstream{};
 
   for (const auto& [expression, expected] : test_cases) {
-    auto operator_predicates = OperatorScanPredicate::from_expression(*expression, *node);
+    const auto operator_predicates = OperatorScanPredicate::from_expression(*expression, *node);
     ASSERT_TRUE(operator_predicates);
     for (const auto& predicate : *operator_predicates) {
       actual << predicate << '\n';


### PR DESCRIPTION
We first tried to add coverage to `TableColumnDefinition`, but found `concatenated` as unsused an also not working function. Hence we removed it to increase coverage this way.
Next we added a simple test for the `Difference` operator's `getName()` function.
Last we added a varying test for the `<<` operator of the `OperatorScanPredicate`