### PR TITLE
Support Clang-16

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,7 +54,11 @@ if (NOT "${HYRISE_RELAXED_BUILD}")
     # -Wno-deprecated-dynamic-exception-spec is needed for jemalloc, at least for the older version that we are using
 
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-        add_compile_options(-Weverything -Wshadow-all -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-documentation -Wno-padded -Wno-global-constructors -Wno-sign-conversion -Wno-exit-time-destructors -Wno-switch-enum -Wno-weak-vtables -Wno-double-promotion -Wno-covered-switch-default -Wno-unused-macros -Wno-newline-eof -Wno-missing-variable-declarations -Wno-weak-template-vtables -Wno-missing-prototypes -Wno-float-equal -Wno-return-std-move-in-c++11 -Wno-unreachable-code-break -Wno-undefined-func-template -Wno-unknown-warning-option -Wno-pass-failed -Wno-ctad-maybe-unsupported -Wno-header-hygiene -Wno-poison-system-directories -Wno-zero-as-null-pointer-constant -Wno-unsafe-buffer-usage)
+        add_compile_options(-Weverything -Wshadow-all -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-documentation -Wno-padded -Wno-global-constructors -Wno-sign-conversion -Wno-exit-time-destructors -Wno-switch-enum -Wno-weak-vtables -Wno-double-promotion -Wno-covered-switch-default -Wno-unused-macros -Wno-newline-eof -Wno-missing-variable-declarations -Wno-weak-template-vtables -Wno-missing-prototypes -Wno-float-equal -Wno-return-std-move-in-c++11 -Wno-unreachable-code-break -Wno-undefined-func-template -Wno-unknown-warning-option -Wno-pass-failed -Wno-ctad-maybe-unsupported -Wno-header-hygiene -Wno-poison-system-directories -Wno-zero-as-null-pointer-constant)
+
+        # We access buffers via pointers / pointer arithmetic in some cases when we know what we do (e.g., uninitialized
+        # vector works like this).
+        add_compile_options(-Wno-unsafe-buffer-usage)
     endif()
 
 else()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,7 +54,7 @@ if (NOT "${HYRISE_RELAXED_BUILD}")
     # -Wno-deprecated-dynamic-exception-spec is needed for jemalloc, at least for the older version that we are using
 
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-        add_compile_options(-Weverything -Wshadow-all -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-documentation -Wno-padded -Wno-global-constructors -Wno-sign-conversion -Wno-exit-time-destructors -Wno-switch-enum -Wno-weak-vtables -Wno-double-promotion -Wno-covered-switch-default -Wno-unused-macros -Wno-newline-eof -Wno-missing-variable-declarations -Wno-weak-template-vtables -Wno-missing-prototypes -Wno-float-equal -Wno-return-std-move-in-c++11 -Wno-unreachable-code-break -Wno-undefined-func-template -Wno-unknown-warning-option -Wno-pass-failed -Wno-ctad-maybe-unsupported -Wno-header-hygiene -Wno-poison-system-directories -Wno-zero-as-null-pointer-constant)
+        add_compile_options(-Weverything -Wshadow-all -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-documentation -Wno-padded -Wno-global-constructors -Wno-sign-conversion -Wno-exit-time-destructors -Wno-switch-enum -Wno-weak-vtables -Wno-double-promotion -Wno-covered-switch-default -Wno-unused-macros -Wno-newline-eof -Wno-missing-variable-declarations -Wno-weak-template-vtables -Wno-missing-prototypes -Wno-float-equal -Wno-return-std-move-in-c++11 -Wno-unreachable-code-break -Wno-undefined-func-template -Wno-unknown-warning-option -Wno-pass-failed -Wno-ctad-maybe-unsupported -Wno-header-hygiene -Wno-poison-system-directories -Wno-zero-as-null-pointer-constant -Wno-unsafe-buffer-usage)
     endif()
 
 else()

