### PR TITLE
Make linker configurable and emit useful messages about linker choice

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # consider updating DEPENDENCIES.md when you touch this line
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 
 project(Hyrise)
 
@@ -105,12 +105,6 @@ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${FLAGS_ALL} ${FLAGS_REL
 set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} ${FLAGS_ALL} ${FLAGS_RELEASE}")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} ${FLAGS_ALL} ${FLAGS_RELEASE}")
 
-# Check for unity builds
-if(${CMAKE_VERSION} VERSION_LESS "3.16.0")
-    if(DEFINED CMAKE_UNITY_BUILD)
-        message(FATAL_ERROR "-DCMAKE_UNITY_BUILD=ON was set, but your cmake version does not support unity builds.")
-    endif()
-endif()
 
 # On Linux, use the lld linker, which is twice as fast for incremental debug builds
 if (NOT APPLE)
@@ -151,17 +145,14 @@ cmake_policy(SET CMP0069 NEW)
 set(CMAKE_POLICY_DEFAULT_CMP0069 NEW)
 option(ENABLE_LTO "Set to ON to build Hyrise with enabled Link Time Optimization (LTO). Default: OFF" OFF)
 if (${ENABLE_LTO})
-    if(NOT ${CMAKE_VERSION} VERSION_LESS "3.9.0")
-        cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
-        include(CheckIPOSupported)
-        check_ipo_supported(RESULT ipo_supported OUTPUT ipo_output)
-        if(ipo_supported)
-            set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
-            add_definitions(-DWITH_LTO)
-            message(STATUS "Building with Link-Time Optimization")
-        else()
-            message(WARNING "LTO not supported: ${ipo_output}")
-        endif()
+    include(CheckIPOSupported)
+    check_ipo_supported(RESULT ipo_supported OUTPUT ipo_output)
+    if(ipo_supported)
+        set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+        add_definitions(-DWITH_LTO)
+        message(STATUS "Building with Link-Time Optimization")
+    else()
+        message(WARNING "LTO not supported: ${ipo_output}")
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,11 +105,25 @@ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${FLAGS_ALL} ${FLAGS_REL
 set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} ${FLAGS_ALL} ${FLAGS_RELEASE}")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} ${FLAGS_ALL} ${FLAGS_RELEASE}")
 
-
-# On Linux, use the lld linker, which is twice as fast for incremental debug builds
-if (NOT APPLE)
-    set(CMAKE_SHARED_LINKER_FLAGS "-fuse-ld=lld")
-    set(CMAKE_EXE_LINKER_FLAGS "-fuse-ld=lld")
+include(CheckLinkerFlag)
+if (HYRISE_LINKER)
+    check_linker_flag(CXX "-fuse-ld=${HYRISE_LINKER}" HAS_HYRISE_LINKER)
+    if (NOT HAS_HYRISE_LINKER)
+        message(FATAL_ERROR "Got HYRISE_LINKER=${HYRISE_LINKER}, but -fuse-ld=${HYRISE_LINKER} does not work.")
+    endif()
+    message(STATUS "Using HYRISE_LINKER (${HYRISE_LINKER}).")
+    add_link_options("-fuse-ld=${HYRISE_LINKER}")
+else()
+    check_linker_flag(CXX "-fuse-ld=lld" HAS_LLD)
+    if (HAS_LLD)
+        message(STATUS "Found LLD, using as linker.")
+        add_link_options("-fuse-ld=lld")
+    else()
+        message(STATUS "Using default linker.")
+        if (NOT APPLE)
+            message(WARNING "Consider installing the LLD linker for faster incremental builds on Linux.")
+        endif()
+    endif()
 endif()
 
 # Require NCurses over Curses

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -16,7 +16,7 @@
 | libnuma-dev               | any              |    Linux |                            Yes (numa) |
 | libnuma1                  | any              |    Linux |                            Yes (numa) |
 | libpq-dev                 | >= 9             |    All   |                                    No |
-| lld                       | any              |    Linux |   No, but could be removed from cmake |
+| lld                       | any              |    Linux |                                   Yes |
 | parallel                  | any              |    All   |                                   Yes |
 | pexpect                   | >= 4             |    All   |                     Yes (tests in CI) |
 | postgresql-server-dev-all | >= 154           |    Linux |                                    No |

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -8,7 +8,7 @@
 | clang-format              | >= 11.0          |    All   |                      Yes (formatting) |
 | clang-tidy                | >= 11.0          |    All   |                         Yes (linting) |
 | coreutils                 | any              |    Mac   |                         Yes (scripts) |
-| cmake                     | >= 3.9           |    All   |                                    No |
+| cmake                     | >= 3.18          |    All   |                                    No |
 | dos2unix                  | any              |    All   |                         Yes (linting) |
 | gcc                       | >= 9.1           |    All   | Yes, if clang installed, not for OS X |
 | gcovr                     | >= 3.2           |    All   |                        Yes (coverage) |

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -754,14 +754,12 @@ target_include_directories(hyrise_impl PUBLIC ${CMAKE_BINARY_DIR})
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 target_compile_options(hyrise_impl PUBLIC -Xclang -fno-pch-timestamp)
 endif()
-if(NOT ${CMAKE_VERSION} VERSION_LESS "3.16.0")
-    target_precompile_headers(hyrise_impl PRIVATE
-      all_parameter_variant.hpp
-      storage/create_iterable_from_segment.hpp
-      storage/table.hpp
-      types.hpp
-    )
-endif()
+target_precompile_headers(hyrise_impl PRIVATE
+  all_parameter_variant.hpp
+  storage/create_iterable_from_segment.hpp
+  storage/table.hpp
+  types.hpp
+)
 
 # -fPIC generates position independent code which is necessary because plugins might access hyrise functions.
 target_compile_options(hyrise_impl PRIVATE -fPIC)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -294,15 +294,13 @@ target_link_libraries(hyriseTest hyrise ${LIBRARIES})
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 target_compile_options(hyriseTest PUBLIC -Xclang -fno-pch-timestamp)
 endif()
-if(NOT ${CMAKE_VERSION} VERSION_LESS "3.16.0")
-    target_precompile_headers(hyriseTest PRIVATE
-        <gtest/gtest.h>
-        [["all_parameter_variant.hpp"]]
-        [["storage/create_iterable_from_segment.hpp"]]
-        [["storage/table.hpp"]]
-        [["types.hpp"]]
-    )
-endif()
+target_precompile_headers(hyriseTest PRIVATE
+    <gtest/gtest.h>
+    [["all_parameter_variant.hpp"]]
+    [["storage/create_iterable_from_segment.hpp"]]
+    [["storage/table.hpp"]]
+    [["types.hpp"]]
+)
 
 # Configure hyriseSystemTest
 add_executable(hyriseSystemTest ${SYSTEM_TEST_SOURCES})


### PR DESCRIPTION
Closes #2572

Notably, LLD is not required anymore, but a warning is shown if the default linker is used on Linux.
I also added the option to use another linker by specifying `HYRISE_LINKER` (for example `mold`) - `CMAKE_LINKER` was actually already set to `/bin/ld`.
