### PR TITLE
Use `std::stringstream` for default-type encoding message

### DIFF
--- a/src/benchmarklib/benchmark_table_encoder.cpp
+++ b/src/benchmarklib/benchmark_table_encoder.cpp
@@ -1,7 +1,7 @@
 #include "benchmark_table_encoder.hpp"
 
-#include <syncstream>
 #include <atomic>
+#include <syncstream>
 
 #include "encoding_config.hpp"
 #include "hyrise.hpp"

--- a/src/benchmarklib/benchmark_table_encoder.cpp
+++ b/src/benchmarklib/benchmark_table_encoder.cpp
@@ -1,7 +1,7 @@
 #include "benchmark_table_encoder.hpp"
 
 #include <atomic>
-#include <syncstream>
+#include <mutex>
 
 #include "encoding_config.hpp"
 #include "hyrise.hpp"
@@ -103,11 +103,11 @@ bool BenchmarkTableEncoder::encode(const std::string& table_name, const std::sha
       // orders.o_totalprice' of type float cannot be encoded as FixedStringDictionary and is  - Column 'left Unencoded.lineitem // NOLINT
       // Example with osyncstream:
       // - Column 'part.p_size' of type int cannot be encoded as FixedStringDictionary and is left Unencoded.
-      auto ostream = std::osyncstream(std::cout);
-      ostream << " - Column '" << table_name << "." << table->column_name(column_id) << "' of type ";
-      ostream << column_data_type << " cannot be encoded as ";
-      ostream << encoding_config.default_encoding_spec.encoding_type << " and is ";
-      ostream << "left Unencoded." << std::endl;
+      auto lock = std::lock_guard{output_stream_mutex};
+      std::cout << " - Column '" << table_name << "." << table->column_name(column_id) << "' of type ";
+      std::cout << column_data_type << " cannot be encoded as ";
+      std::cout << encoding_config.default_encoding_spec.encoding_type << " and is ";
+      std::cout << "left Unencoded." << std::endl;
       chunk_encoding_spec.emplace_back(EncodingType::Unencoded);
     }
   }
@@ -138,5 +138,7 @@ bool BenchmarkTableEncoder::encode(const std::string& table_name, const std::sha
 
   return encoding_performed;
 }
+
+std::mutex BenchmarkTableEncoder::output_stream_mutex{};
 
 }  // namespace hyrise

--- a/src/benchmarklib/benchmark_table_encoder.cpp
+++ b/src/benchmarklib/benchmark_table_encoder.cpp
@@ -98,7 +98,7 @@ bool BenchmarkTableEncoder::encode(const std::string& table_name, const std::sha
       chunk_encoding_spec.push_back(encoding_config.default_encoding_spec);
     } else {
       // Use a stringstream here to bundle all writes into a single one and avoid locking.
-      std::ostringstream output{};
+      auto output = std::ostringstream{};
       output << " - Column '" << table_name << "." << table->column_name(column_id) << "' of type ";
       output << column_data_type << " cannot be encoded as ";
       output << encoding_config.default_encoding_spec.encoding_type << " and is ";

--- a/src/benchmarklib/benchmark_table_encoder.hpp
+++ b/src/benchmarklib/benchmark_table_encoder.hpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <string>
+#include <mutex>
 
 namespace hyrise {
 
@@ -10,11 +11,13 @@ class Table;
 
 class BenchmarkTableEncoder {
  public:
-  // @param out   stream for logging info
   // @return      true, if any encoding operation was performed.
   //              false, if the @param table was already encoded as required by @param encoding_config
   static bool encode(const std::string& table_name, const std::shared_ptr<Table>& table,
                      const EncodingConfig& encoding_config);
+ private:
+  // Used to synchronize output messages when using multiple threads.
+  static std::mutex output_stream_mutex;
 };
 
 }  // namespace hyrise

--- a/src/benchmarklib/benchmark_table_encoder.hpp
+++ b/src/benchmarklib/benchmark_table_encoder.hpp
@@ -2,7 +2,6 @@
 
 #include <memory>
 #include <string>
-#include <mutex>
 
 namespace hyrise {
 
@@ -15,9 +14,6 @@ class BenchmarkTableEncoder {
   //              false, if the @param table was already encoded as required by @param encoding_config
   static bool encode(const std::string& table_name, const std::shared_ptr<Table>& table,
                      const EncodingConfig& encoding_config);
- private:
-  // Used to synchronize output messages when using multiple threads.
-  static std::mutex output_stream_mutex;
 };
 
 }  // namespace hyrise


### PR DESCRIPTION
This PR uses a `std::stringstream` to encapsulate writing the default-type encoding message to `std::cout` to prevent messages from multiple threads being mangled.

Example output line without this change:

```
orders.o_totalprice' of type float cannot be encoded as FixedStringDictionary and is - Column 'left Unencoded.lineitem
```