--- a/src/benchmarklib/random_generator.hpp
+++ b/src/benchmarklib/random_generator.hpp
@@ -10,7 +10,7 @@ namespace hyrise {
 
 class RandomGenerator {
  public:
-  // Fix random seed by default, to make sure the benchmark is deterministic
+  // Fix random seed by default, to make sure the benchmark is deterministic.
   explicit RandomGenerator(uint32_t seed = 42) : engine(seed) {}
 
   /**
@@ -20,28 +20,27 @@ class RandomGenerator {
    * @return            a random number
    */
   uint64_t random_number(uint64_t lower, uint64_t upper) {
-    std::uniform_int_distribution<uint64_t> dist(lower, upper);
+    auto dist = std::uniform_int_distribution<uint64_t>{lower, upper};
     return dist(engine);
   }
 
   /**
-   * Generates a set of unique size_ts in the half open interval [0, id_length)
-   * This function is used, e.g., to generate foreign key relationships
+   * Generates a set of unique size_ts in the half open interval [0, id_length). This function is used, e.g., to
+   * generate foreign key relationships.
    * @param num_unique      number of unique values to be returned
    * @param id_length       maximum number (not included) in the set
    * @return                a set of unique numbers
    */
   std::set<size_t> select_unique_ids(size_t num_unique, size_t id_length) {
-    std::set<size_t> rows;
-    Assert(num_unique <= id_length, "There are not enough ids to be selected!");
-    for (size_t i = 0; i < num_unique; ++i) {
-      size_t index = static_cast<size_t>(-1);
-      do {
-        index = random_number(0, id_length - 1);
-      } while (rows.find(index) != rows.end());
-      rows.insert(index);
+    auto rows = std::set<size_t>{};
+    Assert(num_unique <= id_length, "There are not enough IDs to be selected!");
+    while (true) {
+      rows.emplace(random_number(0, id_length - 1));
+
+      if (rows.size() == num_unique) {
+        return rows;
+      }
     }
-    return rows;
   }
 
  protected:

--- a/src/benchmarklib/random_generator.hpp
+++ b/src/benchmarklib/random_generator.hpp
@@ -33,6 +33,7 @@ class RandomGenerator {
    */
   std::set<size_t> select_unique_ids(size_t num_unique, size_t id_length) {
     auto rows = std::set<size_t>{};
+    Assert(num_unique > 0, "Expected to select at least one ID.");
     Assert(num_unique <= id_length, "There are not enough IDs to be selected!");
     while (true) {
       rows.emplace(random_number(0, id_length - 1));

--- a/src/benchmarklib/tpcc/procedures/tpcc_new_order.cpp
+++ b/src/benchmarklib/tpcc/procedures/tpcc_new_order.cpp
@@ -27,7 +27,8 @@ TPCCNewOrder::TPCCNewOrder(const int num_warehouses, BenchmarkSQLExecutor& sql_e
     if (is_home_warehouse) {
       order_line.ol_supply_w_id = w_id;
     } else {
-      // Choose a warehouse that is different from w_id
+      // Choose a warehouse that is different from w_id.
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-do-while)
       do {
         order_line.ol_supply_w_id = warehouse_dist(_random_engine);
       } while (order_line.ol_supply_w_id == w_id);

--- a/src/benchmarklib/tpcc/procedures/tpcc_payment.cpp
+++ b/src/benchmarklib/tpcc/procedures/tpcc_payment.cpp
@@ -19,7 +19,8 @@ TPCCPayment::TPCCPayment(const int num_warehouses, BenchmarkSQLExecutor& sql_exe
   // Use home warehouse in 85% of cases, otherwise select a random one
   std::uniform_int_distribution<> home_warehouse_dist{1, 100};
   if (num_warehouses > 2 && home_warehouse_dist(_random_engine) > 85) {
-    // Choose remote warehouse
+    // Choose remote warehouse.
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-do-while)
     do {
       c_w_id = warehouse_dist(_random_engine);
     } while (c_w_id == w_id);

--- a/src/benchmarklib/tpch/tpch_benchmark_item_runner.cpp
+++ b/src/benchmarklib/tpch/tpch_benchmark_item_runner.cpp
@@ -226,6 +226,7 @@ std::string TPCHBenchmarkItemRunner::_build_query(const BenchmarkItemID item_id)
     case 7 - 1: {
       const auto* const nation1 = nations.list[nation_dist(random_engine)].text;
       auto nation2 = std::string{};
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-do-while)
       do {
         nation2 = nations.list[nation_dist(random_engine)].text;
       } while (nation1 == nation2);
@@ -294,6 +295,7 @@ std::string TPCHBenchmarkItemRunner::_build_query(const BenchmarkItemID item_id)
     case 12 - 1: {
       const auto* const shipmode1 = l_smode_set.list[shipmode_dist(random_engine)].text;
       std::string shipmode2;
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-do-while)
       do {
         shipmode2 = l_smode_set.list[shipmode_dist(random_engine)].text;
       } while (shipmode1 == shipmode2);

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -197,24 +197,24 @@ int Console::execute_script(const std::string& filepath) {
 }
 
 int Console::_eval(const std::string& input) {
-  // Do nothing if no input was given
+  // Do nothing if no input was given.
   if (input.empty() && _multiline_input.empty()) {
     return ReturnCode::Ok;
   }
 
-  // Dump command to logfile, and to the Console if input comes from a script file
-  // Also remove Readline specific escape sequences ('\001' and '\002') to make it look normal
+  // Dump command to logfile, and to the Console if input comes from a script file. Also remove Readline specific
+  // escape sequences ('\001' and '\002') to make it look normal.
   out(remove_coloring(_prompt + input + "\n", true), _verbose);
 
-  // Check if we already are in multiline input
+  // Check if we already are in multiline input.
   if (_multiline_input.empty()) {
-    // Check if a registered command was entered
-    RegisteredCommands::iterator it;
-    if ((it = _commands.find(input.substr(0, input.find_first_of(" \n;")))) != std::end(_commands)) {
+    // Check if a registered command was entered.
+    const auto it = _commands.find(input.substr(0, input.find_first_of(" \n;")));
+    if (it != _commands.end()) {
       return _eval_command(it->second, input);
     }
 
-    // Regard query as complete if input is valid and not already in multiline
+    // Regard query as complete if input is valid and not already in multiline.
     auto parse_result = hsql::SQLParserResult{};
     hsql::SQLParser::parse(input, &parse_result);
     if (parse_result.isValid()) {
@@ -222,14 +222,14 @@ int Console::_eval(const std::string& input) {
     }
   }
 
-  // Regard query as complete if last character is semicolon, regardless of multiline or not
+  // Regard query as complete if last character is semicolon, regardless of multiline or not.
   if (input.back() == ';') {
     const auto return_code = _eval_sql(_multiline_input + input);
     _multiline_input = "";
     return return_code;
   }
 
-  // If query is not complete(/valid), and the last character is not a semicolon, enter/continue multiline
+  // If query is not complete(/valid), and the last character is not a semicolon, enter/continue multiline.
   _multiline_input += input;
   _multiline_input += '\n';
   return ReturnCode::Multiline;
@@ -991,7 +991,7 @@ int Console::_reset() {
   _lqp_cache->clear();
   _pqp_cache->clear();
 
-  Hyrise::get().reset();
+  Hyrise::reset();
   Hyrise::get().default_pqp_cache = _pqp_cache;
   Hyrise::get().default_lqp_cache = _lqp_cache;
 

--- a/src/lib/expression/evaluation/like_matcher.hpp
+++ b/src/lib/expression/evaluation/like_matcher.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <experimental/functional>
+#include <regex>
 #include <utility>
 #include <variant>
-#include <regex>
 
 #include "types.hpp"
 

--- a/src/lib/expression/evaluation/like_matcher.hpp
+++ b/src/lib/expression/evaluation/like_matcher.hpp
@@ -1,15 +1,11 @@
 #pragma once
 
 #include <experimental/functional>
-#include <optional>
-#include <regex>
-#include <string>
 #include <utility>
 #include <variant>
-#include <vector>
+#include <regex>
 
 #include "types.hpp"
-#include "utils/assert.hpp"
 
 namespace hyrise {
 
@@ -20,8 +16,8 @@ namespace hyrise {
  * check.
  */
 class LikeMatcher {
-  // A faster search algorithm than the typical byte-wise search if we can reuse the searcher
-#ifdef __GLIBCXX__
+  // A faster search algorithm than the typical byte-wise search if we can reuse the searcher.
+#ifdef __cpp_lib_boyer_moore_searcher
   using Searcher = std::boyer_moore_searcher<pmr_string::const_iterator>;
 #else
   using Searcher = std::experimental::boyer_moore_searcher<pmr_string::const_iterator>;

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -10,14 +10,13 @@
 #include <vector>
 
 #include "bytell_hash_map.hpp"
+
 #include "hyrise.hpp"
 #include "join_hash/join_hash_steps.hpp"
 #include "join_hash/join_hash_traits.hpp"
 #include "join_helper/join_output_writing.hpp"
-#include "scheduler/abstract_task.hpp"
 #include "scheduler/job_task.hpp"
 #include "type_comparison.hpp"
-#include "utils/assert.hpp"
 #include "utils/format_duration.hpp"
 #include "utils/timer.hpp"
 

--- a/src/lib/operators/join_sort_merge.cpp
+++ b/src/lib/operators/join_sort_merge.cpp
@@ -116,6 +116,7 @@ class JoinSortMerge::JoinSortMergeImpl : public AbstractReadOnlyOperatorImpl {
   }
 
  protected:
+  // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
   JoinSortMerge& _sort_merge_join;
   const std::shared_ptr<const Table> _left_input_table, _right_input_table;
 
@@ -125,7 +126,7 @@ class JoinSortMerge::JoinSortMergeImpl : public AbstractReadOnlyOperatorImpl {
   MaterializedSegmentList<T> _sorted_left_table;
   MaterializedSegmentList<T> _sorted_right_table;
 
-  // Contains the null value row ids if a join column is an outer join column
+  // Contains the null value row ids if a join column is an outer join column.
   RowIDPosList _null_rows_left;
   RowIDPosList _null_rows_right;
 
@@ -136,11 +137,12 @@ class JoinSortMerge::JoinSortMergeImpl : public AbstractReadOnlyOperatorImpl {
   const JoinMode _mode;
 
   const std::vector<OperatorJoinPredicate>& _secondary_join_predicates;
+  // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
 
   // The cluster count must be a power of two, i.e. 1, 2, 4, 8, 16, ...
   size_t _cluster_count;
 
-  // Contains the output row ids for each cluster
+  // Contains the output row ids for each cluster.
   std::vector<RowIDPosList> _output_pos_lists_left;
   std::vector<RowIDPosList> _output_pos_lists_right;
 
@@ -196,8 +198,10 @@ class JoinSortMerge::JoinSortMergeImpl : public AbstractReadOnlyOperatorImpl {
     template <typename F>
     void for_every_row_id(const MaterializedSegmentList<T>& table, const F& action) {
 // False positive with gcc and tsan (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=92194)
+#ifndef __clang__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
       for (auto cluster = start.cluster; cluster <= end.cluster; ++cluster) {
         const auto start_index = (cluster == start.cluster) ? start.index : 0;
         const auto end_index = (cluster == end.cluster) ? end.index : table[cluster].size();
@@ -205,7 +209,9 @@ class JoinSortMerge::JoinSortMergeImpl : public AbstractReadOnlyOperatorImpl {
           action(table[cluster][index].row_id);
         }
       }
+#ifndef __clang__
 #pragma GCC diagnostic pop
+#endif
     }
   };
 

--- a/src/lib/operators/sort.cpp
+++ b/src/lib/operators/sort.cpp
@@ -471,15 +471,17 @@ class Sort::SortImpl {
     }
   }
 
+  // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
   const std::shared_ptr<const Table> _table_in;
 
-  // column to sort by
+  // Column to sort by.
   const ColumnID _column_id;
   const SortMode _sort_mode;
+  // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
 
   std::vector<RowIDValuePair> _row_id_value_vector;
 
-  // Stored as RowIDValuePair for better type compatibility even if value is unused
+  // Stored as RowIDValuePair for better type compatibility even if value is unused.
   std::vector<RowIDValuePair> _null_value_rows;
 };
 

--- a/src/lib/optimizer/join_ordering/enumerate_ccp.cpp
+++ b/src/lib/optimizer/join_ordering/enumerate_ccp.cpp
@@ -122,6 +122,7 @@ void EnumerateCcp::_enumerate_cmp(const JoinGraphVertexSet& primary_vertex_set) 
   std::vector<size_t> reverse_vertex_indices;
   auto current_vertex_idx = neighborhood.find_first();
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-do-while)
   do {
     reverse_vertex_indices.emplace_back(current_vertex_idx);
   } while ((current_vertex_idx = neighborhood.find_next(current_vertex_idx)) != JoinGraphVertexSet::npos);

--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -173,7 +173,7 @@ OptimizerRuleMetrics::OptimizerRuleMetrics(const std::string& init_rule_name,
  * optimization costs reasonable.
  */
 std::shared_ptr<Optimizer> Optimizer::create_default_optimizer() {
-  const auto optimizer = std::make_shared<Optimizer>();
+  auto optimizer = std::make_shared<Optimizer>();
 
   optimizer->add_rule(std::make_unique<ExpressionReductionRule>());
 
@@ -289,8 +289,8 @@ std::shared_ptr<AbstractLQPNode> Optimizer::optimize(
     }
   }
 
-  // Remove LogicalPlanRootNode
-  const auto optimized_node = root_node->left_input();
+  // Remove LogicalPlanRootNode.
+  auto optimized_node = root_node->left_input();
   root_node->set_left_input(nullptr);
 
   return optimized_node;
@@ -300,8 +300,8 @@ void Optimizer::validate_lqp(const std::shared_ptr<AbstractLQPNode>& root_node) 
   // If you can think of a way in which an LQP can be corrupt, please add it!
   // First, collect all LQPs (the main LQP and all uncorrelated subqueries).
   auto lqps = std::vector<std::shared_ptr<AbstractLQPNode>>{root_node};
-  for (auto& [lqp, _] : collect_lqp_subquery_expressions_by_lqp(root_node, true)) {
-    lqps.emplace_back(std::move(lqp));
+  for (const auto& [lqp, _] : collect_lqp_subquery_expressions_by_lqp(root_node, true)) {
+    lqps.emplace_back(lqp);
   }
 
   auto nodes_by_lqp = LQPNodesByLQP{};

--- a/src/lib/storage/lz4_segment.cpp
+++ b/src/lib/storage/lz4_segment.cpp
@@ -428,7 +428,8 @@ template <typename T>
 std::shared_ptr<AbstractSegment> LZ4Segment<T>::copy_using_allocator(const PolymorphicAllocator<size_t>& alloc) const {
   auto new_lz4_blocks = pmr_vector<pmr_vector<char>>{alloc};
   for (const auto& block : _lz4_blocks) {
-    new_lz4_blocks.emplace_back(pmr_vector<char>{block, alloc});
+    auto block_copy = pmr_vector<char>{block, alloc};
+    new_lz4_blocks.emplace_back(std::move(block_copy));
   }
 
   auto new_null_values =

--- a/src/lib/utils/meta_tables/meta_system_information_table.cpp
+++ b/src/lib/utils/meta_tables/meta_system_information_table.cpp
@@ -59,8 +59,8 @@ size_t MetaSystemInformationTable::_cpu_count() {
 #endif
 
 #ifdef __APPLE__
-  size_t processors;
-  size_t size = sizeof(processors);
+  auto processors = size_t{};
+  auto size = sizeof(processors);
   const auto ret = sysctlbyname("hw.ncpu", &processors, &size, nullptr, 0);
   Assert(ret == 0, "Failed to call sysctl hw.ncpu");
 
@@ -82,8 +82,8 @@ size_t MetaSystemInformationTable::_ram_size() {
 #endif
 
 #ifdef __APPLE__
-  uint64_t ram;
-  size_t size = sizeof(ram);
+  auto ram = uint64_t{};
+  auto size = sizeof(ram);
   const auto ret = sysctlbyname("hw.memsize", &ram, &size, nullptr, 0);
   Assert(ret == 0, "Failed to call sysctl hw.memsize");
 

--- a/src/plugins/mvcc_delete_plugin.cpp
+++ b/src/plugins/mvcc_delete_plugin.cpp
@@ -107,14 +107,14 @@ void MvccDeletePlugin::_physical_delete_loop() {
   const auto lock = std::lock_guard<std::mutex>{_physical_delete_queue_mutex};
 
   if (!_physical_delete_queue.empty()) {
-    TableAndChunkID table_and_chunk_id = _physical_delete_queue.front();
+    const auto& table_and_chunk_id = _physical_delete_queue.front();
     const auto& table = table_and_chunk_id.first;
     const auto& chunk = table->get_chunk(table_and_chunk_id.second);
 
-    DebugAssert(chunk != nullptr, "Chunk does not exist. Physical Delete can not be applied.");
+    DebugAssert(chunk, "Chunk does not exist. Physical Delete can not be applied.");
 
     if (chunk->get_cleanup_commit_id()) {
-      // Check whether there are still active transactions that might use the chunk
+      // Check whether there are still active transactions that might use the chunk.
       auto transactions_conflict = false;
       auto lowest_snapshot_commit_id = Hyrise::get().transaction_manager.get_lowest_active_snapshot_commit_id();
 

--- a/src/plugins/mvcc_delete_plugin.cpp
+++ b/src/plugins/mvcc_delete_plugin.cpp
@@ -92,7 +92,7 @@ void MvccDeletePlugin::_logical_delete_loop() {
     }
     if (saved_memory > 0) {
       auto message = std::ostringstream{};
-      auto saved_mb = static_cast<float>(saved_memory) / (1000.0f * 1000.0f);
+      const auto saved_mb = static_cast<float>(saved_memory) / (1000.0f * 1000.0f);
       message << "Consolidated " << num_chunks << " chunk(s) of " << table_name << ", saved approx. "
               << std::setprecision(2) << saved_mb << " MB";
       Hyrise::get().log_manager.add_message("MvccDeletePlugin", message.str(), LogLevel::Info);
@@ -107,23 +107,22 @@ void MvccDeletePlugin::_physical_delete_loop() {
   const auto lock = std::lock_guard<std::mutex>{_physical_delete_queue_mutex};
 
   if (!_physical_delete_queue.empty()) {
-    const auto& table_and_chunk_id = _physical_delete_queue.front();
-    const auto& table = table_and_chunk_id.first;
-    const auto& chunk = table->get_chunk(table_and_chunk_id.second);
+    const auto& [table, chunk_id] = _physical_delete_queue.front();
+    const auto& chunk = table->get_chunk(chunk_id);
 
     DebugAssert(chunk, "Chunk does not exist. Physical Delete can not be applied.");
 
     if (chunk->get_cleanup_commit_id()) {
       // Check whether there are still active transactions that might use the chunk.
       auto transactions_conflict = false;
-      auto lowest_snapshot_commit_id = Hyrise::get().transaction_manager.get_lowest_active_snapshot_commit_id();
+      const auto lowest_snapshot_commit_id = Hyrise::get().transaction_manager.get_lowest_active_snapshot_commit_id();
 
       if (lowest_snapshot_commit_id) {
-        transactions_conflict = *chunk->get_cleanup_commit_id() > lowest_snapshot_commit_id.value();
+        transactions_conflict = *chunk->get_cleanup_commit_id() > *lowest_snapshot_commit_id;
       }
 
       if (!transactions_conflict) {
-        _delete_chunk_physically(table, table_and_chunk_id.second);
+        _delete_chunk_physically(table, chunk_id);
         _physical_delete_queue.pop();
       }
     }
@@ -135,7 +134,7 @@ bool MvccDeletePlugin::_try_logical_delete(const std::string& table_name, const 
   const auto& table = Hyrise::get().storage_manager.get_table(table_name);
   const auto& chunk = table->get_chunk(chunk_id);
 
-  Assert(chunk != nullptr, "Chunk does not exist. Logical Delete can not be applied.");
+  Assert(chunk, "Chunk does not exist. Logical Delete can not be applied.");
   Assert(chunk_id < (table->chunk_count() - 1),
          "MVCC Logical Delete should not be applied on the last/current mutable chunk.");
 
@@ -145,18 +144,18 @@ bool MvccDeletePlugin::_try_logical_delete(const std::string& table_name, const 
   std::iota(excluded_chunk_ids.begin(), excluded_chunk_ids.begin() + chunk_id, 0);
   std::iota(excluded_chunk_ids.begin() + chunk_id, excluded_chunk_ids.end(), chunk_id + 1);
 
-  auto get_table = std::make_shared<GetTable>(table_name, excluded_chunk_ids, std::vector<ColumnID>());
+  const auto get_table = std::make_shared<GetTable>(table_name, excluded_chunk_ids, std::vector<ColumnID>());
   get_table->set_transaction_context(transaction_context);
   get_table->execute();
 
   // Validate temporary table
-  auto validate = std::make_shared<Validate>(get_table);
+  const auto validate = std::make_shared<Validate>(get_table);
   validate->set_transaction_context(transaction_context);
   validate->execute();
 
   // Use Update operator to delete and re-insert valid records in chunk
   // Pass validate into Update operator twice since data will not be changed.
-  auto update = std::make_shared<Update>(table_name, validate, validate);
+  const auto update = std::make_shared<Update>(table_name, validate, validate);
   update->set_transaction_context(transaction_context);
   update->execute();
 


### PR DESCRIPTION
This PR makes small changes to support builds with clang 16. Notably, we suppress the `-Wunsafe-buffer-usage` check since we access buffers via pointers / pointer arithmetic in some cases when we know what we do (e.g., uninitialized vector works like this). The rest are mainly changes to silence clang-tidy-16. However, currently encounter build errors for tidy builds (see #258), so we do not update the CI yet. 