### PR TITLE
Add ProjectionNode before `SELECT DISTINCT` AggregateNode if necessary

### DIFF
--- a/src/lib/sql/sql_translator.hpp
+++ b/src/lib/sql/sql_translator.hpp
@@ -218,6 +218,8 @@ class SQLTranslator final {
 
   // "Inflated" because all wildcards will be inflated to the expressions they actually represent
   std::vector<SelectListElement> _inflated_select_list_elements;
+
+  std::vector<std::shared_ptr<AbstractExpression>> _order_by_expressions;
 };
 
 }  // namespace hyrise

--- a/src/test/lib/sql/sql_translator_test.cpp
+++ b/src/test/lib/sql/sql_translator_test.cpp
@@ -962,7 +962,8 @@ TEST_F(SQLTranslatorTest, Distinct) {
   // clang-format off
   const auto expected_lqp =
   AggregateNode::make(expression_vector(int_float_b), expression_vector(),
-    stored_table_node_int_float);
+    ProjectionNode::make(expression_vector(int_float_b),
+     stored_table_node_int_float));
   // clang-format on
 
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
@@ -993,6 +994,41 @@ TEST_F(SQLTranslatorTest, DistinctAndGroupBy) {
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
 
+TEST_F(SQLTranslatorTest, DistinctAndOrderBy) {
+  const auto [actual_lqp, translation_info] = sql_to_lqp_helper("SELECT DISTINCT a, b FROM int_float ORDER BY b");
+
+  // clang-format off
+  const auto expected_lqp =
+  AggregateNode::make(expression_vector(int_float_a, int_float_b), expression_vector(),
+    SortNode::make(expression_vector(int_float_b), std::vector<SortMode>{SortMode::Ascending},
+      stored_table_node_int_float));
+  // clang-format on
+
+  EXPECT_LQP_EQ(actual_lqp, expected_lqp);
+}
+
+TEST_F(SQLTranslatorTest, DistinctAndOrderByWithProjection) {
+  const auto [actual_lqp, translation_info] = sql_to_lqp_helper("SELECT DISTINCT a + b FROM int_float ORDER BY a + b");
+
+  // clang-format off
+  const auto expected_lqp =
+  AggregateNode::make(expression_vector(add_(int_float_a, int_float_b)), expression_vector(),
+    // This ProjectionNode seems superfluous, but when we translate the SortNode, we do not know which expressions
+    // will be part of the SELECT list, so we add a + b and do not remove a and b there.
+    ProjectionNode::make(expression_vector(add_(int_float_a, int_float_b)),
+      SortNode::make(expression_vector(add_(int_float_a, int_float_b)), std::vector<SortMode>{SortMode::Ascending},
+        ProjectionNode::make(expression_vector(add_(int_float_a, int_float_b), int_float_a, int_float_b),
+          stored_table_node_int_float))));
+  // clang-format on
+
+  EXPECT_LQP_EQ(actual_lqp, expected_lqp);
+}
+
+TEST_F(SQLTranslatorTest, DistinctAndOrderByInvalid) {
+  // For SELECT DISTINCT, expressions in the ORDER BY clause must also be in the SELECT list.
+  EXPECT_THROW(sql_to_lqp_helper("SELECT DISTINCT a FROM int_float ORDER BY b"), InvalidInputException);
+}
+
 TEST_F(SQLTranslatorTest, AggregateWithDistinctAndRelatedGroupBy) {
   const auto [actual_lqp, translation_info] =
       sql_to_lqp_helper("SELECT DISTINCT b, SUM(a * 3) * b FROM int_float GROUP BY b");
@@ -1002,9 +1038,10 @@ TEST_F(SQLTranslatorTest, AggregateWithDistinctAndRelatedGroupBy) {
   // clang-format off
   const auto expected_lqp =
   AggregateNode::make(expression_vector(int_float_b, mul_(sum_(a_times_3), int_float_b)), expression_vector(),
-    AggregateNode::make(expression_vector(int_float_b), expression_vector(sum_(a_times_3)),
-      ProjectionNode::make(expression_vector(a_times_3, int_float_b),
-        stored_table_node_int_float)));
+    ProjectionNode::make(expression_vector(int_float_b, mul_(sum_(a_times_3), int_float_b)),
+      AggregateNode::make(expression_vector(int_float_b), expression_vector(sum_(a_times_3)),
+        ProjectionNode::make(expression_vector(a_times_3, int_float_b),
+          stored_table_node_int_float))));
   // clang-format on
 
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
@@ -1013,13 +1050,12 @@ TEST_F(SQLTranslatorTest, AggregateWithDistinctAndRelatedGroupBy) {
 TEST_F(SQLTranslatorTest, AggregateWithDistinctAndUnrelatedGroupBy) {
   const auto [actual_lqp, translation_info] = sql_to_lqp_helper("SELECT DISTINCT MIN(a) FROM int_float GROUP BY b");
 
-  const auto a_times_3 = mul_(int_float_a, 3);
-
   // clang-format off
   const auto expected_lqp =
   AggregateNode::make(expression_vector(min_(int_float_a)), expression_vector(),
-    AggregateNode::make(expression_vector(int_float_b), expression_vector(min_(int_float_a)),
-    stored_table_node_int_float));
+    ProjectionNode::make(expression_vector(min_(int_float_a)),
+      AggregateNode::make(expression_vector(int_float_b), expression_vector(min_(int_float_a)),
+        stored_table_node_int_float)));
   // clang-format on
 
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
@@ -2969,16 +3005,16 @@ TEST_F(SQLTranslatorTest, ComplexSetOperationQuery) {
 
   // clang-format off
   const auto expected_lqp =
-  SortNode::make(expression_vector(int_int_int_a), std::vector<SortMode>{ SortMode::Ascending },
+  SortNode::make(expression_vector(int_int_int_a), std::vector<SortMode>{SortMode::Ascending},
     IntersectNode::make(SetOperationMode::Unique,
       ProjectionNode::make(expression_vector(int_int_int_a),
-        SortNode::make(expression_vector(int_int_int_a), std::vector<SortMode>{ SortMode::Ascending },
+        SortNode::make(expression_vector(int_int_int_a), std::vector<SortMode>{SortMode::Ascending},
                        stored_table_node_int_int_int)),
       LimitNode::make(value_(10),
         ExceptNode::make(SetOperationMode::Unique,
           ProjectionNode::make(expression_vector(int_int_int_b), stored_table_node_int_int_int),
           ProjectionNode::make(expression_vector(int_int_int_c),
-            SortNode::make(expression_vector(int_int_int_c), std::vector<SortMode>{ SortMode::Ascending },
+            SortNode::make(expression_vector(int_int_int_c), std::vector<SortMode>{SortMode::Ascending},
                            stored_table_node_int_int_int))))));
   // clang-format on
 


### PR DESCRIPTION
While working on the SQL translation of window functions, I noticed we do not handle `SELECT DISTINCT` statements correctly if there were further operations on the selected columns (see #2570). This PR fixed this issue and makes Hyrise behave consistent to Postgres in these cases.

closes #2570