### PR TITLE
Recursive Scheduler Test and Scheduler Shutdown Fix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -259,7 +259,7 @@ try {
                 sh "cd clang-release-addr-ub-sanitizers && make hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 10))"
                 sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers/hyriseTest clang-release-addr-ub-sanitizers"
                 sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers/hyriseSystemTest ${tests_excluded_in_sanitizer_builds} clang-release-addr-ub-sanitizers"
-                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10"
+                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10 --cores \$(( \$(nproc) / 4))"
                 sh "cd clang-release-addr-ub-sanitizers && LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
               } else {
                 Utils.markStageSkippedForConditional("clangReleaseAddrUBSanitizers")
@@ -271,7 +271,7 @@ try {
                 sh "cd clang-relwithdebinfo-thread-sanitizer && make hyriseTest hyriseSystemTest hyriseBenchmarkTPCH -j \$(( \$(nproc) / 10))"
                 sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseTest clang-relwithdebinfo-thread-sanitizer"
                 sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseSystemTest ${tests_excluded_in_sanitizer_builds} clang-relwithdebinfo-thread-sanitizer"
-                sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10"
+                sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
               } else {
                 Utils.markStageSkippedForConditional("clangRelWithDebInfoThreadSanitizer")
               }

--- a/scripts/test/hyriseBenchmarkJCCH_test.py
+++ b/scripts/test/hyriseBenchmarkJCCH_test.py
@@ -38,7 +38,7 @@ def main():
     benchmark.expect_exact("Using prepared statements: no")
     benchmark.expect_exact("Using JCC-H dbgen from")
     benchmark.expect_exact("JCC-H query parameters are skewed")
-    #benchmark.expect_exact("calling external qgen")
+    # benchmark.expect_exact("calling external qgen")
     benchmark.expect_exact("Multi-threaded Topology:")
 
     close_benchmark(benchmark)

--- a/scripts/test/hyriseBenchmarkJCCH_test.py
+++ b/scripts/test/hyriseBenchmarkJCCH_test.py
@@ -38,7 +38,7 @@ def main():
     benchmark.expect_exact("Using prepared statements: no")
     benchmark.expect_exact("Using JCC-H dbgen from")
     benchmark.expect_exact("JCC-H query parameters are skewed")
-    benchmark.expect_exact("calling external qgen")
+    #benchmark.expect_exact("calling external qgen")
     benchmark.expect_exact("Multi-threaded Topology:")
 
     close_benchmark(benchmark)

--- a/scripts/test/hyriseBenchmarkJCCH_test.py
+++ b/scripts/test/hyriseBenchmarkJCCH_test.py
@@ -38,7 +38,7 @@ def main():
     benchmark.expect_exact("Using prepared statements: no")
     benchmark.expect_exact("Using JCC-H dbgen from")
     benchmark.expect_exact("JCC-H query parameters are skewed")
-    # benchmark.expect_exact("calling external qgen")
+    #benchmark.expect_exact("calling external qgen")
     benchmark.expect_exact("Multi-threaded Topology:")
 
     close_benchmark(benchmark)

--- a/scripts/test/hyriseBenchmarkJCCH_test.py
+++ b/scripts/test/hyriseBenchmarkJCCH_test.py
@@ -38,7 +38,7 @@ def main():
     benchmark.expect_exact("Using prepared statements: no")
     benchmark.expect_exact("Using JCC-H dbgen from")
     benchmark.expect_exact("JCC-H query parameters are skewed")
-    #benchmark.expect_exact("calling external qgen")
+    benchmark.expect_exact("calling external qgen")
     benchmark.expect_exact("Multi-threaded Topology:")
 
     close_benchmark(benchmark)

--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -35,7 +35,7 @@ AbstractTableGenerator::AbstractTableGenerator(const std::shared_ptr<BenchmarkCo
     : _benchmark_config(benchmark_config) {}
 
 void AbstractTableGenerator::generate_and_store() {
-  Timer timer;
+  auto timer = Timer{};
 
   // Encoding table data and generating table statistics are time consuming processes. To reduce the required execution
   // time, we execute these data preparation steps in a multi-threaded way. We store the current scheduler here in case
@@ -55,7 +55,8 @@ void AbstractTableGenerator::generate_and_store() {
   // TODO(any): Finalization might trigger encoding in the future.
   for (auto& [table_name, table_info] : table_info_by_name) {
     auto& table = table_info_by_name[table_name].table;
-    for (auto chunk_id = ChunkID{0}; chunk_id < table->chunk_count(); ++chunk_id) {
+    const auto chunk_count = table->chunk_count();
+    for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
       const auto chunk = table->get_chunk(chunk_id);
       if (chunk->is_mutable()) {
         chunk->finalize();
@@ -74,8 +75,9 @@ void AbstractTableGenerator::generate_and_store() {
       // supposed to be unclustered.
       for (auto& [table_name, table_info] : table_info_by_name) {
         auto& table = table_info_by_name[table_name].table;
-        for (auto chunk_id = ChunkID{0}; chunk_id < table->chunk_count(); ++chunk_id) {
-          const auto chunk = table->get_chunk(chunk_id);
+        const auto chunk_count = table->chunk_count();
+        for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
+          const auto& chunk = table->get_chunk(chunk_id);
           Assert(chunk->individually_sorted_by().empty(),
                  "Tables are sorted, but no clustering has been requested. "
                  "This might be case when clustered data is loaded from "
@@ -156,7 +158,7 @@ void AbstractTableGenerator::generate_and_store() {
           // For this, we use the sort operator. Because it returns a `const Table`, we need to recreate the table and
           // migrate the sorted chunks to that table.
 
-          Timer per_table_timer;
+          auto per_table_timer = Timer{};
 
           auto table_wrapper = std::make_shared<TableWrapper>(table);
           table_wrapper->execute();
@@ -172,9 +174,9 @@ void AbstractTableGenerator::generate_and_store() {
                                           table->target_chunk_size(), UseMvcc::Yes);
           const auto column_count = immutable_sorted_table->column_count();
           for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
-            const auto chunk = immutable_sorted_table->get_chunk(chunk_id);
+            const auto& chunk = immutable_sorted_table->get_chunk(chunk_id);
             auto mvcc_data = std::make_shared<MvccData>(chunk->size(), CommitID{0});
-            Segments segments{};
+            auto segments = Segments{};
             for (auto column_id = ColumnID{0}; column_id < column_count; ++column_id) {
               segments.emplace_back(chunk->get_segment(column_id));
             }
@@ -215,7 +217,7 @@ void AbstractTableGenerator::generate_and_store() {
       auto& table_info = table_info_by_name_pair.second;
 
       const auto encode_table = [&]() {
-        Timer per_table_timer;
+        auto per_table_timer = Timer{};
         table_info.re_encoded =
             BenchmarkTableEncoder::encode(table_name, table_info.table, _benchmark_config->encoding_config);
         auto output = std::stringstream{};
@@ -262,7 +264,7 @@ void AbstractTableGenerator::generate_and_store() {
       }
 
       std::cout << "-  Writing '" << table_name << "' into binary file " << binary_file_path << " " << std::flush;
-      Timer per_table_timer;
+      auto per_table_timer = Timer{};
       BinaryWriter::write(*table_info.table, binary_file_path);
       std::cout << "(" << per_table_timer.lap_formatted() << ")" << std::endl;
     }
@@ -284,7 +286,7 @@ void AbstractTableGenerator::generate_and_store() {
       auto& table_info = table_info_by_name_pair.second;
 
       const auto add_table = [&]() {
-        Timer per_table_timer;
+        auto per_table_timer = Timer{};
         if (storage_manager.has_table(table_name)) {
           storage_manager.drop_table(table_name);
         }
@@ -335,7 +337,7 @@ std::shared_ptr<BenchmarkConfig> AbstractTableGenerator::create_benchmark_config
 
 void AbstractTableGenerator::_create_chunk_indexes(
     std::unordered_map<std::string, BenchmarkTableInfo>& table_info_by_name) {
-  Timer timer;
+  auto timer = Timer{};
   std::cout << "- Creating chunk indexes" << std::endl;
   const auto& indexes_by_table = _indexes_by_table();
   if (indexes_by_table.empty()) {
@@ -354,7 +356,7 @@ void AbstractTableGenerator::_create_chunk_indexes(
         column_ids.emplace_back(table->column_id_by_name(column_name));
       }
       std::cout << "] " << std::flush;
-      Timer per_index_timer;
+      auto per_index_timer = Timer{};
 
       if (column_ids.size() == 1) {
         table->create_chunk_index<GroupKeyIndex>(column_ids);
@@ -371,7 +373,7 @@ void AbstractTableGenerator::_create_chunk_indexes(
 
 void AbstractTableGenerator::_create_table_indexes(
     std::unordered_map<std::string, BenchmarkTableInfo>& table_info_by_name) {
-  Timer timer;
+  auto timer = Timer{};
   std::cout << "- Creating table indexes" << std::endl;
   const auto& indexes_by_table = _indexes_by_table();
   if (indexes_by_table.empty()) {
@@ -390,7 +392,7 @@ void AbstractTableGenerator::_create_table_indexes(
         std::cout << "-  Creating an index on table " << table_name << " (" << column_name << ") covering "
                   << chunk_ids.size() << " (all finalized) chunks]" << std::flush;
 
-        Timer per_table_index_timer;
+        auto per_table_index_timer = Timer{};
         table->create_partial_hash_index(table->column_id_by_name(column_name), chunk_ids);
 
         std::cout << "(" << per_table_index_timer.lap_formatted() << ")" << std::endl;
@@ -415,12 +417,13 @@ void AbstractTableGenerator::_add_constraints(
 
 bool AbstractTableGenerator::_all_chunks_sorted_by(const std::shared_ptr<Table>& table,
                                                    const SortColumnDefinition& sort_column) {
-  for (ChunkID chunk_id{0}; chunk_id < table->chunk_count(); ++chunk_id) {
+  const auto chunk_count = table->chunk_count();
+  for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
     const auto& sorted_columns = table->get_chunk(chunk_id)->individually_sorted_by();
     if (sorted_columns.empty()) {
       return false;
     }
-    bool chunk_sorted = false;
+    auto chunk_sorted = false;
     for (const auto& sorted_column : sorted_columns) {
       if (sorted_column.column == sort_column.column) {
         Assert(sorted_column.sort_mode == sort_column.sort_mode, "Column is already sorted by another SortMode");
@@ -436,14 +439,14 @@ bool AbstractTableGenerator::_all_chunks_sorted_by(const std::shared_ptr<Table>&
 
 std::unordered_map<std::string, BenchmarkTableInfo> AbstractTableGenerator::_load_binary_tables_from_path(
     const std::string& cache_directory) {
-  std::unordered_map<std::string, BenchmarkTableInfo> table_info_by_name;
+  auto table_info_by_name = std::unordered_map<std::string, BenchmarkTableInfo>{};
 
   for (const auto& table_file : list_directory(cache_directory)) {
     const auto table_name = table_file.stem();
     std::cout << "-  Loading table '" << table_name.string() << "' from cached binary " << table_file.relative_path();
 
-    Timer timer;
-    BenchmarkTableInfo table_info;
+    auto timer = Timer{};
+    auto table_info = BenchmarkTableInfo{};
     table_info.table = BinaryParser::parse(table_file);
     table_info.loaded_from_binary = true;
     table_info.binary_file_path = table_file;

--- a/src/benchmarklib/jcch/jcch_benchmark_item_runner.cpp
+++ b/src/benchmarklib/jcch/jcch_benchmark_item_runner.cpp
@@ -47,7 +47,7 @@ void JCCHBenchmarkItemRunner::_load_params() {
 
   // Check if the query parameters have already been generated
   if (!std::filesystem::exists(params_path)) {
-    Timer timer;
+    auto timer = Timer{};
 
     std::cout << "- Creating query parameters by calling external qgen" << std::flush;
 
@@ -90,7 +90,7 @@ void JCCHBenchmarkItemRunner::_load_params() {
   auto file = std::ifstream(params_path);
   Assert(file.is_open(), std::string{"Could not open JCC-H parameters at "} + params_path);
 
-  std::string line;
+  auto line = std::string{};
   while (std::getline(file, line)) {
     // Load the parameter into the corresponding entry in _all_params
     auto string_values = split_string_by_delimiter(line, '\t');
@@ -111,7 +111,7 @@ bool JCCHBenchmarkItemRunner::_on_execute_item(const BenchmarkItemID item_id, Be
   std::uniform_int_distribution<> params_dist{0, static_cast<int>(this_item_params.size() - 1)};
   const auto raw_params_iter = this_item_params.begin() + params_dist(random_engine);
 
-  std::vector<std::string> parameters;
+  auto parameters = std::vector<std::string>{};
   auto sql = std::string{};
 
   // This mirrors TPCHBenchmarkItemRunner::_on_execute_item. Instead of generating random parameters according to the

--- a/src/lib/scheduler/node_queue_scheduler.cpp
+++ b/src/lib/scheduler/node_queue_scheduler.cpp
@@ -69,13 +69,13 @@ void NodeQueueScheduler::wait_for_all_tasks() {
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
 
-  auto queue_check_runs = size_t{0};
   for (auto& queue : _queues) {
+    auto queue_check_runs = size_t{0};
     while (!queue->empty()) {
       // The following assert checks that we are not looping forever. The empty() check can be inaccurate for
       // concurrent queues when many tiny tasks have been scheduled (see MergeSort scheduler test). When this assert is
       // triggered in other situations, there have probably been new tasks added after wait_for_all_tasks() was called.
-      Assert(queue_check_runs < 1'000, "Queues are not empty but all registered tasks have already been processed.");
+      Assert(queue_check_runs < 1'000, "Queue is not empty but all registered tasks have already been processed.");
       std::this_thread::sleep_for(std::chrono::milliseconds(1));
       ++queue_check_runs;
     }

--- a/src/lib/scheduler/node_queue_scheduler.cpp
+++ b/src/lib/scheduler/node_queue_scheduler.cpp
@@ -71,14 +71,14 @@ void NodeQueueScheduler::wait_for_all_tasks() {
 
   auto queue_check_runs = size_t{0};
   for (auto& queue : _queues) {
-    // The following assert checks that we are not looping forever. The empty() check can be inaccurate for concurrent
-    // queues when many tiny tasks have been scheduled (see MergeSort scheduler test). When this assert is triggered in
-    // other situations, there have probably been new tasks added after wait_for_all_tasks() was called.
-    Assert(queue_check_runs < 1'000, "Queues are not empty but all registered tasks have already been processed.");
     while (!queue->empty()) {
+      // The following assert checks that we are not looping forever. The empty() check can be inaccurate for
+      // concurrent queues when many tiny tasks have been scheduled (see MergeSort scheduler test). When this assert is
+      // triggered in other situations, there have probably been new tasks added after wait_for_all_tasks() was called.
+      Assert(queue_check_runs < 1'000, "Queues are not empty but all registered tasks have already been processed.");
       std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      ++queue_check_runs;
     }
-    ++queue_check_runs;
   }
 }
 

--- a/src/lib/scheduler/node_queue_scheduler.cpp
+++ b/src/lib/scheduler/node_queue_scheduler.cpp
@@ -69,11 +69,16 @@ void NodeQueueScheduler::wait_for_all_tasks() {
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
 
+  auto queue_check_runs = size_t{0};
   for (auto& queue : _queues) {
+    // The following assert checks that we are not looping forever. The empty() check can be inaccurate for concurrent
+    // queues when many tiny tasks have been scheduled (see MergeSort scheduler test). When this assert is triggered in
+    // other situations, there have probably been new tasks added after wait_for_all_tasks() was called.
+    Assert(queue_check_runs < 1'000, "Queues are not empty but all registered tasks have already been processed.");
     while (!queue->empty()) {
       std::this_thread::sleep_for(std::chrono::milliseconds(1));
-      std::cout << "slept" << std::endl;
     }
+    ++queue_check_runs;
   }
 }
 

--- a/src/lib/scheduler/node_queue_scheduler.cpp
+++ b/src/lib/scheduler/node_queue_scheduler.cpp
@@ -68,6 +68,13 @@ void NodeQueueScheduler::wait_for_all_tasks() {
 
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
+
+  for (auto& queue : _queues) {
+    while (!queue->empty()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      std::cout << "slept" << std::endl;
+    }
+  }
 }
 
 void NodeQueueScheduler::finish() {

--- a/src/test/lib/scheduler/scheduler_test.cpp
+++ b/src/test/lib/scheduler/scheduler_test.cpp
@@ -340,7 +340,7 @@ void merge_sort(Iterator first, Iterator last) {
   if (std::distance(first, last) == 1) {
     return;
   }
-  
+
   auto middle = first + (std::distance(first, last) / 2);
   auto tasks = std::vector<std::shared_ptr<AbstractTask>>{};
   tasks.emplace_back(std::make_shared<JobTask>([&]() { merge_sort(first, middle); }));


### PR DESCRIPTION
Planned work on Hyrise might recursively add tasks to the scheduler. This PR adds a test doing exactly that (a simple merge sort).

This test triggered a minor issue when shutting down the scheduler. This issue should be fixed with the PR.

Minor:
- changes to Jenkins are solely to avoid starting multiple Hyrise instances using all the threads of the system (the tests are using small scale factors, but we still spawns (partially spinning) worker threads on each core).
- changes in the benchmarklib are solely minor stuff as auto-to-stick