### PR TITLE
No RowID temporaries for emplace_back()

### DIFF
--- a/scripts/test/hyriseConsole_test.py
+++ b/scripts/test/hyriseConsole_test.py
@@ -114,7 +114,7 @@ def main():
 
     # Test TPCH generation.
     console.sendline("generate_tpch     0.01   7")
-    console.expect("Generating tables done")
+    console.expect("Generating tables done", timeout=300)
 
     # Test TPCH tables.
     console.sendline("select * from nation")

--- a/src/lib/operators/difference.cpp
+++ b/src/lib/operators/difference.cpp
@@ -139,7 +139,7 @@ std::shared_ptr<const Table> Difference::_on_execute() {
           if (pos_list_pair.first) {
             pos_list_pair.second->emplace_back((*pos_list_pair.first)[chunk_offset]);
           } else {
-            pos_list_pair.second->emplace_back(RowID{chunk_id, chunk_offset});
+            pos_list_pair.second->emplace_back(chunk_id, chunk_offset);
           }
         }
       }

--- a/src/lib/operators/join_index.cpp
+++ b/src/lib/operators/join_index.cpp
@@ -460,7 +460,7 @@ void JoinIndex::_append_matches(const AbstractChunkIndex::Iterator& range_begin,
 void JoinIndex::_append_matches_dereferenced(const ChunkID& probe_chunk_id, const ChunkOffset& probe_chunk_offset,
                                              const RowIDPosList& index_table_matches) {
   for (const auto& index_side_row_id : index_table_matches) {
-    _probe_pos_list->emplace_back(RowID{probe_chunk_id, probe_chunk_offset});
+    _probe_pos_list->emplace_back(probe_chunk_id, probe_chunk_offset);
     _index_pos_list->emplace_back(index_side_row_id);
     _index_pos_dereferenced.emplace_back(true);
   }
@@ -475,7 +475,7 @@ void JoinIndex::_append_matches_non_inner(const bool is_semi_or_anti_join) {
       for (ChunkOffset chunk_offset{0}; chunk_offset < static_cast<ChunkOffset>(_probe_matches[probe_chunk_id].size());
            ++chunk_offset) {
         if (!_probe_matches[probe_chunk_id][chunk_offset]) {
-          _probe_pos_list->emplace_back(RowID{probe_chunk_id, chunk_offset});
+          _probe_pos_list->emplace_back(probe_chunk_id, chunk_offset);
           _index_pos_list->emplace_back(NULL_ROW_ID);
         }
       }
@@ -490,7 +490,7 @@ void JoinIndex::_append_matches_non_inner(const bool is_semi_or_anti_join) {
       for (ChunkOffset chunk_offset{0}; chunk_offset < static_cast<ChunkOffset>(_index_matches[chunk_id].size());
            ++chunk_offset) {
         if (!_index_matches[chunk_id][chunk_offset]) {
-          _index_pos_list->emplace_back(RowID{chunk_id, chunk_offset});
+          _index_pos_list->emplace_back(chunk_id, chunk_offset);
           _probe_pos_list->emplace_back(NULL_ROW_ID);
         }
       }
@@ -513,7 +513,7 @@ void JoinIndex::_append_matches_non_inner(const bool is_semi_or_anti_join) {
         const auto chunk_size = chunk->size();
         for (ChunkOffset chunk_offset{0}; chunk_offset < chunk_size; ++chunk_offset) {
           if (_probe_matches[chunk_id][chunk_offset] ^ invert) {
-            _probe_pos_list->emplace_back(RowID{chunk_id, chunk_offset});
+            _probe_pos_list->emplace_back(chunk_id, chunk_offset);
           }
         }
       }
@@ -526,7 +526,7 @@ void JoinIndex::_append_matches_non_inner(const bool is_semi_or_anti_join) {
         const auto chunk_size = chunk->size();
         for (ChunkOffset chunk_offset{0}; chunk_offset < chunk_size; ++chunk_offset) {
           if (_index_matches[chunk_id][chunk_offset] ^ invert) {
-            _index_pos_list->emplace_back(RowID{chunk_id, chunk_offset});
+            _index_pos_list->emplace_back(chunk_id, chunk_offset);
           }
         }
       }

--- a/src/lib/operators/join_nested_loop.cpp
+++ b/src/lib/operators/join_nested_loop.cpp
@@ -189,7 +189,7 @@ std::shared_ptr<const Table> JoinNestedLoop::_on_execute() {
       // Add unmatched rows on the left for Left and Full Outer joins
       for (ChunkOffset chunk_offset{0}; chunk_offset < static_cast<ChunkOffset>(left_matches.size()); ++chunk_offset) {
         if (!left_matches[chunk_offset]) {
-          pos_list_left->emplace_back(RowID{chunk_id_left, chunk_offset});
+          pos_list_left->emplace_back(chunk_id_left, chunk_offset);
           pos_list_right->emplace_back(NULL_ROW_ID);
         }
       }
@@ -209,7 +209,7 @@ std::shared_ptr<const Table> JoinNestedLoop::_on_execute() {
       for (auto chunk_offset = ChunkOffset{0}; chunk_offset < chunk_size; ++chunk_offset) {
         if (!right_matches_by_chunk[chunk_id_right][chunk_offset]) {
           pos_list_left->emplace_back(NULL_ROW_ID);
-          pos_list_right->emplace_back(RowID{chunk_id_right, chunk_offset});
+          pos_list_right->emplace_back(chunk_id_right, chunk_offset);
         }
       }
     }
@@ -226,7 +226,7 @@ std::shared_ptr<const Table> JoinNestedLoop::_on_execute() {
       const auto chunk_size = chunk_left->size();
       for (auto chunk_offset = ChunkOffset{0}; chunk_offset < chunk_size; ++chunk_offset) {
         if (left_matches_by_chunk[chunk_id][chunk_offset] ^ invert) {
-          pos_list_left->emplace_back(RowID{chunk_id, chunk_offset});
+          pos_list_left->emplace_back(chunk_id, chunk_offset);
         }
       }
     }

--- a/src/lib/operators/product.cpp
+++ b/src/lib/operators/product.cpp
@@ -112,7 +112,7 @@ void Product::_add_product_of_two_chunks(const std::shared_ptr<Table>& output, C
           if (pos_list_in) {
             pos_list_out->emplace_back((*pos_list_in)[offset]);
           } else {
-            pos_list_out->emplace_back(RowID{is_left_side ? chunk_id_left : chunk_id_right, offset});
+            pos_list_out->emplace_back(is_left_side ? chunk_id_left : chunk_id_right, offset);
           }
         }
       }

--- a/src/lib/operators/table_scan/abstract_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/abstract_table_scan_impl.hpp
@@ -67,12 +67,12 @@ class AbstractTableScanImpl {
       const auto left = *left_it;
       if constexpr (std::is_same_v<RightIterator, std::false_type>) {
         if ((!CheckForNull || !left.is_null()) && func(left)) {
-          matches_out.emplace_back(RowID{chunk_id, left.chunk_offset()});
+          matches_out.emplace_back(chunk_id, left.chunk_offset());
         }
       } else {
         const auto right = *right_it;
         if ((!CheckForNull || (!left.is_null() && !right.is_null())) && func(left, right)) {
-          matches_out.emplace_back(RowID{chunk_id, left.chunk_offset()});
+          matches_out.emplace_back(chunk_id, left.chunk_offset());
         }
         ++right_it;
       }

--- a/src/lib/statistics/cardinality_estimator.cpp
+++ b/src/lib/statistics/cardinality_estimator.cpp
@@ -917,8 +917,6 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_operator_scan_pr
           return;
         }
 
-        // std::cout << "NARF" << predicate << std::endl;
-
         // TODO(anybody) Simplify this block if AbstractStatisticsObject ever supports total_count()
         const auto sliced_histogram =
             std::dynamic_pointer_cast<AbstractHistogram<ColumnDataType>>(sliced_statistics_object);
@@ -945,7 +943,6 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_operator_scan_pr
   for (auto column_id = ColumnID{0}; column_id < output_column_statistics.size(); ++column_id) {
     if (!output_column_statistics[column_id]) {
       output_column_statistics[column_id] = input_table_statistics->column_statistics[column_id]->scaled(selectivity);
-      // std::cout << *output_column_statistics[column_id] << std::endl;
     }
   }
 

--- a/src/lib/statistics/cardinality_estimator.cpp
+++ b/src/lib/statistics/cardinality_estimator.cpp
@@ -917,13 +917,17 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_operator_scan_pr
           return;
         }
 
+        // std::cout << "NARF" << predicate << std::endl;
+
         // TODO(anybody) Simplify this block if AbstractStatisticsObject ever supports total_count()
         const auto sliced_histogram =
             std::dynamic_pointer_cast<AbstractHistogram<ColumnDataType>>(sliced_statistics_object);
         DebugAssert(sliced_histogram, "Expected slicing of a Histogram to return either nullptr or a Histogram");
         if (input_table_statistics->row_count == 0 || sliced_histogram->total_count() == 0.0f) {
+          // std::cout << "setting selectivity of 0.0f" << std::endl;
           selectivity = 0.0f;
         } else {
+          // std::cout << "setting selectivity of sliced_histogram->total_count() / input_table_statistics->row_count: " <<  sliced_histogram->total_count() << "/" << input_table_statistics->row_count << std::endl;
           selectivity = sliced_histogram->total_count() / input_table_statistics->row_count;
         }
 
@@ -943,10 +947,12 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_operator_scan_pr
   for (auto column_id = ColumnID{0}; column_id < output_column_statistics.size(); ++column_id) {
     if (!output_column_statistics[column_id]) {
       output_column_statistics[column_id] = input_table_statistics->column_statistics[column_id]->scaled(selectivity);
+      // std::cout << *output_column_statistics[column_id] << std::endl;
     }
   }
 
   const auto row_count = Cardinality{input_table_statistics->row_count * selectivity};
+  std::cout << "ROW COUNT: " << row_count << std::endl;
   return std::make_shared<TableStatistics>(std::move(output_column_statistics), row_count);
 }
 

--- a/src/lib/statistics/cardinality_estimator.cpp
+++ b/src/lib/statistics/cardinality_estimator.cpp
@@ -924,10 +924,8 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_operator_scan_pr
             std::dynamic_pointer_cast<AbstractHistogram<ColumnDataType>>(sliced_statistics_object);
         DebugAssert(sliced_histogram, "Expected slicing of a Histogram to return either nullptr or a Histogram");
         if (input_table_statistics->row_count == 0 || sliced_histogram->total_count() == 0.0f) {
-          // std::cout << "setting selectivity of 0.0f" << std::endl;
           selectivity = 0.0f;
         } else {
-          // std::cout << "setting selectivity of sliced_histogram->total_count() / input_table_statistics->row_count: " <<  sliced_histogram->total_count() << "/" << input_table_statistics->row_count << std::endl;
           selectivity = sliced_histogram->total_count() / input_table_statistics->row_count;
         }
 
@@ -952,7 +950,6 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_operator_scan_pr
   }
 
   const auto row_count = Cardinality{input_table_statistics->row_count * selectivity};
-  std::cout << "ROW COUNT: " << row_count << std::endl;
   return std::make_shared<TableStatistics>(std::move(output_column_statistics), row_count);
 }
 

