### PR TITLE
Limit scale factors for TPC-DS and SSB verification

### DIFF
--- a/src/benchmark/star_schema_benchmark.cpp
+++ b/src/benchmark/star_schema_benchmark.cpp
@@ -63,11 +63,11 @@ int main(int argc, char* argv[]) {
   context.emplace("scale_factor", scale_factor);
   // We cannot verify the results for larger scale factors (SFs) since SQLite overflows integers for aggregation
   // results. We could use dedicated result sets in these cases similar to TPC-DS. However, we need to generate these
-  // result sets using a trustworthy DBMS, such as Postgres. Since we do not consider this worth the effort for now and
-  // in particular, it does not solve the issue of requiring special SFs (the result set is only valid fot the SF it
-  //  was generated with), we simply limit verification to rather small SFs.
-  We empirically tested that errors occur for SF > 0.1 (0.11 due to float
-  // comparison).
+  // result sets using a trustworthy DBMS, such as Postgres. We decided against this approach for two reasons. First,
+  // we do not consider this worth the effort for now. Second, it does not solve the issue of requiring specific SFs:
+  // The result set would only be valid for the SF it was generated on. Thus, we simply limit verification to rather
+  // small SFs.
+  // We empirically figured out that errors do not occur for SF <= 0.1 (0.11 to account for float comparison).
   Assert(!config->verify || scale_factor < 0.11,
          "SSB result verification is only supported fo scale factors <= 0.1 (--scale 0.1).");
 

--- a/src/benchmark/star_schema_benchmark.cpp
+++ b/src/benchmark/star_schema_benchmark.cpp
@@ -61,9 +61,12 @@ int main(int argc, char* argv[]) {
 
   std::cout << "- SSB scale factor is " << scale_factor << std::endl;
   context.emplace("scale_factor", scale_factor);
-  // We cannot verify the results for larger SFs since SQLite overflows integers for aggregation results. We could use
-  // dedicated result sets in these cases similar to TPC-DS. However, we need to generate these result sets using a
-  // trustworthy DBMS, such as Postgres. We empirically tested that errors occur for SF > 0.1 (0.11 due to float
+  // We cannot verify the results for larger scale factors (SFs) since SQLite overflows integers for aggregation
+  // results. We could use dedicated result sets in these cases similar to TPC-DS. However, we need to generate these
+  // result sets using a trustworthy DBMS, such as Postgres. Since we do not consider this worth the effort for now and
+  // in particular, it does not solve the issue of requiring special SFs (the result set is only valid fot the SF it
+  //  was generated with), we simply limit verification to rather small SFs.
+  We empirically tested that errors occur for SF > 0.1 (0.11 due to float
   // comparison).
   Assert(!config->verify || scale_factor < 0.11,
          "SSB result verification is only supported fo scale factors <= 0.1 (--scale 0.1).");

--- a/src/benchmark/star_schema_benchmark.cpp
+++ b/src/benchmark/star_schema_benchmark.cpp
@@ -61,6 +61,12 @@ int main(int argc, char* argv[]) {
 
   std::cout << "- SSB scale factor is " << scale_factor << std::endl;
   context.emplace("scale_factor", scale_factor);
+  // We cannot verify the results for larger SFs since SQLite overflows integers for aggregation results. We could use
+  // dedicated result sets in these cases similar to TPC-DS. However, we need to generate these result sets using a
+  // trustworthy DBMS, such as Postgres. We empirically tested that errors occur for SF > 0.1 (0.11 due to float
+  // comparison).
+  Assert(!config->verify || scale_factor < 0.11,
+         "SSB result verification is only supported fo scale factors <= 0.1 (--scale 0.1).");
 
   // Different from the TPC-H benchmark, where the table and query generators are immediately embedded in Hyrise, the
   // SSB implementation calls those generators externally. This is because we would get linking conflicts if we were

--- a/src/benchmark/tpcds_benchmark.cpp
+++ b/src/benchmark/tpcds_benchmark.cpp
@@ -67,7 +67,7 @@ int main(int argc, char* argv[]) {
 
   auto query_generator = std::make_unique<FileBasedBenchmarkItemRunner>(config, query_path, filename_blacklist());
   if (config->verify) {
-    // We can only verify the results for SF 1 since the dedicated result sets were obtained on this SF.
+    // We can only verify the results for scale factor (SF) 1 since the dedicated result sets were obtained on this SF.
     Assert(scale_factor == 1, "TPC-DS result verification can only be performed on scale factor 1 (--scale 1).");
     query_generator->load_dedicated_expected_results(
         std::filesystem::path{"resources/benchmark/tpcds/tpcds-result-reproduction/answer_sets_tbl"});

--- a/src/benchmark/tpcds_benchmark.cpp
+++ b/src/benchmark/tpcds_benchmark.cpp
@@ -3,17 +3,19 @@
 #include <iostream>
 #include <string>
 
+#include "cxxopts.hpp"
+
 #include "benchmark_runner.hpp"
 #include "cli_config_parser.hpp"
-#include "cxxopts.hpp"
 #include "file_based_benchmark_item_runner.hpp"
 #include "tpcds/tpcds_table_generator.hpp"
 #include "utils/assert.hpp"
 #include "utils/sqlite_add_indices.hpp"
 
-using namespace hyrise;  // NOLINT
+using namespace hyrise;  // NOLINT(build/namespaces)
 
 namespace {
+
 const std::unordered_set<std::string> filename_blacklist() {
   auto filename_blacklist = std::unordered_set<std::string>{};
   const auto blacklist_file_path = "resources/benchmark/tpcds/query_blacklist.cfg";
@@ -32,6 +34,7 @@ const std::unordered_set<std::string> filename_blacklist() {
   }
   return filename_blacklist;
 }
+
 }  // namespace
 
 int main(int argc, char* argv[]) {
@@ -57,13 +60,15 @@ int main(int argc, char* argv[]) {
 
   std::cout << "- TPC-DS scale factor is " << scale_factor << std::endl;
 
-  std::string query_path = "resources/benchmark/tpcds/tpcds-result-reproduction/query_qualification";
+  const auto query_path = std::string{"resources/benchmark/tpcds/tpcds-result-reproduction/query_qualification"};
 
   Assert(std::filesystem::is_directory(query_path), "Query path (" + query_path + ") has to be a directory.");
   Assert(std::filesystem::exists(std::filesystem::path{query_path + "/01.sql"}), "Queries have to be available.");
 
   auto query_generator = std::make_unique<FileBasedBenchmarkItemRunner>(config, query_path, filename_blacklist());
   if (config->verify) {
+    // We can only verify the results for SF 1 since the dedicated result sets were obtained on this SF.
+    Assert(scale_factor == 1, "TPC-DS result verification can only be performed on scale factor 1 (--scale 1).");
     query_generator->load_dedicated_expected_results(
         std::filesystem::path{"resources/benchmark/tpcds/tpcds-result-reproduction/answer_sets_tbl"});
   }


### PR DESCRIPTION
TPC-DS verification uses fixed result sets for some queries that are not supported by SQLite, which are only valid for SF 1. Some SSB queries `SUM` integers, which lead to `int` overfloaws in SQLite (and thus, wrong results) for SF > 0.1. This PR ensures that the two benchmark binaries crash when invoked with unfitting SFs and `--verify`.