--- a/src/test/lib/operators/join_test_runner.cpp
+++ b/src/test/lib/operators/join_test_runner.cpp
@@ -564,7 +564,7 @@ class JoinTestRunner : public BaseTestWithParam<JoinTestConfiguration> {
           if (input_table_type == InputTableType::SharedPosList) {
             const auto pos_list = std::make_shared<RowIDPosList>();
             for (auto chunk_offset = ChunkOffset{0}; chunk_offset < input_chunk->size(); ++chunk_offset) {
-              pos_list->emplace_back(RowID{chunk_id, chunk_offset});
+              pos_list->emplace_back(chunk_id, chunk_offset);
             }
 
             if (chunk_id >= single_chunk_reference_range.first && chunk_id < single_chunk_reference_range.second) {
@@ -579,7 +579,7 @@ class JoinTestRunner : public BaseTestWithParam<JoinTestConfiguration> {
             for (auto column_id = ColumnID{0}; column_id < data_table->column_count(); ++column_id) {
               const auto pos_list = std::make_shared<RowIDPosList>();
               for (auto chunk_offset = ChunkOffset{0}; chunk_offset < input_chunk->size(); ++chunk_offset) {
-                pos_list->emplace_back(RowID{chunk_id, chunk_offset});
+                pos_list->emplace_back(chunk_id, chunk_offset);
               }
               if (chunk_id >= single_chunk_reference_range.first && chunk_id < single_chunk_reference_range.second) {
                 pos_list->guarantee_single_chunk();

--- a/src/test/lib/operators/sort_test.cpp
+++ b/src/test/lib/operators/sort_test.cpp
@@ -188,9 +188,9 @@ TEST_F(SortTest, InputReferencesDifferentTables) {
       TableColumnDefinitions{TableColumnDefinition{"a", DataType::Int, true}}, TableType::References);
 
   auto pos_list = std::make_shared<RowIDPosList>();
-  pos_list->emplace_back(RowID{ChunkID{0}, ChunkOffset{0}});
-  pos_list->emplace_back(RowID{ChunkID{0}, ChunkOffset{1}});
-  pos_list->emplace_back(RowID{ChunkID{1}, ChunkOffset{0}});
+  pos_list->emplace_back(ChunkID{0}, ChunkOffset{0});
+  pos_list->emplace_back(ChunkID{0}, ChunkOffset{1});
+  pos_list->emplace_back(ChunkID{1}, ChunkOffset{0});
 
   auto first_reference_segment = std::make_shared<ReferenceSegment>(input_table, ColumnID{0}, pos_list);
   union_table->append_chunk(Segments{first_reference_segment});
@@ -216,9 +216,9 @@ TEST_F(SortTest, InputReferencesDifferentColumns) {
       TableColumnDefinitions{TableColumnDefinition{"a", DataType::Int, true}}, TableType::References);
 
   auto pos_list = std::make_shared<RowIDPosList>();
-  pos_list->emplace_back(RowID{ChunkID{0}, ChunkOffset{0}});
-  pos_list->emplace_back(RowID{ChunkID{0}, ChunkOffset{1}});
-  pos_list->emplace_back(RowID{ChunkID{1}, ChunkOffset{0}});
+  pos_list->emplace_back(ChunkID{0}, ChunkOffset{0});
+  pos_list->emplace_back(ChunkID{0}, ChunkOffset{1});
+  pos_list->emplace_back(ChunkID{1}, ChunkOffset{0});
 
   auto first_reference_segment = std::make_shared<ReferenceSegment>(input_table, ColumnID{0}, pos_list);
   weird_table->append_chunk(Segments{first_reference_segment});

--- a/src/test/lib/operators/table_scan_test.cpp
+++ b/src/test/lib/operators/table_scan_test.cpp
@@ -122,13 +122,13 @@ class OperatorsTableScanTest : public BaseTest, public ::testing::WithParamInter
     const auto test_table_part_compressed = _int_int_partly_compressed->get_output();
 
     auto pos_list = std::make_shared<RowIDPosList>();
-    pos_list->emplace_back(RowID{ChunkID{2}, ChunkOffset{0}});
-    pos_list->emplace_back(RowID{ChunkID{1}, ChunkOffset{1}});
-    pos_list->emplace_back(RowID{ChunkID{1}, ChunkOffset{3}});
-    pos_list->emplace_back(RowID{ChunkID{0}, ChunkOffset{2}});
-    pos_list->emplace_back(RowID{ChunkID{2}, ChunkOffset{2}});
-    pos_list->emplace_back(RowID{ChunkID{0}, ChunkOffset{0}});
-    pos_list->emplace_back(RowID{ChunkID{0}, ChunkOffset{4}});
+    pos_list->emplace_back(ChunkID{2}, ChunkOffset{0});
+    pos_list->emplace_back(ChunkID{1}, ChunkOffset{1});
+    pos_list->emplace_back(ChunkID{1}, ChunkOffset{3});
+    pos_list->emplace_back(ChunkID{0}, ChunkOffset{2});
+    pos_list->emplace_back(ChunkID{2}, ChunkOffset{2});
+    pos_list->emplace_back(ChunkID{0}, ChunkOffset{0});
+    pos_list->emplace_back(ChunkID{0}, ChunkOffset{4});
 
     auto segment_a = std::make_shared<ReferenceSegment>(test_table_part_compressed, ColumnID{0}, pos_list);
     auto segment_b = std::make_shared<ReferenceSegment>(test_table_part_compressed, ColumnID{1}, pos_list);
@@ -1181,17 +1181,17 @@ TEST_P(OperatorsTableScanTest, SortedFlagReferenceSegments) {
   const auto ref_table = std::make_shared<Table>(table->column_definitions(), TableType::References);
 
   auto pos_list_1 = std::make_shared<RowIDPosList>();
-  pos_list_1->emplace_back(RowID{ChunkID{0}, ChunkOffset{1}});
-  pos_list_1->emplace_back(RowID{ChunkID{0}, ChunkOffset{0}});
-  pos_list_1->emplace_back(RowID{ChunkID{0}, ChunkOffset{3}});
-  pos_list_1->emplace_back(RowID{ChunkID{0}, ChunkOffset{2}});
+  pos_list_1->emplace_back(ChunkID{0}, ChunkOffset{1});
+  pos_list_1->emplace_back(ChunkID{0}, ChunkOffset{0});
+  pos_list_1->emplace_back(ChunkID{0}, ChunkOffset{3});
+  pos_list_1->emplace_back(ChunkID{0}, ChunkOffset{2});
   pos_list_1->guarantee_single_chunk();
 
   const auto segment_1 = std::make_shared<ReferenceSegment>(table, ColumnID{0}, pos_list_1);
   ref_table->append_chunk({segment_1});
 
   auto pos_list_2 = std::make_shared<RowIDPosList>();
-  pos_list_2->emplace_back(RowID{ChunkID{1}, ChunkOffset{0}});
+  pos_list_2->emplace_back(ChunkID{1}, ChunkOffset{0});
   pos_list_2->guarantee_single_chunk();
 
   const auto segment_2 = std::make_shared<ReferenceSegment>(table, ColumnID{0}, pos_list_2);
@@ -1229,14 +1229,14 @@ TEST_P(OperatorsTableScanTest, SortedFlagSingleChunkNotGuaranteed) {
   const auto ref_table = std::make_shared<Table>(table->column_definitions(), TableType::References);
 
   auto pos_list_1 = std::make_shared<RowIDPosList>();
-  pos_list_1->emplace_back(RowID{ChunkID{0}, ChunkOffset{1}});
-  pos_list_1->emplace_back(RowID{ChunkID{0}, ChunkOffset{3}});
+  pos_list_1->emplace_back(ChunkID{0}, ChunkOffset{1});
+  pos_list_1->emplace_back(ChunkID{0}, ChunkOffset{3});
 
   const auto segment_1 = std::make_shared<ReferenceSegment>(table, ColumnID{0}, pos_list_1);
   ref_table->append_chunk({segment_1});
 
   auto pos_list_2 = std::make_shared<RowIDPosList>();
-  pos_list_2->emplace_back(RowID{ChunkID{1}, ChunkOffset{0}});
+  pos_list_2->emplace_back(ChunkID{1}, ChunkOffset{0});
 
   const auto segment_2 = std::make_shared<ReferenceSegment>(table, ColumnID{0}, pos_list_2);
   ref_table->append_chunk({segment_2});
@@ -1279,11 +1279,11 @@ TEST_P(OperatorsTableScanTest, SortedFlagMultipleChunksReferenced) {
   const auto ref_table = std::make_shared<Table>(table->column_definitions(), TableType::References);
 
   auto pos_list_1 = std::make_shared<RowIDPosList>();
-  pos_list_1->emplace_back(RowID{ChunkID{0}, ChunkOffset{1}});
-  pos_list_1->emplace_back(RowID{ChunkID{0}, ChunkOffset{0}});
-  pos_list_1->emplace_back(RowID{ChunkID{0}, ChunkOffset{3}});
-  pos_list_1->emplace_back(RowID{ChunkID{0}, ChunkOffset{2}});
-  pos_list_1->emplace_back(RowID{ChunkID{1}, ChunkOffset{0}});
+  pos_list_1->emplace_back(ChunkID{0}, ChunkOffset{1});
+  pos_list_1->emplace_back(ChunkID{0}, ChunkOffset{0});
+  pos_list_1->emplace_back(ChunkID{0}, ChunkOffset{3});
+  pos_list_1->emplace_back(ChunkID{0}, ChunkOffset{2});
+  pos_list_1->emplace_back(ChunkID{1}, ChunkOffset{0});
 
   const auto segment = std::make_shared<ReferenceSegment>(table, ColumnID{0}, pos_list_1);
   ref_table->append_chunk({segment});

--- a/src/test/lib/operators/union_positions_test.cpp
+++ b/src/test/lib/operators/union_positions_test.cpp
@@ -227,49 +227,49 @@ TEST_F(UnionPositionsTest, MultipleShuffledPosList) {
    */
   // Left input table, chunk 0, pos_list 0
   auto pos_list_left_0_0 = std::make_shared<RowIDPosList>();
-  pos_list_left_0_0->emplace_back(RowID{ChunkID{1}, ChunkOffset{2}});
-  pos_list_left_0_0->emplace_back(RowID{ChunkID{0}, ChunkOffset{1}});
-  pos_list_left_0_0->emplace_back(RowID{ChunkID{1}, ChunkOffset{2}});
+  pos_list_left_0_0->emplace_back(ChunkID{1}, ChunkOffset{2});
+  pos_list_left_0_0->emplace_back(ChunkID{0}, ChunkOffset{1});
+  pos_list_left_0_0->emplace_back(ChunkID{1}, ChunkOffset{2});
 
   // Left input table, chunk 1, pos_list 0
   auto pos_list_left_1_0 = std::make_shared<RowIDPosList>();
-  pos_list_left_1_0->emplace_back(RowID{ChunkID{2}, ChunkOffset{0}});
-  pos_list_left_1_0->emplace_back(RowID{ChunkID{0}, ChunkOffset{1}});
+  pos_list_left_1_0->emplace_back(ChunkID{2}, ChunkOffset{0});
+  pos_list_left_1_0->emplace_back(ChunkID{0}, ChunkOffset{1});
 
   // Left input table, chunk 0, pos_list 1
   auto pos_list_left_0_1 = std::make_shared<RowIDPosList>();
-  pos_list_left_0_1->emplace_back(RowID{ChunkID{2}, ChunkOffset{0}});
-  pos_list_left_0_1->emplace_back(RowID{ChunkID{1}, ChunkOffset{1}});
-  pos_list_left_0_1->emplace_back(RowID{ChunkID{1}, ChunkOffset{1}});
+  pos_list_left_0_1->emplace_back(ChunkID{2}, ChunkOffset{0});
+  pos_list_left_0_1->emplace_back(ChunkID{1}, ChunkOffset{1});
+  pos_list_left_0_1->emplace_back(ChunkID{1}, ChunkOffset{1});
 
   // Left input table, chunk 1, pos_list 1
   auto pos_list_left_1_1 = std::make_shared<RowIDPosList>();
-  pos_list_left_1_1->emplace_back(RowID{ChunkID{1}, ChunkOffset{0}});
-  pos_list_left_1_1->emplace_back(RowID{ChunkID{2}, ChunkOffset{0}});
+  pos_list_left_1_1->emplace_back(ChunkID{1}, ChunkOffset{0});
+  pos_list_left_1_1->emplace_back(ChunkID{2}, ChunkOffset{0});
 
   // Right input table, chunk 0, pos_list 0
   auto pos_list_right_0_0 = std::make_shared<RowIDPosList>();
-  pos_list_right_0_0->emplace_back(RowID{ChunkID{2}, ChunkOffset{0}});
-  pos_list_right_0_0->emplace_back(RowID{ChunkID{2}, ChunkOffset{0}});
-  pos_list_right_0_0->emplace_back(RowID{ChunkID{1}, ChunkOffset{2}});
-  pos_list_right_0_0->emplace_back(RowID{ChunkID{1}, ChunkOffset{0}});
+  pos_list_right_0_0->emplace_back(ChunkID{2}, ChunkOffset{0});
+  pos_list_right_0_0->emplace_back(ChunkID{2}, ChunkOffset{0});
+  pos_list_right_0_0->emplace_back(ChunkID{1}, ChunkOffset{2});
+  pos_list_right_0_0->emplace_back(ChunkID{1}, ChunkOffset{0});
 
   // Right input table, chunk 1, pos_list 0
   auto pos_list_right_1_0 = std::make_shared<RowIDPosList>();
-  pos_list_right_1_0->emplace_back(RowID{ChunkID{0}, ChunkOffset{0}});
-  pos_list_right_1_0->emplace_back(RowID{ChunkID{2}, ChunkOffset{0}});
+  pos_list_right_1_0->emplace_back(ChunkID{0}, ChunkOffset{0});
+  pos_list_right_1_0->emplace_back(ChunkID{2}, ChunkOffset{0});
 
   // Right input table, chunk 0, pos_list 1
   auto pos_list_right_0_1 = std::make_shared<RowIDPosList>();
-  pos_list_right_0_1->emplace_back(RowID{ChunkID{1}, ChunkOffset{0}});
-  pos_list_right_0_1->emplace_back(RowID{ChunkID{1}, ChunkOffset{0}});
-  pos_list_right_0_1->emplace_back(RowID{ChunkID{2}, ChunkOffset{0}});
-  pos_list_right_0_1->emplace_back(RowID{ChunkID{0}, ChunkOffset{0}});
+  pos_list_right_0_1->emplace_back(ChunkID{1}, ChunkOffset{0});
+  pos_list_right_0_1->emplace_back(ChunkID{1}, ChunkOffset{0});
+  pos_list_right_0_1->emplace_back(ChunkID{2}, ChunkOffset{0});
+  pos_list_right_0_1->emplace_back(ChunkID{0}, ChunkOffset{0});
 
   // Right input table, chunk 1, pos_list 1
   auto pos_list_right_1_1 = std::make_shared<RowIDPosList>();
-  pos_list_right_1_1->emplace_back(RowID{ChunkID{1}, ChunkOffset{0}});
-  pos_list_right_1_1->emplace_back(RowID{ChunkID{1}, ChunkOffset{0}});
+  pos_list_right_1_1->emplace_back(ChunkID{1}, ChunkOffset{0});
+  pos_list_right_1_1->emplace_back(ChunkID{1}, ChunkOffset{0});
 
   auto segment_left_0_0 = std::make_shared<ReferenceSegment>(_table_int_float4, ColumnID{0}, pos_list_left_0_0);
   auto segment_left_1_0 = std::make_shared<ReferenceSegment>(_table_int_float4, ColumnID{0}, pos_list_left_1_0);

--- a/src/test/lib/operators/validate_test.cpp
+++ b/src/test/lib/operators/validate_test.cpp
@@ -224,7 +224,7 @@ TEST_F(OperatorsValidateTest, ValidateReferenceSegmentWithMultipleChunks) {
   for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
     const auto chunk_size = _test_table->get_chunk(chunk_id)->size();
     for (auto chunk_offset = ChunkOffset{0}; chunk_offset < chunk_size; ++chunk_offset) {
-      pos_list->emplace_back(RowID{chunk_id, chunk_offset});
+      pos_list->emplace_back(chunk_id, chunk_offset);
     }
   }
 

--- a/src/test/lib/storage/encoded_segment_test.cpp
+++ b/src/test/lib/storage/encoded_segment_test.cpp
@@ -85,17 +85,17 @@ class EncodedSegmentTest : public BaseTestWithParam<SegmentEncodingSpec> {
   }
 
   static std::shared_ptr<RowIDPosList> _create_sequential_position_filter(size_t row_count) {
-    auto list = std::make_shared<RowIDPosList>();
-    list->guarantee_single_chunk();
+    auto position_list = std::make_shared<RowIDPosList>();
+    position_list->guarantee_single_chunk();
 
     for (auto offset_in_referenced_chunk = ChunkOffset{0}; offset_in_referenced_chunk < row_count;
          ++offset_in_referenced_chunk) {
       if (offset_in_referenced_chunk % 2) {
-        list->push_back(RowID{ChunkID{0}, offset_in_referenced_chunk});
+        position_list->emplace_back(ChunkID{0}, offset_in_referenced_chunk);
       }
     }
 
-    return list;
+    return position_list;
   }
 
   std::shared_ptr<RowIDPosList> _create_random_access_position_filter() {

--- a/src/test/lib/storage/encoded_string_segment_test.cpp
+++ b/src/test/lib/storage/encoded_string_segment_test.cpp
@@ -70,17 +70,17 @@ class EncodedStringSegmentTest : public BaseTestWithParam<SegmentEncodingSpec> {
   }
 
   std::shared_ptr<RowIDPosList> _create_sequential_position_filter() {
-    auto list = std::make_shared<RowIDPosList>();
-    list->guarantee_single_chunk();
+    auto position_list = std::make_shared<RowIDPosList>();
+    position_list->guarantee_single_chunk();
 
     for (auto offset_in_referenced_chunk = ChunkOffset{0}; offset_in_referenced_chunk < _row_count;
          ++offset_in_referenced_chunk) {
       if (offset_in_referenced_chunk % 2) {
-        list->emplace_back(ChunkID{0}, offset_in_referenced_chunk);
+        position_list->emplace_back(ChunkID{0}, offset_in_referenced_chunk);
       }
     }
 
-    return list;
+    return position_list;
   }
 
   std::shared_ptr<RowIDPosList> _create_random_access_position_filter() {

--- a/src/test/lib/storage/encoded_string_segment_test.cpp
+++ b/src/test/lib/storage/encoded_string_segment_test.cpp
@@ -76,7 +76,7 @@ class EncodedStringSegmentTest : public BaseTestWithParam<SegmentEncodingSpec> {
     for (auto offset_in_referenced_chunk = ChunkOffset{0}; offset_in_referenced_chunk < _row_count;
          ++offset_in_referenced_chunk) {
       if (offset_in_referenced_chunk % 2) {
-        list->push_back(RowID{ChunkID{0}, offset_in_referenced_chunk});
+        list->emplace_back(ChunkID{0}, offset_in_referenced_chunk);
       }
     }
 

--- a/src/test/lib/storage/reference_segment_test.cpp
+++ b/src/test/lib/storage/reference_segment_test.cpp
@@ -113,8 +113,8 @@ TEST_F(ReferenceSegmentTest, MemoryUsageEstimation) {
    */
 
   const auto pos_list_a = std::make_shared<RowIDPosList>();
-  pos_list_a->emplace_back(RowID{ChunkID{0}, ChunkOffset{0}});
-  pos_list_a->emplace_back(RowID{ChunkID{0}, ChunkOffset{1}});
+  pos_list_a->emplace_back(ChunkID{0}, ChunkOffset{0});
+  pos_list_a->emplace_back(ChunkID{0}, ChunkOffset{1});
   const auto pos_list_b = std::make_shared<RowIDPosList>();
 
   ReferenceSegment reference_segment_a(_test_table, ColumnID{0}, pos_list_a);

--- a/src/test/lib/storage/segment_iterators_test.cpp
+++ b/src/test/lib/storage/segment_iterators_test.cpp
@@ -76,18 +76,18 @@ TEST_P(SegmentIteratorsTest, LegacyForwardIteratorCompatible) {
   const auto table = load_table_with_encoding("resources/test_data/tbl/all_data_types_sorted.tbl", ChunkOffset{5});
 
   const auto position_filter = std::make_shared<RowIDPosList>();
-  position_filter->emplace_back(RowID{ChunkID{0}, ChunkOffset{0}});
-  position_filter->emplace_back(RowID{ChunkID{0}, ChunkOffset{1}});
-  position_filter->emplace_back(RowID{ChunkID{0}, ChunkOffset{2}});
-  position_filter->emplace_back(RowID{ChunkID{0}, ChunkOffset{3}});
-  position_filter->emplace_back(RowID{ChunkID{0}, ChunkOffset{4}});
+  position_filter->emplace_back(ChunkID{0}, ChunkOffset{0});
+  position_filter->emplace_back(ChunkID{0}, ChunkOffset{1});
+  position_filter->emplace_back(ChunkID{0}, ChunkOffset{2});
+  position_filter->emplace_back(ChunkID{0}, ChunkOffset{3});
+  position_filter->emplace_back(ChunkID{0}, ChunkOffset{4});
   position_filter->guarantee_single_chunk();
 
   const auto position_filter_multi_chunk =
       std::make_shared<RowIDPosList>(position_filter->begin(), position_filter->end());
-  position_filter_multi_chunk->emplace_back(RowID{ChunkID{1}, ChunkOffset{0}});
-  position_filter_multi_chunk->emplace_back(RowID{ChunkID{1}, ChunkOffset{1}});
-  position_filter_multi_chunk->emplace_back(RowID{ChunkID{1}, ChunkOffset{2}});
+  position_filter_multi_chunk->emplace_back(ChunkID{1}, ChunkOffset{0});
+  position_filter_multi_chunk->emplace_back(ChunkID{1}, ChunkOffset{1});
+  position_filter_multi_chunk->emplace_back(ChunkID{1}, ChunkOffset{2});
 
   /**
    * Takes an iterator pair and verifies its LegacyForwardIterators compatibility by feeding it into STL algorithms that
@@ -141,15 +141,15 @@ TEST_P(SegmentIteratorsTest, LegacyBidirectionalIteratorCompatible) {
   const auto table = load_table_with_encoding("resources/test_data/tbl/all_data_types_sorted.tbl", ChunkOffset{3});
 
   const auto position_filter = std::make_shared<RowIDPosList>();
-  position_filter->emplace_back(RowID{ChunkID{0}, ChunkOffset{0}});
-  position_filter->emplace_back(RowID{ChunkID{0}, ChunkOffset{1}});
-  position_filter->emplace_back(RowID{ChunkID{0}, ChunkOffset{2}});
+  position_filter->emplace_back(ChunkID{0}, ChunkOffset{0});
+  position_filter->emplace_back(ChunkID{0}, ChunkOffset{1});
+  position_filter->emplace_back(ChunkID{0}, ChunkOffset{2});
   position_filter->guarantee_single_chunk();
 
   const auto position_filter_multi_chunk =
       std::make_shared<RowIDPosList>(position_filter->begin(), position_filter->end());
-  position_filter_multi_chunk->emplace_back(RowID{ChunkID{1}, ChunkOffset{0}});
-  position_filter_multi_chunk->emplace_back(RowID{ChunkID{1}, ChunkOffset{1}});
+  position_filter_multi_chunk->emplace_back(ChunkID{1}, ChunkOffset{0});
+  position_filter_multi_chunk->emplace_back(ChunkID{1}, ChunkOffset{1});
 
   /**
    * Takes an iterator pair and verifies its LegacyBidirectionalIterators compatibility by both post and pre
@@ -186,15 +186,15 @@ TEST_P(SegmentIteratorsTest, LegacyRandomIteratorCompatible) {
   const auto table = load_table_with_encoding("resources/test_data/tbl/all_data_types_sorted.tbl", ChunkOffset{3});
 
   const auto position_filter = std::make_shared<RowIDPosList>();
-  position_filter->emplace_back(RowID{ChunkID{0}, ChunkOffset{0}});
-  position_filter->emplace_back(RowID{ChunkID{0}, ChunkOffset{1}});
-  position_filter->emplace_back(RowID{ChunkID{0}, ChunkOffset{2}});
+  position_filter->emplace_back(ChunkID{0}, ChunkOffset{0});
+  position_filter->emplace_back(ChunkID{0}, ChunkOffset{1});
+  position_filter->emplace_back(ChunkID{0}, ChunkOffset{2});
   position_filter->guarantee_single_chunk();
 
   const auto position_filter_multi_chunk =
       std::make_shared<RowIDPosList>(position_filter->begin(), position_filter->end());
-  position_filter_multi_chunk->emplace_back(RowID{ChunkID{1}, ChunkOffset{0}});
-  position_filter_multi_chunk->emplace_back(RowID{ChunkID{1}, ChunkOffset{1}});
+  position_filter_multi_chunk->emplace_back(ChunkID{1}, ChunkOffset{0});
+  position_filter_multi_chunk->emplace_back(ChunkID{1}, ChunkOffset{1});
 
   /**
    * Takes an iterator pair and verifies its LegacyRandomAccessIterator compatibility by feeding it into STL algorithms


### PR DESCRIPTION
Just PR just applies the "best practice" of avoiding temporaries when using `emplace_back()`.

All cases should be trivial for compilers to optimize and I thus don't expect any performance changes. ~Going to measure anyways. Benchmarks are running right now.~

Nothing surprising in terms of performance.

### Additional changes

This PR increases the timeouts for the Python `pexpect` scripts as they often timed out when the load on the CI server was high.

### Benchmarks

**System**
<details>
<summary>node-17 - click to expand</summary>

| property | value |
| -- | -- |
| Hostname | node-17 |
| CPU | AMD EPYC 7742 64-Core Processor |
| Memory | 492GB |
| numactl | nodebind: 0  |
| numactl | membind: 0 1  |
</details>

**Commit Info and Build Time**
| commit | date | message | build time |
| -- | -- | -- | -- |
| 8114ddda7 | 22.06.2023 20:32 | Recursive Scheduler Test and Scheduler Shutdown Fix (#2580) | real 421.30 user 2994.26 sys 373.49|
| f3ee47377 | 25.06.2023 23:35 | Lint | real 439.10 user 3024.09 sys 398.21|


**hyriseBenchmarkTPCH - single-threaded, SF 10.0**
<details>
<summary>
Sum of avg. item runtimes: -1%
 ||
Geometric mean of throughput changes: -1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /hyrise/rel_amd_nolto/benchmark_all_results/hyriseBenchmarkTPCH_8114ddda7b19816aae0d18a9c621ac3784b0dceb_st.json | /hyrise/rel_amd_nolto/benchmark_all_results/hyriseBenchmarkTPCH_f3ee473771660d25cc31399eaf28cee941423b9c_st.json |
 +--------------------------+------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 8114ddda7b19816aae0d18a9c621ac3784b0dceb-dirty                                                                   | f3ee473771660d25cc31399eaf28cee941423b9c-dirty                                                                   |
 |  benchmark_mode          | Ordered                                                                                                          | Ordered                                                                                                          |
 |  build_type              | release                                                                                                          | release                                                                                                          |
 |  chunk_indexes           | False                                                                                                            | False                                                                                                            |
 |  chunk_size              | 65535                                                                                                            | 65535                                                                                                            |
 |  clients                 | 1                                                                                                                | 1                                                                                                                |
 |  clustering              | None                                                                                                             | None                                                                                                             |
 |  compiler                | clang 14.0.0                                                                                                     | clang 14.0.0                                                                                                     |
 |  cores                   | 0                                                                                                                | 0                                                                                                                |
 |  data_preparation_cores  | 0                                                                                                                | 0                                                                                                                |
 |  date                    | 2023-06-26 13:20:01                                                                                              | 2023-06-26 09:02:51                                                                                              |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                          | {'default': {'encoding': 'Dictionary'}}                                                                          |
 |  max_duration            | 60000000000                                                                                                      | 60000000000                                                                                                      |
 |  max_runs                | 100                                                                                                              | 100                                                                                                              |
 |  scale_factor            | 10.0                                                                                                             | 10.0                                                                                                             |
 |  time_unit               | ns                                                                                                               | ns                                                                                                               |
 |  use_prepared_statements | False                                                                                                            | False                                                                                                            |
 |  using_scheduler         | False                                                                                                            | False                                                                                                            |
 |  verify                  | False                                                                                                            | False                                                                                                            |
 |  warmup_duration         | 1000000000                                                                                                       | 1000000000                                                                                                       |
 +--------------------------+------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+----------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)   | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |      new |        ||      old |      new |        |         |
 +----------++----------+----------+--------++----------+----------+--------+---------+
+| TPC-H 01 ||  6232.79 |  5905.33 |   -5%  ||     0.16 |     0.17 |   +6%  |  0.0064 |
 | TPC-H 02 ||    54.98 |    52.94 |   -4%˄ ||    18.18 |    18.89 |   +4%˄ |  0.0228 |
 | TPC-H 03 ||  2582.95 |  2547.24 |   -1%  ||     0.39 |     0.39 |   +1%  |  0.2025 |
 | TPC-H 04 ||  2220.38 |  2159.63 |   -3%  ||     0.45 |     0.46 |   +3%  |  0.0062 |
 | TPC-H 05 ||  5194.81 |  5119.38 |   -1%  ||     0.19 |     0.20 |   +1%  |  0.3679 |
 | TPC-H 06 ||   236.33 |   229.27 |   -3%˄ ||     4.23 |     4.36 |   +3%˄ |  0.0004 |
 | TPC-H 07 ||  1158.41 |  1129.59 |   -2%  ||     0.86 |     0.89 |   +3%  |  0.0000 |
 | TPC-H 08 ||  1051.41 |  1092.43 |   +4%  ||     0.95 |     0.92 |   -4%  |  0.0029 |
+| TPC-H 09 || 10198.28 |  8739.85 |  -14%  ||     0.10 |     0.11 |  +17%  |       ˅ |
+| TPC-H 10 ||  3408.99 |  3223.59 |   -5%  ||     0.29 |     0.31 |   +6%  |  0.0009 |
 | TPC-H 11 ||    87.80 |    87.96 |   +0%˄ ||    11.39 |    11.37 |   -0%˄ |  0.7783 |
+| TPC-H 12 ||  2017.98 |  1910.38 |   -5%  ||     0.50 |     0.52 |   +6%  |  0.0000 |
 | TPC-H 13 ||  7136.52 |  6945.32 |   -3%  ||     0.14 |     0.14 |   +3%  |       ˅ |
 | TPC-H 14 ||   678.77 |   671.18 |   -1%  ||     1.47 |     1.49 |   +1%  |  0.0352 |
 | TPC-H 15 ||   264.90 |   266.51 |   +1%˄ ||     3.77 |     3.75 |   -1%˄ |  0.2502 |
 | TPC-H 16 ||   834.57 |   845.46 |   +1%  ||     1.20 |     1.18 |   -1%  |  0.1850 |
 | TPC-H 17 ||   291.62 |   290.38 |   -0%˄ ||     3.43 |     3.44 |   +0%˄ |  0.3664 |
 | TPC-H 18 ||  1617.29 |  1548.49 |   -4%  ||     0.62 |     0.65 |   +4%  |  0.0000 |
-| TPC-H 19 ||   328.13 |   422.54 |  +29%˄ ||     3.05 |     2.37 |  -22%˄ |  0.0000 |
-| TPC-H 20 ||   610.07 |   867.20 |  +42%  ||     1.64 |     1.15 |  -30%  |  0.0000 |
-| TPC-H 21 ||  7961.09 |  9306.06 |  +17%  ||     0.13 |     0.11 |  -14%  |       ˅ |
 | TPC-H 22 ||   612.50 |   601.87 |   -2%˄ ||     1.63 |     1.66 |   +2%˄ |  0.0000 |
 +----------++----------+----------+--------++----------+----------+--------+---------+
 | Sum      || 54780.58 | 53962.60 |   -1%  ||          |          |        |         |
 | Geomean  ||          |          |        ||          |          |   -1%  |         |
 +----------++----------+----------+--------++----------+----------+--------+---------+
 |    Notes || ˄ Execution stopped due to max runs reached                            |
 |          || ˅ Insufficient number of runs for p-value calculation                  |
 +----------++----------+----------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - single-threaded, SF 0.01**
<details>
<summary>
Sum of avg. item runtimes: +2%
 ||
Geometric mean of throughput changes: -1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+----------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /hyrise/rel_amd_nolto/benchmark_all_results/hyriseBenchmarkTPCH_8114ddda7b19816aae0d18a9c621ac3784b0dceb_st_s01.json | /hyrise/rel_amd_nolto/benchmark_all_results/hyriseBenchmarkTPCH_f3ee473771660d25cc31399eaf28cee941423b9c_st_s01.json |
 +--------------------------+----------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 8114ddda7b19816aae0d18a9c621ac3784b0dceb-dirty                                                                       | f3ee473771660d25cc31399eaf28cee941423b9c-dirty                                                                       |
 |  benchmark_mode          | Ordered                                                                                                              | Ordered                                                                                                              |
 |  build_type              | release                                                                                                              | release                                                                                                              |
 |  chunk_indexes           | False                                                                                                                | False                                                                                                                |
 |  chunk_size              | 65535                                                                                                                | 65535                                                                                                                |
 |  clients                 | 1                                                                                                                    | 1                                                                                                                    |
 |  clustering              | None                                                                                                                 | None                                                                                                                 |
 |  compiler                | clang 14.0.0                                                                                                         | clang 14.0.0                                                                                                         |
 |  cores                   | 0                                                                                                                    | 0                                                                                                                    |
 |  data_preparation_cores  | 0                                                                                                                    | 0                                                                                                                    |
 |  date                    | 2023-06-26 13:43:15                                                                                                  | 2023-06-26 09:26:08                                                                                                  |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                              | {'default': {'encoding': 'Dictionary'}}                                                                              |
 |  max_duration            | 60000000000                                                                                                          | 60000000000                                                                                                          |
 |  max_runs                | 100                                                                                                                  | 100                                                                                                                  |
 |  scale_factor            | 0.009999999776482582                                                                                                 | 0.009999999776482582                                                                                                 |
 |  time_unit               | ns                                                                                                                   | ns                                                                                                                   |
 |  use_prepared_statements | False                                                                                                                | False                                                                                                                |
 |  using_scheduler         | False                                                                                                                | False                                                                                                                |
 |  verify                  | False                                                                                                                | False                                                                                                                |
 |  warmup_duration         | 1000000000                                                                                                           | 1000000000                                                                                                           |
 +--------------------------+----------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
+| TPC-H 01 ||     7.64 |    7.16 |   -6%˄ ||   130.84 |   139.55 |   +7%˄ |  0.0000 |
 | TPC-H 02 ||     4.04 |    4.19 |   +4%˄ ||   247.12 |   238.69 |   -3%˄ |  0.4894 |
 | TPC-H 03 ||     0.64 |    0.64 |   +0%˄ ||  1554.38 |  1552.51 |   -0%˄ |  0.9204 |
 | TPC-H 04 ||     0.43 |    0.43 |   +1%˄ ||  2312.59 |  2294.68 |   -1%˄ |  0.0337 |
 | TPC-H 05 ||     1.04 |    1.01 |   -3%˄ ||   960.78 |   987.17 |   +3%˄ |  0.0024 |
-| TPC-H 06 ||     0.22 |    0.23 |   +5%˄ ||  4531.00 |  4333.65 |   -4%˄ |  0.0000 |
-| TPC-H 07 ||    10.21 |   12.03 |  +18%˄ ||    97.88 |    83.13 |  -15%˄ |  0.0091 |
 | TPC-H 08 ||    15.85 |   15.20 |   -4%˄ ||    63.07 |    65.79 |   +4%˄ |  0.0550 |
-| TPC-H 09 ||     3.58 |    4.44 |  +24%˄ ||   279.37 |   224.90 |  -19%˄ |  0.1344 |
 | TPC-H 10 ||     0.72 |    0.72 |   +0%˄ ||  1383.14 |  1378.50 |   -0%˄ |  0.3193 |
 | TPC-H 11 ||     0.20 |    0.20 |   +2%˄ ||  5069.48 |  4992.69 |   -2%˄ |  0.1715 |
 | TPC-H 12 ||     0.68 |    0.68 |   +0%˄ ||  1471.40 |  1469.14 |   -0%˄ |  0.6478 |
 | TPC-H 13 ||     2.18 |    2.10 |   -4%˄ ||   457.53 |   476.05 |   +4%˄ |  0.0000 |
 | TPC-H 14 ||     0.33 |    0.33 |   +0%˄ ||  3056.41 |  3042.95 |   -0%˄ |  0.6637 |
 | TPC-H 15 ||     1.24 |    1.24 |   +1%˄ ||   806.23 |   800.93 |   -1%˄ |  0.6861 |
 | TPC-H 16 ||     2.13 |    2.09 |   -2%˄ ||   469.35 |   478.60 |   +2%˄ |  0.0646 |
 | TPC-H 17 ||     0.63 |    0.63 |   +1%˄ ||  1596.03 |  1585.71 |   -1%˄ |  0.9611 |
 | TPC-H 18 ||     1.12 |    1.13 |   +1%˄ ||   894.86 |   884.70 |   -1%˄ |  0.0000 |
 | TPC-H 19 ||     5.41 |    5.36 |   -1%˄ ||   184.83 |   186.64 |   +1%˄ |  0.0000 |
 | TPC-H 20 ||     2.28 |    2.26 |   -1%˄ ||   437.48 |   442.19 |   +1%˄ |  0.4667 |
+| TPC-H 21 ||     1.51 |    1.41 |   -6%˄ ||   662.73 |   707.18 |   +7%˄ |  0.1486 |
 | TPC-H 22 ||     1.09 |    1.05 |   -4%˄ ||   918.89 |   954.12 |   +4%˄ |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||    63.17 |   64.54 |   +2%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   -1%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 |    Notes || ˄ Execution stopped due to max runs reached                           |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - multi-threaded, ordered, 1 client, 64 cores, SF 10.0**
<details>
<summary>
Sum of avg. item runtimes: +1%
 ||
Geometric mean of throughput changes: -1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+--------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /hyrise/rel_amd_nolto/benchmark_all_results/hyriseBenchmarkTPCH_8114ddda7b19816aae0d18a9c621ac3784b0dceb_mt_ordered.json | /hyrise/rel_amd_nolto/benchmark_all_results/hyriseBenchmarkTPCH_f3ee473771660d25cc31399eaf28cee941423b9c_mt_ordered.json |
 +-------------------------------+--------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 8114ddda7b19816aae0d18a9c621ac3784b0dceb-dirty                                                                           | f3ee473771660d25cc31399eaf28cee941423b9c-dirty                                                                           |
 |  benchmark_mode               | Ordered                                                                                                                  | Ordered                                                                                                                  |
 |  build_type                   | release                                                                                                                  | release                                                                                                                  |
 |  chunk_indexes                | False                                                                                                                    | False                                                                                                                    |
 |  chunk_size                   | 65535                                                                                                                    | 65535                                                                                                                    |
 |  clients                      | 1                                                                                                                        | 1                                                                                                                        |
 |  clustering                   | None                                                                                                                     | None                                                                                                                     |
 |  compiler                     | clang 14.0.0                                                                                                             | clang 14.0.0                                                                                                             |
 |  cores                        | 64                                                                                                                       | 64                                                                                                                       |
 |  data_preparation_cores       | 0                                                                                                                        | 0                                                                                                                        |
 |  date                         | 2023-06-26 13:43:44                                                                                                      | 2023-06-26 09:26:37                                                                                                      |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                  | {'default': {'encoding': 'Dictionary'}}                                                                                  |
 |  max_duration                 | 60000000000                                                                                                              | 60000000000                                                                                                              |
 |  max_runs                     | -1                                                                                                                       | -1                                                                                                                       |
 |  scale_factor                 | 10.0                                                                                                                     | 10.0                                                                                                                     |
 |  time_unit                    | ns                                                                                                                       | ns                                                                                                                       |
 |  use_prepared_statements      | False                                                                                                                    | False                                                                                                                    |
 |  using_scheduler              | True                                                                                                                     | True                                                                                                                     |
 |  utilized_cores_per_numa_node | [64]                                                                                                                     | [64]                                                                                                                     |
 |  verify                       | False                                                                                                                    | False                                                                                                                    |
 |  warmup_duration              | 0                                                                                                                        | 0                                                                                                                        |
 +-------------------------------+--------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+----------+--------++----------+----------+--------+----------------------+
 | Item     || Latency (ms/iter)   | Change || Throughput (iter/s) | Change |              p-value |
 |          ||      old |      new |        ||      old |      new |        |                      |
 +----------++----------+----------+--------++----------+----------+--------+----------------------+
+| TPC-H 01 ||  5629.21 |  5375.39 |   -5%  ||     0.17 |     0.18 |  +10%  | (run time too short) |
 | TPC-H 02 ||    56.75 |    57.41 |   +1%  ||    15.80 |    15.58 |   -1%  |               0.1873 |
 | TPC-H 03 ||  1227.52 |  1270.37 |   +3%  ||     0.80 |     0.78 |   -2%  | (run time too short) |
 | TPC-H 04 ||   949.62 |   957.47 |   +1%  ||     1.03 |     1.03 |   +0%  | (run time too short) |
-| TPC-H 05 ||  1254.48 |  1325.77 |   +6%  ||     0.78 |     0.75 |   -4%  | (run time too short) |
-| TPC-H 06 ||    65.40 |    68.31 |   +4%  ||    14.23 |    13.57 |   -5%  |               0.0000 |
 | TPC-H 07 ||   364.95 |   370.74 |   +2%  ||     2.70 |     2.65 |   -2%  |               0.0053 |
 | TPC-H 08 ||   398.44 |   402.98 |   +1%  ||     2.47 |     2.45 |   -1%  |               0.0549 |
-| TPC-H 09 ||  2851.16 |  2934.95 |   +3%  ||     0.35 |     0.33 |   -5%  | (run time too short) |
 | TPC-H 10 ||  1888.85 |  1895.73 |   +0%  ||     0.52 |     0.52 |   +0%  | (run time too short) |
 | TPC-H 11 ||    91.68 |    93.75 |   +2%  ||    10.33 |    10.13 |   -2%  |               0.0001 |
-| TPC-H 12 ||   743.61 |   774.68 |   +4%  ||     1.33 |     1.27 |   -5%  | (run time too short) |
 | TPC-H 13 ||  4425.02 |  4479.06 |   +1%  ||     0.22 |     0.22 |   +0%  | (run time too short) |
 | TPC-H 14 ||   158.92 |   162.41 |   +2%  ||     6.10 |     5.97 |   -2%  |               0.0037 |
 | TPC-H 15 ||   183.83 |   188.24 |   +2%  ||     5.28 |     5.17 |   -2%  |               0.0022 |
 | TPC-H 16 ||   984.26 |   994.03 |   +1%  ||     1.00 |     1.00 |   -0%  |               0.2953 |
 | TPC-H 17 ||    90.37 |    93.27 |   +3%  ||    10.47 |    10.15 |   -3%  |               0.0000 |
 | TPC-H 18 ||  2555.66 |  2561.91 |   +0%  ||     0.38 |     0.38 |   +0%  | (run time too short) |
 | TPC-H 19 ||   136.43 |   138.26 |   +1%  ||     7.07 |     7.00 |   -1%  |               0.2750 |
 | TPC-H 20 ||   253.71 |   259.20 |   +2%  ||     3.85 |     3.77 |   -2%  |               0.0024 |
-| TPC-H 21 ||  1676.79 |  1786.77 |   +7%  ||     0.58 |     0.55 |   -6%  | (run time too short) |
 | TPC-H 22 ||   163.99 |   160.04 |   -2%  ||     5.92 |     6.05 |   +2%  |               0.0000 |
 +----------++----------+----------+--------++----------+----------+--------+----------------------+
 | Sum      || 26150.65 | 26350.76 |   +1%  ||          |          |        |                      |
 | Geomean  ||          |          |        ||          |          |   -1%  |                      |
 +----------++----------+----------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkTPCH - multi-threaded, shuffled, 64 clients, 64 cores, SF 10.0**
<details>
<summary>
Sum of avg. item runtimes: +1%
 ||
Geometric mean of throughput changes: -1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /hyrise/rel_amd_nolto/benchmark_all_results/hyriseBenchmarkTPCH_8114ddda7b19816aae0d18a9c621ac3784b0dceb_mt.json | /hyrise/rel_amd_nolto/benchmark_all_results/hyriseBenchmarkTPCH_f3ee473771660d25cc31399eaf28cee941423b9c_mt.json |
 +-------------------------------+------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 8114ddda7b19816aae0d18a9c621ac3784b0dceb-dirty                                                                   | f3ee473771660d25cc31399eaf28cee941423b9c-dirty                                                                   |
 |  benchmark_mode               | Shuffled                                                                                                         | Shuffled                                                                                                         |
 |  build_type                   | release                                                                                                          | release                                                                                                          |
 |  chunk_indexes                | False                                                                                                            | False                                                                                                            |
 |  chunk_size                   | 65535                                                                                                            | 65535                                                                                                            |
 |  clients                      | 64                                                                                                               | 64                                                                                                               |
 |  clustering                   | None                                                                                                             | None                                                                                                             |
 |  compiler                     | clang 14.0.0                                                                                                     | clang 14.0.0                                                                                                     |
 |  cores                        | 64                                                                                                               | 64                                                                                                               |
 |  data_preparation_cores       | 0                                                                                                                | 0                                                                                                                |
 |  date                         | 2023-06-26 14:09:11                                                                                              | 2023-06-26 09:52:30                                                                                              |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                          | {'default': {'encoding': 'Dictionary'}}                                                                          |
 |  max_duration                 | 1200000000000                                                                                                    | 1200000000000                                                                                                    |
 |  max_runs                     | -1                                                                                                               | -1                                                                                                               |
 |  scale_factor                 | 10.0                                                                                                             | 10.0                                                                                                             |
 |  time_unit                    | ns                                                                                                               | ns                                                                                                               |
 |  use_prepared_statements      | False                                                                                                            | False                                                                                                            |
 |  using_scheduler              | True                                                                                                             | True                                                                                                             |
 |  utilized_cores_per_numa_node | [64]                                                                                                             | [64]                                                                                                             |
 |  verify                       | False                                                                                                            | False                                                                                                            |
 |  warmup_duration              | 0                                                                                                                | 0                                                                                                                |
 +-------------------------------+------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+----------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)   | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |      new |        ||      old |      new |        |         |
 +----------++----------+----------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||  6551.52 |  6519.53 |   -0%  ||     0.84 |     0.84 |   -1%  |  0.8359 |
-| TPC-H 02 ||   552.59 |   640.99 |  +16%  ||     0.85 |     0.84 |   -1%  |  0.3607 |
 | TPC-H 03 ||  3813.32 |  3841.33 |   +1%  ||     0.84 |     0.84 |   -1%  |  0.8847 |
 | TPC-H 04 ||  3519.70 |  3443.32 |   -2%  ||     0.85 |     0.84 |   -1%  |  0.7470 |
 | TPC-H 05 ||  5127.94 |  5197.07 |   +1%  ||     0.84 |     0.84 |   -1%  |  0.7919 |
+| TPC-H 06 ||   957.86 |   906.79 |   -5%  ||     0.85 |     0.84 |   -1%  |  0.6388 |
-| TPC-H 07 ||  3774.89 |  4114.90 |   +9%  ||     0.85 |     0.84 |   -1%  |  0.1941 |
 | TPC-H 08 ||  3087.80 |  3078.80 |   -0%  ||     0.84 |     0.84 |   -1%  |  0.9690 |
-| TPC-H 09 ||  7224.54 |  7960.78 |  +10%  ||     0.84 |     0.84 |   -1%  |  0.0104 |
 | TPC-H 10 ||  5436.43 |  5476.82 |   +1%  ||     0.84 |     0.83 |   -1%  |  0.8769 |
-| TPC-H 11 ||   525.02 |   717.61 |  +37%  ||     0.85 |     0.84 |   -1%  |  0.0800 |
 | TPC-H 12 ||  3384.91 |  3411.68 |   +1%  ||     0.84 |     0.84 |   -1%  |  0.8955 |
 | TPC-H 13 ||  6682.55 |  6820.94 |   +2%  ||     0.84 |     0.83 |   -1%  |  0.4345 |
 | TPC-H 14 ||  1477.77 |  1442.47 |   -2%  ||     0.85 |     0.84 |   -1%  |  0.8057 |
-| TPC-H 15 ||   787.88 |   872.21 |  +11%  ||     0.85 |     0.84 |   -1%  |  0.3991 |
+| TPC-H 16 ||  3283.94 |  3017.95 |   -8%  ||     0.85 |     0.84 |   -1%  |  0.1741 |
+| TPC-H 17 ||  1131.89 |   959.11 |  -15%  ||     0.85 |     0.84 |   -1%  |  0.1328 |
 | TPC-H 18 ||  4465.13 |  4652.84 |   +4%  ||     0.84 |     0.84 |   -1%  |  0.2099 |
+| TPC-H 19 ||  1427.17 |  1143.12 |  -20%  ||     0.85 |     0.84 |   -1%  |  0.0398 |
 | TPC-H 20 ||  2315.40 |  2286.61 |   -1%  ||     0.85 |     0.84 |   -1%  |  0.8786 |
 | TPC-H 21 ||  8002.03 |  7680.10 |   -4%  ||     0.84 |     0.83 |   -1%  |  0.3113 |
+| TPC-H 22 ||  1414.38 |  1343.93 |   -5%  ||     0.85 |     0.84 |   -1%  |  0.6131 |
 +----------++----------+----------+--------++----------+----------+--------+---------+
 | Sum      || 74944.66 | 75528.90 |   +1%  ||          |          |        |         |
 | Geomean  ||          |          |        ||          |          |   -1%  |         |
 +----------++----------+----------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCDS - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: +1%
 ||
Geometric mean of throughput changes: -2%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---+-------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------+
 | Parameter               | /hyrise/rel_amd_nolto/benchmark_all_results/hyriseBenchmarkTPCDS_8114ddda7b19816aae0d18a9c621ac3784b0dceb_st.json | /hyrise/rel_amd_nolto/benchmark_all_results/hyriseBenchmarkTPCDS_f3ee473771660d25cc31399eaf28cee941423b9c_st.json |
 +-------------------------+-------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH               | 8114ddda7b19816aae0d18a9c621ac3784b0dceb-dirty                                                                    | f3ee473771660d25cc31399eaf28cee941423b9c-dirty                                                                    |
 |  benchmark_mode         | Ordered                                                                                                           | Ordered                                                                                                           |
 |  build_type             | release                                                                                                           | release                                                                                                           |
 |  chunk_indexes          | False                                                                                                             | False                                                                                                             |
 |  chunk_size             | 65535                                                                                                             | 65535                                                                                                             |
 |  clients                | 1                                                                                                                 | 1                                                                                                                 |
 |  compiler               | clang 14.0.0                                                                                                      | clang 14.0.0                                                                                                      |
 |  cores                  | 0                                                                                                                 | 0                                                                                                                 |
 |  data_preparation_cores | 0                                                                                                                 | 0                                                                                                                 |
 |  date                   | 2023-06-26 14:32:19                                                                                               | 2023-06-26 10:15:06                                                                                               |
 |  encoding               | {'default': {'encoding': 'Dictionary'}}                                                                           | {'default': {'encoding': 'Dictionary'}}                                                                           |
 |  max_duration           | 60000000000                                                                                                       | 60000000000                                                                                                       |
 |  max_runs               | 100                                                                                                               | 100                                                                                                               |
 |  time_unit              | ns                                                                                                                | ns                                                                                                                |
 |  using_scheduler        | False                                                                                                             | False                                                                                                             |
 |  verify                 | False                                                                                                             | False                                                                                                             |
 |  warmup_duration        | 1000000000                                                                                                        | 1000000000                                                                                                        |
 +-------------------------+-------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change |              p-value |
 |         ||      old |      new |        ||      old |      new |        |                      |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
-| 01      ||   301.59 |   332.94 |  +10%˄ ||     3.32 |     3.00 |   -9%˄ |               0.0000 |
 | 03      ||   101.22 |    98.16 |   -3%˄ ||     9.88 |    10.19 |   +3%˄ |               0.0001 |
 | 06      ||   141.16 |   142.10 |   +1%˄ ||     7.08 |     7.04 |   -1%˄ |               0.3039 |
 | 07      ||   373.06 |   377.46 |   +1%˄ ||     2.68 |     2.65 |   -1%˄ |               0.1090 |
 | 09      ||  1071.65 |  1041.15 |   -3%  ||     0.93 |     0.96 |   +3%  |               0.0000 |
-| 10      ||   161.12 |   171.31 |   +6%˄ ||     6.21 |     5.84 |   -6%˄ |               0.0002 |
+| 13      ||   617.55 |   583.81 |   -5%˄ ||     1.62 |     1.71 |   +6%˄ | (run time too short) |
 | 15      ||   131.29 |   132.51 |   +1%˄ ||     7.62 |     7.55 |   -1%˄ |               0.0789 |
 | 16      ||   186.46 |   187.80 |   +1%˄ ||     5.36 |     5.32 |   -1%˄ |               0.0811 |
-| 17      ||   411.68 |   473.89 |  +15%˄ ||     2.43 |     2.11 |  -13%˄ |               0.0000 |
-| 19      ||   132.49 |   184.41 |  +39%˄ ||     7.55 |     5.42 |  -28%˄ |               0.0000 |
-| 25      ||   201.84 |   238.30 |  +18%˄ ||     4.95 |     4.20 |  -15%˄ |               0.0000 |
 | 26      ||   152.56 |   150.22 |   -2%˄ ||     6.55 |     6.66 |   +2%˄ |               0.0002 |
 | 28      ||   776.62 |   780.66 |   +1%  ||     1.29 |     1.28 |   -1%  |               0.3718 |
 | 29      ||   595.00 |   600.99 |   +1%˄ ||     1.68 |     1.66 |   -1%˄ |               0.0227 |
 | 31      ||  1558.00 |  1549.99 |   -1%  ||     0.64 |     0.65 |   +1%  |               0.5989 |
 | 32      ||    49.59 |    48.83 |   -2%˄ ||    20.16 |    20.47 |   +2%˄ |               0.0005 |
 | 34      ||   217.49 |   220.45 |   +1%˄ ||     4.60 |     4.54 |   -1%˄ |               0.0055 |
 | 35      ||   799.18 |   808.46 |   +1%  ||     1.25 |     1.24 |   -1%  |               0.0000 |
 | 37      ||   282.38 |   294.70 |   +4%˄ ||     3.54 |     3.39 |   -4%˄ |               0.0069 |
 | 39a     ||  2057.88 |  2102.71 |   +2%  ||     0.49 |     0.48 |   -2%  |               0.0000 |
 | 39b     ||  2048.00 |  2053.51 |   +0%  ||     0.49 |     0.49 |   -0%  |               0.3515 |
 | 41      ||   302.11 |   294.47 |   -3%˄ ||     3.31 |     3.40 |   +3%˄ |               0.0000 |
 | 42      ||   107.18 |   108.17 |   +1%˄ ||     9.33 |     9.24 |   -1%˄ |               0.0093 |
 | 43      ||  1112.02 |  1120.77 |   +1%  ||     0.90 |     0.89 |   -1%  |               0.0036 |
 | 45      ||   171.48 |   171.68 |   +0%˄ ||     5.83 |     5.82 |   -0%˄ |               0.7531 |
 | 48      ||  1094.75 |  1095.93 |   +0%  ||     0.91 |     0.91 |   -0%  |               0.7914 |
 | 50      ||   149.84 |   154.89 |   +3%˄ ||     6.67 |     6.46 |   -3%˄ |               0.0000 |
 | 52      ||   106.66 |   108.79 |   +2%˄ ||     9.38 |     9.19 |   -2%˄ |               0.0018 |
 | 55      ||    98.85 |   101.98 |   +3%˄ ||    10.12 |     9.80 |   -3%˄ |               0.0000 |
 | 62      ||   609.98 |   625.74 |   +3%  ||     1.64 |     1.60 |   -3%  |               0.0000 |
 | 65      ||  2268.42 |  2296.22 |   +1%  ||     0.44 |     0.44 |   -1%  |               0.3309 |
 | 69      ||   148.79 |   153.98 |   +3%˄ ||     6.72 |     6.49 |   -3%˄ |               0.0000 |
 | 73      ||   101.41 |   104.61 |   +3%˄ ||     9.86 |     9.56 |   -3%˄ |               0.0000 |
 | 79      ||   601.71 |   611.88 |   +2%˄ ||     1.66 |     1.63 |   -2%˄ |               0.0000 |
 | 81      ||   241.67 |   244.13 |   +1%˄ ||     4.14 |     4.10 |   -1%˄ |               0.0006 |
 | 82      ||   382.27 |   383.58 |   +0%˄ ||     2.62 |     2.61 |   -0%˄ |               0.3854 |
 | 83      ||    58.06 |    60.12 |   +4%˄ ||    17.22 |    16.63 |   -3%˄ |               0.0012 |
 | 85      ||   177.83 |   177.50 |   -0%˄ ||     5.62 |     5.63 |   +0%˄ |               0.6885 |
 | 88      ||   920.10 |   941.24 |   +2%  ||     1.09 |     1.06 |   -2%  |               0.0000 |
+| 91      ||    28.34 |    25.87 |   -9%˄ ||    35.28 |    38.64 |  +10%˄ |               0.0000 |
 | 92      ||    80.46 |    80.29 |   -0%˄ ||    12.43 |    12.45 |   +0%˄ |               0.6726 |
 | 93      ||  5203.39 |  5207.80 |   +0%  ||     0.19 |     0.19 |   -0%  |               0.8192 |
 | 94      ||   153.25 |   155.01 |   +1%˄ ||     6.53 |     6.45 |   -1%˄ |               0.0379 |
 | 95      ||  9126.02 |  9175.54 |   +1%  ||     0.11 |     0.11 |   -1%  |                    ˅ |
 | 96      ||    80.46 |    82.53 |   +3%˄ ||    12.43 |    12.12 |   -3%˄ |               0.0150 |
 | 97      ||  3501.30 |  3522.21 |   +1%  ||     0.29 |     0.28 |   -1%  |               0.1288 |
-| 99      ||  1146.23 |  1201.94 |   +5%  ||     0.87 |     0.83 |   -5%  |               0.0019 |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 | Sum     || 40340.39 | 40781.20 |   +1%  ||          |          |        |                      |
 | Geomean ||          |          |        ||          |          |   -2%  |                      |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 |   Notes || ˄ Execution stopped due to max runs reached                                         |
 |         || ˅ Insufficient number of runs for p-value calculation                               |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkTPCDS - multi-threaded, shuffled, 64 clients, 64 cores**
<details>
<summary>
Sum of avg. item runtimes: +0%
 ||
Geometric mean of throughput changes: -0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+-------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /hyrise/rel_amd_nolto/benchmark_all_results/hyriseBenchmarkTPCDS_8114ddda7b19816aae0d18a9c621ac3784b0dceb_mt.json | /hyrise/rel_amd_nolto/benchmark_all_results/hyriseBenchmarkTPCDS_f3ee473771660d25cc31399eaf28cee941423b9c_mt.json |
 +-------------------------------+-------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 8114ddda7b19816aae0d18a9c621ac3784b0dceb-dirty                                                                    | f3ee473771660d25cc31399eaf28cee941423b9c-dirty                                                                    |
 |  benchmark_mode               | Shuffled                                                                                                          | Shuffled                                                                                                          |
 |  build_type                   | release                                                                                                           | release                                                                                                           |
 |  chunk_indexes                | False                                                                                                             | False                                                                                                             |
 |  chunk_size                   | 65535                                                                                                             | 65535                                                                                                             |
 |  clients                      | 64                                                                                                                | 64                                                                                                                |
 |  compiler                     | clang 14.0.0                                                                                                      | clang 14.0.0                                                                                                      |
 |  cores                        | 64                                                                                                                | 64                                                                                                                |
 |  data_preparation_cores       | 0                                                                                                                 | 0                                                                                                                 |
 |  date                         | 2023-06-26 15:01:20                                                                                               | 2023-06-26 10:44:16                                                                                               |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                           | {'default': {'encoding': 'Dictionary'}}                                                                           |
 |  max_duration                 | 1200000000000                                                                                                     | 1200000000000                                                                                                     |
 |  max_runs                     | -1                                                                                                                | -1                                                                                                                |
 |  time_unit                    | ns                                                                                                                | ns                                                                                                                |
 |  using_scheduler              | True                                                                                                              | True                                                                                                              |
 |  utilized_cores_per_numa_node | [64]                                                                                                              | [64]                                                                                                              |
 |  verify                       | False                                                                                                             | False                                                                                                             |
 |  warmup_duration              | 0                                                                                                                 | 0                                                                                                                 |
 +-------------------------------+-------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |      new |        ||      old |      new |        |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
+| 01      ||   834.15 |   768.47 |   -8%  ||     0.82 |     0.82 |   -0%  |  0.3121 |
 | 03      ||   368.02 |   360.55 |   -2%  ||     0.82 |     0.82 |   -0%  |  0.8998 |
+| 06      ||   993.74 |   875.28 |  -12%  ||     0.82 |     0.82 |   -0%  |  0.1879 |
 | 07      ||  1099.56 |  1135.84 |   +3%  ||     0.82 |     0.82 |   -0%  |  0.7017 |
 | 09      ||  1021.06 |   995.19 |   -3%  ||     0.82 |     0.82 |   -0%  |  0.7873 |
-| 10      ||   946.73 |  1016.56 |   +7%  ||     0.82 |     0.82 |   -0%  |  0.5290 |
+| 13      ||  2093.10 |  1904.72 |   -9%  ||     0.82 |     0.82 |   -0%  |  0.1719 |
+| 15      ||   656.60 |   607.26 |   -8%  ||     0.82 |     0.82 |   -0%  |  0.5072 |
 | 16      ||   980.56 |   994.67 |   +1%  ||     0.82 |     0.82 |   -0%  |  0.8886 |
 | 17      ||  1455.04 |  1431.84 |   -2%  ||     0.82 |     0.82 |   -0%  |  0.8367 |
+| 19      ||   734.18 |   671.08 |   -9%  ||     0.82 |     0.82 |   -0%  |  0.3723 |
 | 25      ||  1120.55 |  1125.16 |   +0%  ||     0.82 |     0.82 |   -0%  |  0.9630 |
+| 26      ||   660.12 |   553.08 |  -16%  ||     0.82 |     0.82 |   -0%  |  0.1019 |
-| 28      ||  1645.07 |  1763.17 |   +7%  ||     0.82 |     0.82 |   +0%  |  0.3825 |
 | 29      ||  2046.89 |  2097.77 |   +2%  ||     0.82 |     0.82 |   -0%  |  0.7139 |
 | 31      ||  3232.43 |  3149.47 |   -3%  ||     0.82 |     0.82 |   -0%  |  0.6308 |
+| 32      ||   310.29 |   255.46 |  -18%  ||     0.82 |     0.82 |   -0%  |  0.2647 |
+| 34      ||   878.50 |   762.92 |  -13%  ||     0.82 |     0.82 |   -0%  |  0.1668 |
-| 35      ||  2272.42 |  2476.04 |   +9%  ||     0.82 |     0.82 |   +0%  |  0.1279 |
-| 37      ||   722.29 |   778.94 |   +8%  ||     0.82 |     0.82 |   -0%  |  0.5451 |
+| 39a     ||  3122.17 |  2958.12 |   -5%  ||     0.82 |     0.82 |   -0%  |  0.1749 |
+| 39b     ||  3192.85 |  2989.44 |   -6%  ||     0.82 |     0.82 |   +0%  |  0.1432 |
 | 41      ||  4985.91 |  4770.25 |   -4%  ||     0.82 |     0.82 |   -0%  |  0.2832 |
 | 42      ||   591.15 |   613.84 |   +4%  ||     0.82 |     0.82 |   -0%  |  0.7808 |
 | 43      ||  1747.94 |  1820.75 |   +4%  ||     0.82 |     0.82 |   -0%  |  0.5463 |
-| 45      ||   818.98 |   883.55 |   +8%  ||     0.82 |     0.82 |   -0%  |  0.4437 |
 | 48      ||  2864.87 |  2976.10 |   +4%  ||     0.82 |     0.82 |   -0%  |  0.4736 |
+| 50      ||  1059.93 |  1007.88 |   -5%  ||     0.82 |     0.82 |   -0%  |  0.5718 |
-| 52      ||   540.27 |   622.93 |  +15%  ||     0.82 |     0.82 |   -0%  |  0.2164 |
+| 55      ||   481.20 |   439.03 |   -9%  ||     0.82 |     0.82 |   -0%  |  0.5067 |
+| 62      ||  1220.88 |  1150.79 |   -6%  ||     0.82 |     0.82 |   -0%  |  0.4440 |
 | 65      ||  4989.45 |  5043.97 |   +1%  ||     0.82 |     0.82 |   -0%  |  0.5991 |
+| 69      ||  1067.68 |  1014.09 |   -5%  ||     0.82 |     0.82 |   -0%  |  0.6014 |
-| 73      ||   593.78 |   686.22 |  +16%  ||     0.82 |     0.82 |   -0%  |  0.2552 |
 | 79      ||  1713.43 |  1738.45 |   +1%  ||     0.82 |     0.82 |   -0%  |  0.8079 |
 | 81      ||   885.33 |   850.43 |   -4%  ||     0.82 |     0.82 |   -0%  |  0.6231 |
+| 82      ||   953.73 |   895.48 |   -6%  ||     0.82 |     0.82 |   -0%  |  0.4646 |
 | 83      ||   434.71 |   423.10 |   -3%  ||     0.82 |     0.82 |   -0%  |  0.8617 |
-| 85      ||   999.66 |  1062.94 |   +6%  ||     0.82 |     0.82 |   +0%  |  0.5086 |
 | 88      ||  3181.23 |  3212.18 |   +1%  ||     0.82 |     0.82 |   -0%  |  0.8743 |
 | 91      ||   277.09 |   277.38 |   +0%  ||     0.82 |     0.82 |   -0%  |  0.9952 |
-| 92      ||   380.05 |   432.79 |  +14%  ||     0.82 |     0.82 |   -0%  |  0.3391 |
-| 93      ||  2508.62 |  2678.11 |   +7%  ||     0.82 |     0.82 |   -0%  |  0.1733 |
-| 94      ||   935.98 |  1072.40 |  +15%  ||     0.82 |     0.82 |   -0%  |  0.1972 |
 | 95      ||  6084.25 |  6117.34 |   +1%  ||     0.82 |     0.82 |   -0%  |  0.8581 |
+| 96      ||   500.15 |   433.73 |  -13%  ||     0.82 |     0.82 |   -0%  |  0.3040 |
-| 97      ||  5522.60 |  5856.49 |   +6%  ||     0.82 |     0.82 |   -0%  |  0.0291 |
 | 99      ||  1570.80 |  1633.65 |   +4%  ||     0.82 |     0.82 |   -0%  |  0.5106 |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Sum     || 77296.02 | 77384.92 |   +0%  ||          |          |        |         |
 | Geomean ||          |          |        ||          |          |   -0%  |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCC - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -3%
 ||
Geometric mean of throughput changes: +2%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---+------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------+
 | Parameter               | /hyrise/rel_amd_nolto/benchmark_all_results/hyriseBenchmarkTPCC_8114ddda7b19816aae0d18a9c621ac3784b0dceb_st.json | /hyrise/rel_amd_nolto/benchmark_all_results/hyriseBenchmarkTPCC_f3ee473771660d25cc31399eaf28cee941423b9c_st.json |
 +-------------------------+------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH               | 8114ddda7b19816aae0d18a9c621ac3784b0dceb-dirty                                                                   | f3ee473771660d25cc31399eaf28cee941423b9c-dirty                                                                   |
 |  benchmark_mode         | Shuffled                                                                                                         | Shuffled                                                                                                         |
 |  build_type             | release                                                                                                          | release                                                                                                          |
 |  chunk_indexes          | False                                                                                                            | False                                                                                                            |
 |  chunk_size             | 65535                                                                                                            | 65535                                                                                                            |
 |  clients                | 1                                                                                                                | 1                                                                                                                |
 |  compiler               | clang 14.0.0                                                                                                     | clang 14.0.0                                                                                                     |
 |  cores                  | 0                                                                                                                | 0                                                                                                                |
 |  data_preparation_cores | 0                                                                                                                | 0                                                                                                                |
 |  date                   | 2023-06-26 15:22:01                                                                                              | 2023-06-26 11:04:57                                                                                              |
 |  encoding               | {'default': {'encoding': 'Dictionary'}}                                                                          | {'default': {'encoding': 'Dictionary'}}                                                                          |
 |  max_duration           | 60000000000                                                                                                      | 60000000000                                                                                                      |
 |  max_runs               | -1                                                                                                               | -1                                                                                                               |
 |  scale_factor           | 1                                                                                                                | 1                                                                                                                |
 |  time_unit              | ns                                                                                                               | ns                                                                                                               |
 |  using_scheduler        | False                                                                                                            | False                                                                                                            |
 |  verify                 | False                                                                                                            | False                                                                                                            |
 |  warmup_duration        | 0                                                                                                                | 0                                                                                                                |
 +-------------------------+------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |              ||      old |     new |        ||      old |      new |        |         |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Delivery     ||    26.31 |   25.29 |   -4%  ||     3.78 |     3.88 |   +3%  |  0.0000 |
 | New-Order    ||    18.37 |   17.97 |   -2%  ||    42.56 |    43.56 |   +2%  |  0.0095 |
 | Order-Status ||     1.31 |    1.28 |   -2%  ||     3.78 |     3.87 |   +2%  |  0.1973 |
 | Payment      ||     2.36 |    2.31 |   -2%  ||    40.72 |    41.71 |   +2%  |  0.0000 |
 | Stock-Level  ||     4.10 |    4.05 |   -1%  ||     3.80 |     3.87 |   +2%  |  0.3582 |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Sum          ||    52.45 |   50.91 |   -3%  ||          |          |        |         |
 | Geomean      ||          |         |        ||          |          |   +2%  |         |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCC - multi-threaded, shuffled, 64 clients, 64 cores**
<details>
<summary>
Sum of avg. item runtimes: -1%
 ||
Geometric mean of throughput changes: +0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /hyrise/rel_amd_nolto/benchmark_all_results/hyriseBenchmarkTPCC_8114ddda7b19816aae0d18a9c621ac3784b0dceb_mt.json | /hyrise/rel_amd_nolto/benchmark_all_results/hyriseBenchmarkTPCC_f3ee473771660d25cc31399eaf28cee941423b9c_mt.json |
 +-------------------------------+------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 8114ddda7b19816aae0d18a9c621ac3784b0dceb-dirty                                                                   | f3ee473771660d25cc31399eaf28cee941423b9c-dirty                                                                   |
 |  benchmark_mode               | Shuffled                                                                                                         | Shuffled                                                                                                         |
 |  build_type                   | release                                                                                                          | release                                                                                                          |
 |  chunk_indexes                | False                                                                                                            | False                                                                                                            |
 |  chunk_size                   | 65535                                                                                                            | 65535                                                                                                            |
 |  clients                      | 64                                                                                                               | 64                                                                                                               |
 |  compiler                     | clang 14.0.0                                                                                                     | clang 14.0.0                                                                                                     |
 |  cores                        | 64                                                                                                               | 64                                                                                                               |
 |  data_preparation_cores       | 0                                                                                                                | 0                                                                                                                |
 |  date                         | 2023-06-26 15:23:02                                                                                              | 2023-06-26 11:05:59                                                                                              |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                          | {'default': {'encoding': 'Dictionary'}}                                                                          |
 |  max_duration                 | 1200000000000                                                                                                    | 1200000000000                                                                                                    |
 |  max_runs                     | -1                                                                                                               | -1                                                                                                               |
 |  scale_factor                 | 1                                                                                                                | 1                                                                                                                |
 |  time_unit                    | ns                                                                                                               | ns                                                                                                               |
 |  using_scheduler              | True                                                                                                             | True                                                                                                             |
 |  utilized_cores_per_numa_node | [64]                                                                                                             | [64]                                                                                                             |
 |  verify                       | False                                                                                                            | False                                                                                                            |
 |  warmup_duration              | 0                                                                                                                | 0                                                                                                                |
 +-------------------------------+------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |              ||      old |     new |        ||      old |      new |        |         |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Delivery     ||   229.51 |  227.62 |   -1%  ||     4.27 |     4.30 |   +1%  |  0.2292 |
 |    unsucc.:  ||     4.86 |    4.78 |   -2%  ||   177.04 |   177.52 |   +0%  |         |
 | New-Order    ||    71.08 |   70.90 |   -0%  ||   124.23 |   124.23 |   +0%  |  0.1095 |
 |    unsucc.:  ||     5.10 |    5.10 |   -0%  ||  1915.47 |  1921.33 |   +0%  |         |
 | Order-Status ||     7.70 |    7.76 |   +1%  ||   181.31 |   181.83 |   +0%  |  0.0002 |
 | Payment      ||    12.61 |   12.44 |   -1%  ||     5.40 |     5.41 |   +0%  |  0.2356 |
 |    unsucc.:  ||     5.30 |    5.22 |   -1%  ||  1943.66 |  1949.25 |   +0%  |         |
 | Stock-Level  ||    17.12 |   16.99 |   -1%  ||   181.31 |   181.83 |   +0%  |  0.0013 |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Sum          ||   338.01 |  335.72 |   -1%  ||          |          |        |         |
 | Geomean      ||          |         |        ||          |          |   +0%  |         |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkJoinOrder - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -1%
 ||
Geometric mean of throughput changes: +0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---+-----------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------+
 | Parameter               | /hyrise/rel_amd_nolto/benchmark_all_results/hyriseBenchmarkJoinOrder_8114ddda7b19816aae0d18a9c621ac3784b0dceb_st.json | /hyrise/rel_amd_nolto/benchmark_all_results/hyriseBenchmarkJoinOrder_f3ee473771660d25cc31399eaf28cee941423b9c_st.json |
 +-------------------------+-----------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH               | 8114ddda7b19816aae0d18a9c621ac3784b0dceb-dirty                                                                        | f3ee473771660d25cc31399eaf28cee941423b9c-dirty                                                                        |
 |  benchmark_mode         | Ordered                                                                                                               | Ordered                                                                                                               |
 |  build_type             | release                                                                                                               | release                                                                                                               |
 |  chunk_indexes          | False                                                                                                                 | False                                                                                                                 |
 |  chunk_size             | 65535                                                                                                                 | 65535                                                                                                                 |
 |  clients                | 1                                                                                                                     | 1                                                                                                                     |
 |  compiler               | clang 14.0.0                                                                                                          | clang 14.0.0                                                                                                          |
 |  cores                  | 0                                                                                                                     | 0                                                                                                                     |
 |  data_preparation_cores | 0                                                                                                                     | 0                                                                                                                     |
 |  date                   | 2023-06-26 15:43:18                                                                                                   | 2023-06-26 11:26:14                                                                                                   |
 |  encoding               | {'default': {'encoding': 'Dictionary'}}                                                                               | {'default': {'encoding': 'Dictionary'}}                                                                               |
 |  max_duration           | 60000000000                                                                                                           | 60000000000                                                                                                           |
 |  max_runs               | 100                                                                                                                   | 100                                                                                                                   |
 |  time_unit              | ns                                                                                                                    | ns                                                                                                                    |
 |  using_scheduler        | False                                                                                                                 | False                                                                                                                 |
 |  verify                 | False                                                                                                                 | False                                                                                                                 |
 |  warmup_duration        | 1000000000                                                                                                            | 1000000000                                                                                                            |
 +-------------------------+-----------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change |              p-value |
 |         ||      old |      new |        ||      old |      new |        |                      |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
-| 10a     ||   249.96 |   266.57 |   +7%˄ ||     4.00 |     3.75 |   -6%˄ |               0.0001 |
 | 10b     ||   191.09 |   195.55 |   +2%˄ ||     5.23 |     5.11 |   -2%˄ |               0.0045 |
 | 10c     ||   413.29 |   413.16 |   -0%˄ ||     2.42 |     2.42 |   +0%˄ |               0.9495 |
+| 11a     ||    29.09 |    24.27 |  -17%˄ ||    34.37 |    41.19 |  +20%˄ |               0.0000 |
+| 11b     ||    28.13 |    23.93 |  -15%˄ ||    35.53 |    41.77 |  +18%˄ |               0.0000 |
+| 11c     ||    34.14 |    29.71 |  -13%˄ ||    29.28 |    33.65 |  +15%˄ |               0.0000 |
+| 11d     ||    37.14 |    33.59 |  -10%˄ ||    26.92 |    29.76 |  +11%˄ |               0.0000 |
 | 12a     ||    67.96 |    65.85 |   -3%˄ ||    14.71 |    15.19 |   +3%˄ |               0.0000 |
 | 12b     ||    33.12 |    32.95 |   -1%˄ ||    30.19 |    30.34 |   +1%˄ |               0.6374 |
 | 12c     ||   122.68 |   120.90 |   -1%˄ ||     8.15 |     8.27 |   +1%˄ |               0.0208 |
-| 13a     ||   345.28 |   371.77 |   +8%˄ ||     2.90 |     2.69 |   -7%˄ |               0.0000 |
-| 13b     ||   211.70 |   226.30 |   +7%˄ ||     4.72 |     4.42 |   -6%˄ |               0.0000 |
-| 13c     ||   150.36 |   158.84 |   +6%˄ ||     6.65 |     6.30 |   -5%˄ |               0.0000 |
 | 13d     ||   727.84 |   721.12 |   -1%  ||     1.37 |     1.39 |   +1%  |               0.0005 |
 | 14a     ||   521.85 |   507.40 |   -3%˄ ||     1.92 |     1.97 |   +3%˄ |               0.0000 |
 | 14b     ||   301.68 |   288.75 |   -4%˄ ||     3.31 |     3.46 |   +4%˄ |               0.0000 |
 | 14c     ||   604.32 |   587.65 |   -3%˄ ||     1.65 |     1.70 |   +3%˄ |               0.0000 |
 | 15a     ||    91.52 |    90.71 |   -1%˄ ||    10.93 |    11.02 |   +1%˄ |               0.1747 |
 | 15b     ||    91.26 |    89.95 |   -1%˄ ||    10.96 |    11.12 |   +1%˄ |               0.0000 |
 | 15c     ||    97.00 |    95.72 |   -1%˄ ||    10.31 |    10.45 |   +1%˄ |               0.0000 |
 | 15d     ||    95.32 |    93.47 |   -2%˄ ||    10.49 |    10.70 |   +2%˄ |               0.0006 |
 | 16a     ||  2778.78 |  2734.01 |   -2%  ||     0.36 |     0.37 |   +2%  |               0.0003 |
 | 16b     ||  3949.63 |  3850.07 |   -3%  ||     0.25 |     0.26 |   +3%  |               0.0000 |
 | 16c     ||  2885.59 |  2841.15 |   -2%  ||     0.35 |     0.35 |   +2%  |               0.0001 |
 | 16d     ||  2864.88 |  2812.10 |   -2%  ||     0.35 |     0.36 |   +2%  |               0.0000 |
 | 17a     ||   943.43 |   932.33 |   -1%  ||     1.06 |     1.07 |   +1%  |               0.0010 |
 | 17b     ||   781.01 |   771.70 |   -1%  ||     1.28 |     1.30 |   +1%  |               0.0011 |
 | 17c     ||   749.96 |   742.68 |   -1%  ||     1.33 |     1.35 |   +1%  |               0.0077 |
 | 17d     ||   895.99 |   886.39 |   -1%  ||     1.12 |     1.13 |   +1%  |               0.0022 |
 | 17e     ||  2270.49 |  2242.33 |   -1%  ||     0.44 |     0.45 |   +1%  |               0.0002 |
 | 17f     ||  1416.90 |  1396.43 |   -1%  ||     0.71 |     0.72 |   +1%  |               0.0000 |
 | 18a     ||   835.77 |   816.18 |   -2%  ||     1.20 |     1.23 |   +2%  |               0.0000 |
 | 18b     ||   183.27 |   180.39 |   -2%˄ ||     5.46 |     5.54 |   +2%˄ |               0.0066 |
 | 18c     ||   802.87 |   803.47 |   +0%  ||     1.25 |     1.24 |   -0%  |               0.7751 |
 | 19a     ||   250.21 |   244.22 |   -2%˄ ||     4.00 |     4.09 |   +2%˄ |               0.0000 |
 | 19b     ||   190.42 |   187.01 |   -2%˄ ||     5.25 |     5.35 |   +2%˄ |               0.0001 |
 | 19c     ||   264.28 |   258.94 |   -2%˄ ||     3.78 |     3.86 |   +2%˄ |               0.0000 |
 | 19d     ||   916.45 |   896.05 |   -2%  ||     1.09 |     1.12 |   +2%  |               0.0000 |
 | 1a      ||    13.88 |    13.58 |   -2%˄ ||    72.02 |    73.59 |   +2%˄ |               0.0000 |
 | 1b      ||    13.04 |    12.87 |   -1%˄ ||    76.61 |    77.65 |   +1%˄ |               0.0000 |
 | 1c      ||    15.92 |    15.67 |   -2%˄ ||    62.77 |    63.79 |   +2%˄ |               0.0000 |
+| 1d      ||    13.47 |    12.87 |   -4%˄ ||    74.19 |    77.66 |   +5%˄ |               0.1169 |
 | 20a     ||   660.54 |   656.70 |   -1%  ||     1.51 |     1.52 |   +1%  |               0.3800 |
 | 20b     ||   379.04 |   376.45 |   -1%˄ ||     2.64 |     2.66 |   +1%˄ |               0.0408 |
 | 20c     ||   372.39 |   368.46 |   -1%˄ ||     2.69 |     2.71 |   +1%˄ |               0.0039 |
 | 21a     ||    43.34 |    42.95 |   -1%˄ ||    23.07 |    23.28 |   +1%˄ |               0.0068 |
+| 21b     ||    26.79 |    25.26 |   -6%˄ ||    37.32 |    39.57 |   +6%˄ |               0.0000 |
 | 21c     ||    43.77 |    43.35 |   -1%˄ ||    22.84 |    23.06 |   +1%˄ |               0.0060 |
 | 22a     ||   246.93 |   241.63 |   -2%˄ ||     4.05 |     4.14 |   +2%˄ |               0.0000 |
 | 22b     ||   181.74 |   186.85 |   +3%˄ ||     5.50 |     5.35 |   -3%˄ |               0.0338 |
 | 22c     ||   608.68 |   586.66 |   -4%˄ ||     1.64 |     1.70 |   +4%˄ | (run time too short) |
 | 22d     ||  1058.30 |  1029.71 |   -3%  ||     0.94 |     0.97 |   +3%  |               0.0000 |
 | 23a     ||    52.81 |    54.03 |   +2%˄ ||    18.93 |    18.51 |   -2%˄ |               0.0000 |
 | 23b     ||    66.55 |    67.89 |   +2%˄ ||    15.03 |    14.73 |   -2%˄ |               0.0000 |
 | 23c     ||   100.94 |   104.03 |   +3%˄ ||     9.91 |     9.61 |   -3%˄ |               0.0000 |
 | 24a     ||   222.97 |   221.76 |   -1%˄ ||     4.48 |     4.51 |   +1%˄ |               0.2764 |
 | 24b     ||   186.06 |   187.42 |   +1%˄ ||     5.37 |     5.34 |   -1%˄ |               0.0921 |
 | 25a     ||   435.59 |   435.23 |   -0%˄ ||     2.30 |     2.30 |   +0%˄ |               0.7786 |
 | 25b     ||   173.33 |   174.40 |   +1%˄ ||     5.77 |     5.73 |   -1%˄ |               0.2785 |
 | 25c     ||  1452.16 |  1438.67 |   -1%  ||     0.69 |     0.70 |   +1%  |               0.0005 |
 | 26a     ||   271.28 |   270.83 |   -0%˄ ||     3.69 |     3.69 |   +0%˄ |               0.7315 |
 | 26b     ||   217.92 |   217.57 |   -0%˄ ||     4.59 |     4.60 |   +0%˄ |               0.6836 |
 | 26c     ||   394.36 |   393.03 |   -0%˄ ||     2.54 |     2.54 |   +0%˄ |               0.3889 |
 | 27a     ||    32.06 |    32.84 |   +2%˄ ||    31.18 |    30.44 |   -2%˄ |               0.0002 |
 | 27b     ||    31.68 |    32.34 |   +2%˄ ||    31.56 |    30.91 |   -2%˄ |               0.0000 |
 | 27c     ||    43.76 |    44.99 |   +3%˄ ||    22.85 |    22.23 |   -3%˄ |               0.0001 |
 | 28a     ||   357.69 |   350.03 |   -2%˄ ||     2.80 |     2.86 |   +2%˄ |               0.0000 |
 | 28b     ||    52.66 |    53.26 |   +1%˄ ||    18.99 |    18.77 |   -1%˄ |               0.0085 |
 | 28c     ||   404.50 |   392.15 |   -3%˄ ||     2.47 |     2.55 |   +3%˄ |               0.0000 |
-| 29a     ||   116.87 |   123.42 |   +6%˄ ||     8.56 |     8.10 |   -5%˄ |               0.0000 |
-| 29b     ||    88.70 |    96.24 |   +9%˄ ||    11.27 |    10.39 |   -8%˄ |               0.0000 |
 | 29c     ||   223.65 |   221.79 |   -1%˄ ||     4.47 |     4.51 |   +1%˄ |               0.0155 |
 | 2a      ||    79.43 |    79.19 |   -0%˄ ||    12.59 |    12.63 |   +0%˄ |               0.6742 |
 | 2b      ||    63.07 |    63.26 |   +0%˄ ||    15.85 |    15.81 |   -0%˄ |               0.6260 |
 | 2c      ||    35.57 |    35.74 |   +0%˄ ||    28.11 |    27.97 |   -0%˄ |               0.0000 |
 | 2d      ||   108.87 |   106.28 |   -2%˄ ||     9.18 |     9.41 |   +2%˄ |               0.0000 |
 | 30a     ||   234.43 |   233.72 |   -0%˄ ||     4.27 |     4.28 |   +0%˄ |               0.5611 |
 | 30b     ||   203.91 |   205.44 |   +1%˄ ||     4.90 |     4.87 |   -1%˄ |               0.1705 |
 | 30c     ||   545.45 |   540.82 |   -1%˄ ||     1.83 |     1.85 |   +1%˄ |               0.0031 |
 | 31a     ||   221.81 |   222.53 |   +0%˄ ||     4.51 |     4.49 |   -0%˄ |               0.4509 |
 | 31b     ||   189.21 |   190.80 |   +1%˄ ||     5.28 |     5.24 |   -1%˄ |               0.0859 |
 | 31c     ||   257.32 |   256.54 |   -0%˄ ||     3.89 |     3.90 |   +0%˄ |               0.4603 |
 | 32a     ||    23.33 |    23.63 |   +1%˄ ||    42.84 |    42.31 |   -1%˄ |               0.2401 |
 | 32b     ||    55.39 |    55.67 |   +0%˄ ||    18.05 |    17.96 |   -0%˄ |               0.6231 |
 | 33a     ||    27.55 |    28.08 |   +2%˄ ||    36.29 |    35.61 |   -2%˄ |               0.0000 |
 | 33b     ||    26.89 |    27.23 |   +1%˄ ||    37.18 |    36.72 |   -1%˄ |               0.0000 |
 | 33c     ||    30.55 |    30.97 |   +1%˄ ||    32.72 |    32.28 |   -1%˄ |               0.0274 |
 | 3a      ||   186.61 |   185.87 |   -0%˄ ||     5.36 |     5.38 |   +0%˄ |               0.3798 |
 | 3b      ||    19.77 |    20.17 |   +2%˄ ||    50.55 |    49.57 |   -2%˄ |               0.0000 |
 | 3c      ||   637.69 |   635.10 |   -0%  ||     1.57 |     1.57 |   +0%  |               0.1223 |
+| 4a      ||   167.57 |   157.02 |   -6%˄ ||     5.97 |     6.37 |   +7%˄ |               0.0000 |
 | 4b      ||    17.50 |    18.05 |   +3%˄ ||    57.10 |    55.38 |   -3%˄ |               0.0152 |
 | 4c      ||   182.21 |   176.89 |   -3%˄ ||     5.49 |     5.65 |   +3%˄ |               0.0001 |
 | 5a      ||    81.75 |    81.81 |   +0%˄ ||    12.23 |    12.22 |   -0%˄ |               0.9331 |
 | 5b      ||   172.94 |   171.45 |   -1%˄ ||     5.78 |     5.83 |   +1%˄ |               0.0009 |
 | 5c      ||   242.59 |   243.50 |   +0%˄ ||     4.12 |     4.11 |   -0%˄ |               0.1359 |
 | 6a      ||   171.76 |   169.41 |   -1%˄ ||     5.82 |     5.90 |   +1%˄ |               0.0447 |
 | 6b      ||   194.36 |   194.98 |   +0%˄ ||     5.14 |     5.13 |   -0%˄ |               0.5340 |
 | 6c      ||   162.29 |   163.37 |   +1%˄ ||     6.16 |     6.12 |   -1%˄ |               0.3493 |
 | 6d      ||   841.15 |   842.92 |   +0%  ||     1.19 |     1.19 |   -0%  |               0.4858 |
 | 6e      ||   171.16 |   170.25 |   -1%˄ ||     5.84 |     5.87 |   +1%˄ |               0.4381 |
 | 6f      ||  1076.77 |  1076.32 |   -0%  ||     0.93 |     0.93 |   +0%  |               0.8945 |
 | 7a      ||    64.45 |    62.27 |   -3%˄ ||    15.51 |    16.06 |   +4%˄ |               0.0000 |
-| 7b      ||    53.78 |    57.68 |   +7%˄ ||    18.59 |    17.33 |   -7%˄ |               0.0000 |
 | 7c      ||   773.10 |   773.14 |   +0%  ||     1.29 |     1.29 |   -0%  |               0.9798 |
-| 8a      ||    57.53 |    62.37 |   +8%˄ ||    17.38 |    16.03 |   -8%˄ |               0.0000 |
-| 8b      ||    52.35 |    55.99 |   +7%˄ ||    19.10 |    17.86 |   -6%˄ |               0.0000 |
 | 8c      ||  2209.50 |  2218.76 |   +0%  ||     0.45 |     0.45 |   -0%  |               0.0519 |
 | 8d      ||   368.76 |   372.04 |   +1%˄ ||     2.71 |     2.69 |   -1%˄ |               0.0002 |
-| 9a      ||   258.18 |   273.34 |   +6%˄ ||     3.87 |     3.66 |   -6%˄ |               0.0000 |
 | 9b      ||   161.59 |   166.16 |   +3%˄ ||     6.19 |     6.02 |   -3%˄ |               0.0000 |
 | 9c      ||   381.45 |   397.01 |   +4%˄ ||     2.62 |     2.52 |   -4%˄ |               0.0000 |
 | 9d      ||   648.32 |   659.61 |   +2%  ||     1.54 |     1.52 |   -2%  |               0.0000 |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 | Sum     || 47485.95 | 47063.88 |   -1%  ||          |          |        |                      |
 | Geomean ||          |          |        ||          |          |   +0%  |                      |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 |   Notes || ˄ Execution stopped due to max runs reached                                         |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkJoinOrder - multi-threaded, shuffled, 64 clients, 64 cores**
<details>
<summary>
Sum of avg. item runtimes: -0%
 ||
Geometric mean of throughput changes: -0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+-----------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /hyrise/rel_amd_nolto/benchmark_all_results/hyriseBenchmarkJoinOrder_8114ddda7b19816aae0d18a9c621ac3784b0dceb_mt.json | /hyrise/rel_amd_nolto/benchmark_all_results/hyriseBenchmarkJoinOrder_f3ee473771660d25cc31399eaf28cee941423b9c_mt.json |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 8114ddda7b19816aae0d18a9c621ac3784b0dceb-dirty                                                                        | f3ee473771660d25cc31399eaf28cee941423b9c-dirty                                                                        |
 |  benchmark_mode               | Shuffled                                                                                                              | Shuffled                                                                                                              |
 |  build_type                   | release                                                                                                               | release                                                                                                               |
 |  chunk_indexes                | False                                                                                                                 | False                                                                                                                 |
 |  chunk_size                   | 65535                                                                                                                 | 65535                                                                                                                 |
 |  clients                      | 64                                                                                                                    | 64                                                                                                                    |
 |  compiler                     | clang 14.0.0                                                                                                          | clang 14.0.0                                                                                                          |
 |  cores                        | 64                                                                                                                    | 64                                                                                                                    |
 |  data_preparation_cores       | 0                                                                                                                     | 0                                                                                                                     |
 |  date                         | 2023-06-26 16:35:00                                                                                                   | 2023-06-26 12:17:54                                                                                                   |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                               | {'default': {'encoding': 'Dictionary'}}                                                                               |
 |  max_duration                 | 1200000000000                                                                                                         | 1200000000000                                                                                                         |
 |  max_runs                     | -1                                                                                                                    | -1                                                                                                                    |
 |  time_unit                    | ns                                                                                                                    | ns                                                                                                                    |
 |  using_scheduler              | True                                                                                                                  | True                                                                                                                  |
 |  utilized_cores_per_numa_node | [64]                                                                                                                  | [64]                                                                                                                  |
 |  verify                       | False                                                                                                                 | False                                                                                                                 |
 |  warmup_duration              | 0                                                                                                                     | 0                                                                                                                     |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |      new |        ||      old |      new |        |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | 10a     ||   268.11 |   258.18 |   -4%  ||     0.89 |     0.89 |   +0%  |  0.7569 |
+| 10b     ||   260.41 |   204.75 |  -21%  ||     0.89 |     0.89 |   +0%  |  0.0426 |
 | 10c     ||   547.98 |   524.19 |   -4%  ||     0.89 |     0.89 |   +0%  |  0.5054 |
-| 11a     ||    62.55 |    79.97 |  +28%  ||     0.89 |     0.89 |   +0%  |  0.1151 |
-| 11b     ||    70.92 |   112.12 |  +58%  ||     0.89 |     0.89 |   +0%  |  0.0873 |
-| 11c     ||   113.51 |   134.94 |  +19%  ||     0.89 |     0.89 |   -0%  |  0.3014 |
-| 11d     ||   136.58 |   177.56 |  +30%  ||     0.89 |     0.89 |   +0%  |  0.1237 |
 | 12a     ||   262.86 |   272.99 |   +4%  ||     0.89 |     0.89 |   +0%  |  0.7615 |
+| 12b     ||   110.63 |    78.61 |  -29%  ||     0.89 |     0.89 |   +0%  |  0.1154 |
-| 12c     ||   526.97 |   561.41 |   +7%  ||     0.89 |     0.89 |   +0%  |  0.4242 |
+| 13a     ||   800.78 |   738.77 |   -8%  ||     0.89 |     0.89 |   +0%  |  0.1807 |
 | 13b     ||   301.26 |   300.80 |   -0%  ||     0.89 |     0.89 |   +0%  |  0.9876 |
 | 13c     ||   280.68 |   288.41 |   +3%  ||     0.89 |     0.89 |   -0%  |  0.7817 |
+| 13d     ||  1246.74 |  1190.19 |   -5%  ||     0.89 |     0.89 |   -0%  |  0.3076 |
 | 14a     ||  1048.55 |  1049.40 |   +0%  ||     0.89 |     0.89 |   -0%  |  0.9882 |
-| 14b     ||   675.76 |   716.29 |   +6%  ||     0.89 |     0.89 |   -0%  |  0.4361 |
 | 14c     ||  1197.10 |  1197.87 |   +0%  ||     0.89 |     0.89 |   +0%  |  0.9895 |
 | 15a     ||   193.44 |   191.38 |   -1%  ||     0.89 |     0.89 |   +0%  |  0.9326 |
-| 15b     ||   178.57 |   188.19 |   +5%  ||     0.89 |     0.89 |   +0%  |  0.7139 |
 | 15c     ||   204.87 |   212.81 |   +4%  ||     0.89 |     0.89 |   -0%  |  0.7663 |
+| 15d     ||   282.88 |   255.52 |  -10%  ||     0.89 |     0.89 |   -0%  |  0.4216 |
 | 16a     ||  3030.44 |  3004.10 |   -1%  ||     0.89 |     0.89 |   -0%  |  0.7379 |
 | 16b     ||  4397.52 |  4409.99 |   +0%  ||     0.89 |     0.89 |   +0%  |  0.8639 |
 | 16c     ||  3189.67 |  3226.42 |   +1%  ||     0.89 |     0.89 |   +0%  |  0.6425 |
 | 16d     ||  3125.08 |  3219.78 |   +3%  ||     0.89 |     0.89 |   +0%  |  0.2611 |
+| 17a     ||  1219.40 |  1108.38 |   -9%  ||     0.89 |     0.89 |   -0%  |  0.0827 |
+| 17b     ||   926.69 |   865.82 |   -7%  ||     0.89 |     0.89 |   -0%  |  0.2556 |
 | 17c     ||   790.08 |   817.67 |   +3%  ||     0.89 |     0.89 |   +0%  |  0.6277 |
-| 17d     ||   813.27 |   862.72 |   +6%  ||     0.89 |     0.89 |   +0%  |  0.3279 |
 | 17e     ||  1988.34 |  1976.46 |   -1%  ||     0.89 |     0.89 |   -0%  |  0.8572 |
 | 17f     ||  1491.98 |  1478.03 |   -1%  ||     0.89 |     0.89 |   -0%  |  0.8143 |
 | 18a     ||  1070.98 |  1037.22 |   -3%  ||     0.89 |     0.89 |   -0%  |  0.5325 |
+| 18b     ||   271.11 |   231.48 |  -15%  ||     0.89 |     0.89 |   -0%  |  0.1646 |
 | 18c     ||  1056.65 |  1063.67 |   +1%  ||     0.89 |     0.89 |   +0%  |  0.9054 |
-| 19a     ||   747.95 |   790.13 |   +6%  ||     0.89 |     0.89 |   -0%  |  0.4750 |
 | 19b     ||   501.04 |   519.81 |   +4%  ||     0.89 |     0.89 |   +0%  |  0.6518 |
 | 19c     ||   906.16 |   900.87 |   -1%  ||     0.89 |     0.89 |   -0%  |  0.9394 |
 | 19d     ||  1944.91 |  1859.38 |   -4%  ||     0.89 |     0.89 |   +0%  |  0.2968 |
+| 1a      ||    51.31 |    44.29 |  -14%  ||     0.89 |     0.89 |   -0%  |  0.5057 |
-| 1b      ||    44.84 |    51.68 |  +15%  ||     0.89 |     0.89 |   +0%  |  0.6738 |
-| 1c      ||    50.96 |    59.72 |  +17%  ||     0.89 |     0.89 |   +0%  |  0.4430 |
+| 1d      ||    39.85 |    37.13 |   -7%  ||     0.89 |     0.89 |   +0%  |  0.7839 |
 | 20a     ||   844.60 |   831.14 |   -2%  ||     0.89 |     0.89 |   +0%  |  0.7844 |
 | 20b     ||   650.25 |   640.86 |   -1%  ||     0.89 |     0.89 |   +0%  |  0.8445 |
-| 20c     ||   565.99 |   652.74 |  +15%  ||     0.89 |     0.89 |   -0%  |  0.0395 |
 | 21a     ||   118.99 |   122.04 |   +3%  ||     0.89 |     0.89 |   +0%  |  0.8786 |
-| 21b     ||   121.62 |   151.05 |  +24%  ||     0.89 |     0.89 |   +0%  |  0.1961 |
 | 21c     ||   104.91 |   106.87 |   +2%  ||     0.89 |     0.89 |   -0%  |  0.8974 |
+| 22a     ||   760.33 |   709.92 |   -7%  ||     0.89 |     0.89 |   +0%  |  0.3250 |
 | 22b     ||   488.97 |   469.43 |   -4%  ||     0.89 |     0.89 |   +0%  |  0.6395 |
 | 22c     ||  1094.54 |  1126.70 |   +3%  ||     0.89 |     0.89 |   +0%  |  0.6155 |
-| 22d     ||  1397.96 |  1465.05 |   +5%  ||     0.89 |     0.89 |   +0%  |  0.3523 |
-| 23a     ||   224.61 |   253.52 |  +13%  ||     0.89 |     0.89 |   +0%  |  0.2896 |
-| 23b     ||   197.26 |   206.59 |   +5%  ||     0.89 |     0.89 |   -0%  |  0.7340 |
-| 23c     ||   225.18 |   265.98 |  +18%  ||     0.89 |     0.89 |   +0%  |  0.1669 |
 | 24a     ||   404.71 |   404.85 |   +0%  ||     0.89 |     0.89 |   +0%  |  0.9973 |
 | 24b     ||   209.87 |   206.08 |   -2%  ||     0.89 |     0.89 |   +0%  |  0.8736 |
 | 25a     ||   740.19 |   740.37 |   +0%  ||     0.89 |     0.89 |   +0%  |  0.9971 |
 | 25b     ||   195.86 |   198.16 |   +1%  ||     0.89 |     0.89 |   +0%  |  0.9253 |
+| 25c     ||  1436.34 |  1366.80 |   -5%  ||     0.89 |     0.89 |   -0%  |  0.3003 |
+| 26a     ||   491.70 |   459.03 |   -7%  ||     0.89 |     0.89 |   -0%  |  0.3836 |
+| 26b     ||   310.41 |   290.98 |   -6%  ||     0.89 |     0.89 |   -0%  |  0.5557 |
-| 26c     ||   645.05 |   691.19 |   +7%  ||     0.89 |     0.89 |   +0%  |  0.3034 |
 | 27a     ||   192.14 |   188.27 |   -2%  ||     0.89 |     0.89 |   -0%  |  0.9025 |
+| 27b     ||   204.53 |   172.29 |  -16%  ||     0.89 |     0.89 |   +0%  |  0.3242 |
-| 27c     ||   108.36 |   137.44 |  +27%  ||     0.89 |     0.89 |   +0%  |  0.1207 |
+| 28a     ||  1051.49 |   999.31 |   -5%  ||     0.89 |     0.89 |   +0%  |  0.4089 |
-| 28b     ||   272.05 |   332.63 |  +22%  ||     0.89 |     0.89 |   -0%  |  0.0746 |
 | 28c     ||  1112.12 |  1101.80 |   -1%  ||     0.89 |     0.89 |   -0%  |  0.8819 |
 | 29a     ||   255.12 |   253.79 |   -1%  ||     0.89 |     0.89 |   +0%  |  0.9560 |
 | 29b     ||   195.54 |   204.28 |   +4%  ||     0.89 |     0.89 |   -0%  |  0.7373 |
+| 29c     ||   353.93 |   309.63 |  -13%  ||     0.89 |     0.89 |   -0%  |  0.1890 |
-| 2a      ||   260.42 |   299.50 |  +15%  ||     0.89 |     0.89 |   -0%  |  0.3037 |
-| 2b      ||   226.25 |   254.27 |  +12%  ||     0.89 |     0.89 |   +0%  |  0.3915 |
 | 2c      ||   115.59 |   111.95 |   -3%  ||     0.89 |     0.89 |   -0%  |  0.8378 |
+| 2d      ||   349.35 |   327.07 |   -6%  ||     0.89 |     0.89 |   -0%  |  0.4770 |
-| 30a     ||   512.38 |   574.55 |  +12%  ||     0.89 |     0.89 |   +0%  |  0.1740 |
 | 30b     ||   420.67 |   409.86 |   -3%  ||     0.89 |     0.89 |   -0%  |  0.8262 |
 | 30c     ||  1019.33 |  1059.50 |   +4%  ||     0.89 |     0.89 |   -0%  |  0.4901 |
 | 31a     ||   440.77 |   426.16 |   -3%  ||     0.89 |     0.89 |   -0%  |  0.6998 |
+| 31b     ||   224.74 |   210.24 |   -6%  ||     0.89 |     0.89 |   +0%  |  0.5082 |
+| 31c     ||   498.15 |   446.60 |  -10%  ||     0.89 |     0.89 |   -0%  |  0.2406 |
-| 32a     ||    58.96 |    62.74 |   +6%  ||     0.89 |     0.89 |   +0%  |  0.7838 |
+| 32b     ||   218.04 |   196.30 |  -10%  ||     0.89 |     0.89 |   +0%  |  0.3688 |
 | 33a     ||   102.18 |    99.85 |   -2%  ||     0.89 |     0.89 |   +0%  |  0.8955 |
 | 33b     ||   100.81 |   102.81 |   +2%  ||     0.89 |     0.89 |   +0%  |  0.9192 |
+| 33c     ||   112.18 |   102.43 |   -9%  ||     0.89 |     0.89 |   -0%  |  0.5062 |
 | 3a      ||   530.89 |   509.83 |   -4%  ||     0.89 |     0.89 |   +0%  |  0.6308 |
-| 3b      ||    99.88 |   105.74 |   +6%  ||     0.89 |     0.89 |   +0%  |  0.8087 |
+| 3c      ||   807.09 |   731.50 |   -9%  ||     0.89 |     0.89 |   -0%  |  0.1712 |
-| 4a      ||   243.49 |   279.51 |  +15%  ||     0.89 |     0.89 |   +0%  |  0.2224 |
+| 4b      ||    93.87 |    76.28 |  -19%  ||     0.89 |     0.89 |   +0%  |  0.3263 |
+| 4c      ||   305.54 |   282.86 |   -7%  ||     0.89 |     0.89 |   +0%  |  0.4499 |
 | 5a      ||   287.21 |   297.41 |   +4%  ||     0.89 |     0.89 |   +0%  |  0.7911 |
-| 5b      ||   245.27 |   296.20 |  +21%  ||     0.89 |     0.89 |   -0%  |  0.0721 |
+| 5c      ||   424.07 |   400.63 |   -6%  ||     0.89 |     0.89 |   -0%  |  0.5904 |
 | 6a      ||   161.62 |   162.40 |   +0%  ||     0.89 |     0.89 |   -0%  |  0.9733 |
 | 6b      ||   241.15 |   239.41 |   -1%  ||     0.89 |     0.89 |   +0%  |  0.9429 |
-| 6c      ||   136.27 |   144.20 |   +6%  ||     0.89 |     0.89 |   -0%  |  0.6982 |
 | 6d      ||   864.18 |   849.70 |   -2%  ||     0.89 |     0.89 |   -0%  |  0.7839 |
+| 6e      ||   158.58 |   143.01 |  -10%  ||     0.89 |     0.89 |   -0%  |  0.3746 |
 | 6f      ||  1345.40 |  1387.49 |   +3%  ||     0.89 |     0.89 |   +0%  |  0.4381 |
+| 7a      ||   200.81 |   184.45 |   -8%  ||     0.89 |     0.89 |   +0%  |  0.5501 |
+| 7b      ||   143.84 |   132.16 |   -8%  ||     0.89 |     0.89 |   +0%  |  0.4571 |
-| 7c      ||  1218.43 |  1320.49 |   +8%  ||     0.89 |     0.89 |   -0%  |  0.0991 |
+| 8a      ||   222.79 |   180.96 |  -19%  ||     0.89 |     0.89 |   +0%  |  0.1295 |
+| 8b      ||   220.80 |   164.62 |  -25%  ||     0.89 |     0.89 |   -0%  |  0.0479 |
 | 8c      ||  2543.63 |  2523.84 |   -1%  ||     0.89 |     0.89 |   -0%  |  0.7387 |
 | 8d      ||   767.22 |   752.06 |   -2%  ||     0.89 |     0.89 |   +0%  |  0.7264 |
 | 9a      ||   839.62 |   868.27 |   +3%  ||     0.89 |     0.89 |   +0%  |  0.6155 |
+| 9b      ||   487.66 |   426.76 |  -12%  ||     0.89 |     0.89 |   +0%  |  0.1101 |
-| 9c      ||   993.26 |  1042.14 |   +5%  ||     0.89 |     0.89 |   +0%  |  0.3803 |
 | 9d      ||  1451.20 |  1453.89 |   +0%  ||     0.89 |     0.89 |   +0%  |  0.9691 |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Sum     || 71097.60 | 70997.52 |   -0%  ||          |          |        |         |
 | Geomean ||          |          |        ||          |          |   -0%  |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkStarSchema - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: +1%
 ||
Geometric mean of throughput changes: -1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---+------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
 | Parameter               | /hyrise/rel_amd_nolto/benchmark_all_results/hyriseBenchmarkStarSchema_8114ddda7b19816aae0d18a9c621ac3784b0dceb_st.json | /hyrise/rel_amd_nolto/benchmark_all_results/hyriseBenchmarkStarSchema_f3ee473771660d25cc31399eaf28cee941423b9c_st.json |
 +-------------------------+------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH               | 8114ddda7b19816aae0d18a9c621ac3784b0dceb-dirty                                                                         | f3ee473771660d25cc31399eaf28cee941423b9c-dirty                                                                         |
 |  benchmark_mode         | Ordered                                                                                                                | Ordered                                                                                                                |
 |  build_type             | release                                                                                                                | release                                                                                                                |
 |  chunk_indexes          | False                                                                                                                  | False                                                                                                                  |
 |  chunk_size             | 65535                                                                                                                  | 65535                                                                                                                  |
 |  clients                | 1                                                                                                                      | 1                                                                                                                      |
 |  compiler               | clang 14.0.0                                                                                                           | clang 14.0.0                                                                                                           |
 |  cores                  | 0                                                                                                                      | 0                                                                                                                      |
 |  data_preparation_cores | 0                                                                                                                      | 0                                                                                                                      |
 |  date                   | 2023-06-26 16:55:37                                                                                                    | 2023-06-26 12:38:25                                                                                                    |
 |  encoding               | {'default': {'encoding': 'Dictionary'}}                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                |
 |  max_duration           | 60000000000                                                                                                            | 60000000000                                                                                                            |
 |  max_runs               | 100                                                                                                                    | 100                                                                                                                    |
 |  scale_factor           | 10.0                                                                                                                   | 10.0                                                                                                                   |
 |  time_unit              | ns                                                                                                                     | ns                                                                                                                     |
 |  using_scheduler        | False                                                                                                                  | False                                                                                                                  |
 |  verify                 | False                                                                                                                  | False                                                                                                                  |
 |  warmup_duration        | 1000000000                                                                                                             | 1000000000                                                                                                             |
 +-------------------------+------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |      new |        ||      old |      new |        |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | 1.1     ||   419.45 |   413.20 |   -1%˄ ||     2.38 |     2.42 |   +2%˄ |  0.2059 |
 | 1.2     ||   116.73 |   117.37 |   +1%˄ ||     8.57 |     8.52 |   -1%˄ |  0.4881 |
 | 1.3     ||   111.27 |   114.51 |   +3%˄ ||     8.99 |     8.73 |   -3%˄ |  0.0002 |
 | 2.1     ||   840.95 |   858.58 |   +2%  ||     1.19 |     1.16 |   -2%  |  0.0001 |
+| 2.2     ||   473.37 |   446.83 |   -6%˄ ||     2.11 |     2.24 |   +6%˄ |  0.0000 |
 | 2.3     ||   265.90 |   261.05 |   -2%˄ ||     3.76 |     3.83 |   +2%˄ |  0.0000 |
 | 3.1     ||  3240.46 |  3303.07 |   +2%  ||     0.31 |     0.30 |   -2%  |  0.0061 |
 | 3.2     ||   428.27 |   434.27 |   +1%˄ ||     2.33 |     2.30 |   -1%˄ |  0.0002 |
 | 3.3     ||   168.37 |   170.51 |   +1%˄ ||     5.94 |     5.86 |   -1%˄ |  0.0112 |
 | 3.4     ||   155.54 |   159.41 |   +2%˄ ||     6.43 |     6.27 |   -2%˄ |  0.0000 |
 | 4.1     ||  5034.24 |  5111.04 |   +2%  ||     0.20 |     0.20 |   -2%  |  0.1146 |
 | 4.2     ||  1041.45 |  1082.24 |   +4%  ||     0.96 |     0.92 |   -4%  |  0.0000 |
 | 4.3     ||   360.77 |   370.74 |   +3%˄ ||     2.77 |     2.70 |   -3%˄ |  0.0000 |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Sum     || 12656.78 | 12842.81 |   +1%  ||          |          |        |         |
 | Geomean ||          |          |        ||          |          |   -1%  |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 |   Notes || ˄ Execution stopped due to max runs reached                            |
 +---------++----------+----------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkStarSchema - multi-threaded, shuffled, 64 clients, 64 cores**
<details>
<summary>
Sum of avg. item runtimes: +1%
 ||
Geometric mean of throughput changes: -0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /hyrise/rel_amd_nolto/benchmark_all_results/hyriseBenchmarkStarSchema_8114ddda7b19816aae0d18a9c621ac3784b0dceb_mt.json | /hyrise/rel_amd_nolto/benchmark_all_results/hyriseBenchmarkStarSchema_f3ee473771660d25cc31399eaf28cee941423b9c_mt.json |
 +-------------------------------+------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 8114ddda7b19816aae0d18a9c621ac3784b0dceb-dirty                                                                         | f3ee473771660d25cc31399eaf28cee941423b9c-dirty                                                                         |
 |  benchmark_mode               | Shuffled                                                                                                               | Shuffled                                                                                                               |
 |  build_type                   | release                                                                                                                | release                                                                                                                |
 |  chunk_indexes                | False                                                                                                                  | False                                                                                                                  |
 |  chunk_size                   | 65535                                                                                                                  | 65535                                                                                                                  |
 |  clients                      | 64                                                                                                                     | 64                                                                                                                     |
 |  compiler                     | clang 14.0.0                                                                                                           | clang 14.0.0                                                                                                           |
 |  cores                        | 64                                                                                                                     | 64                                                                                                                     |
 |  data_preparation_cores       | 0                                                                                                                      | 0                                                                                                                      |
 |  date                         | 2023-06-26 17:04:35                                                                                                    | 2023-06-26 12:52:30                                                                                                    |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                |
 |  max_duration                 | 1200000000000                                                                                                          | 1200000000000                                                                                                          |
 |  max_runs                     | -1                                                                                                                     | -1                                                                                                                     |
 |  scale_factor                 | 10.0                                                                                                                   | 10.0                                                                                                                   |
 |  time_unit                    | ns                                                                                                                     | ns                                                                                                                     |
 |  using_scheduler              | True                                                                                                                   | True                                                                                                                   |
 |  utilized_cores_per_numa_node | [64]                                                                                                                   | [64]                                                                                                                   |
 |  verify                       | False                                                                                                                  | False                                                                                                                  |
 |  warmup_duration              | 0                                                                                                                      | 0                                                                                                                      |
 +-------------------------------+------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |      new |        ||      old |      new |        |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | 1.1     ||   928.64 |   916.48 |   -1%  ||     3.23 |     3.22 |   -0%  |  0.7056 |
 | 1.2     ||   558.12 |   551.30 |   -1%  ||     3.23 |     3.22 |   -0%  |  0.7804 |
 | 1.3     ||   353.03 |   351.46 |   -0%  ||     3.23 |     3.22 |   -0%  |  0.9377 |
 | 2.1     ||  2417.05 |  2369.51 |   -2%  ||     3.23 |     3.21 |   -0%  |  0.3588 |
 | 2.2     ||  1348.89 |  1386.01 |   +3%  ||     3.23 |     3.22 |   -0%  |  0.3415 |
-| 2.3     ||   450.04 |   484.96 |   +8%  ||     3.23 |     3.22 |   -0%  |  0.1237 |
 | 3.1     ||  3434.84 |  3447.98 |   +0%  ||     3.22 |     3.21 |   -0%  |  0.8251 |
 | 3.2     ||  1251.36 |  1225.90 |   -2%  ||     3.23 |     3.22 |   -0%  |  0.4975 |
-| 3.3     ||   638.19 |   680.00 |   +7%  ||     3.23 |     3.22 |   -0%  |  0.1651 |
 | 3.4     ||   623.39 |   633.04 |   +2%  ||     3.23 |     3.22 |   -0%  |  0.7261 |
 | 4.1     ||  3828.40 |  3860.50 |   +1%  ||     3.22 |     3.21 |   -0%  |  0.5623 |
 | 4.2     ||  2810.91 |  2817.46 |   +0%  ||     3.23 |     3.21 |   -0%  |  0.9100 |
 | 4.3     ||  1036.90 |  1061.88 |   +2%  ||     3.23 |     3.22 |   -0%  |  0.4676 |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Sum     || 19679.78 | 19786.49 |   +1%  ||          |          |        |         |
 | Geomean ||          |          |        ||          |          |   -0%  |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
```
</details>
