### PR TITLE
Update plot_performance_breakdown.py Script

### DIFF
--- a/scripts/plot_performance_breakdown.py
+++ b/scripts/plot_performance_breakdown.py
@@ -9,8 +9,13 @@ import matplotlib.ticker as mplticker
 import pandas as pd
 import sys
 
+
 benchmarks = []
 rule_benchmarks = []
+
+y_ticks = [x / 5 for x in range(6)]
+y_tick_labels = [f"{x:,.0%}" for x in y_ticks]
+
 
 if len(sys.argv) != 2:
     exit("Usage: " + sys.argv[0] + " benchmark.json")
@@ -78,9 +83,8 @@ plt.figure()
 ax = benchmark_df.plot.bar(x="Benchmark", stacked=True)
 ax.set_ylabel("Share of Query Runtime")
 
-y_ticks_loc = ax.get_yticks().tolist()
-ax.yaxis.set_major_locator(mplticker.FixedLocator(y_ticks_loc))
-ax.set_yticklabels([f"{x:,.0%}" for x in y_ticks_loc])
+ax.yaxis.set_major_locator(mplticker.FixedLocator(y_ticks))
+ax.set_yticklabels(y_tick_labels)
 
 # Reverse legend so that it matches the stacked bars
 handles, labels = ax.get_legend_handles_labels()
@@ -121,14 +125,12 @@ plt.figure()
 ax = rule_benchmark_df.plot.bar(x="Benchmark", stacked=True)
 ax.set_ylabel("Share of Optimizer Runtime")
 
-y_ticks_loc = ax.get_yticks().tolist()
-ax.yaxis.set_major_locator(mplticker.FixedLocator(y_ticks_loc))
-ax.set_yticklabels([f"{x:,.0%}" for x in y_ticks_loc])
+ax.yaxis.set_major_locator(mplticker.FixedLocator(y_ticks))
+ax.set_yticklabels(y_tick_labels)
 
 # Reverse legend so that it matches the stacked bars
 handles, labels = ax.get_legend_handles_labels()
 ax.legend(reversed(handles), reversed(labels), bbox_to_anchor=(0.5, 1.05), loc="lower center", ncols=2)
-
 
 # Add total runtime to labels
 xlabels = ax.get_xticklabels()

--- a/scripts/plot_performance_breakdown.py
+++ b/scripts/plot_performance_breakdown.py
@@ -5,6 +5,7 @@
 
 import json
 import matplotlib.pyplot as plt
+import matplotlib.ticker as mplticker
 import pandas as pd
 import sys
 
@@ -44,8 +45,6 @@ for benchmark_json in data["benchmarks"]:
 
                 if statement["optimizer_rule_durations"]:
                     for rule_name, rule_duration in statement["optimizer_rule_durations"].items():
-                        # crop typeid().name down to the actual rule name. This might be compiler dependent
-                        rule_name = rule_name[11:-1]
                         if rule_name not in sum_optimizer_rule_durations:
                             sum_optimizer_rule_durations[rule_name] = rule_duration
                         else:
@@ -77,12 +76,15 @@ print(benchmark_df)
 
 plt.figure()
 ax = benchmark_df.plot.bar(x="Benchmark", stacked=True)
-ax.set_ylabel("Share of query run time")
-ax.set_yticklabels(["{:,.0%}".format(x) for x in ax.get_yticks()])
+ax.set_ylabel("Share of Query Runtime")
+
+y_ticks_loc = ax.get_yticks().tolist()
+ax.yaxis.set_major_locator(mplticker.FixedLocator(y_ticks_loc))
+ax.set_yticklabels([f"{x:,.0%}" for x in y_ticks_loc])
 
 # Reverse legend so that it matches the stacked bars
 handles, labels = ax.get_legend_handles_labels()
-ax.legend(reversed(handles), reversed(labels), bbox_to_anchor=(1.0, 1.0))
+ax.legend(reversed(handles), reversed(labels), bbox_to_anchor=(0.5, 1.05), loc="lower center", ncols=2)
 
 # Add total runtime to labels
 xlabels = ax.get_xticklabels()
@@ -92,13 +94,14 @@ ax.set_xticklabels(xlabels)
 
 basename = sys.argv[1].replace(".json", "")
 plt.tight_layout()
-plt.savefig(basename + "_breakdown.png")
+plt.savefig(basename + "_breakdown.pdf")
 
 rule_benchmark_df = pd.DataFrame(rule_benchmarks, columns=["Benchmark"] + list(sum_optimizer_rule_durations.keys()))
 # sort optimizer rules
 rule_benchmark_df = rule_benchmark_df.reindex(
     columns=[rule_benchmark_df.columns[0]] + sorted(rule_benchmark_df.columns[1:], key=str.casefold, reverse=True)
 )
+
 # summing up the runtimes from all rules for each query
 optimizer_total_time = rule_benchmark_df.iloc[:, 1:].apply(lambda x: x.sum(), axis=1)
 # Normalize data from nanoseconds to percentage of total cost
@@ -108,7 +111,7 @@ rule_benchmark_df.iloc[:, 1:] = rule_benchmark_df.iloc[:, 1:].apply(lambda x: x 
 rule_benchmark_df.insert(0, "Other Rules", 0)
 threshold = 0.05
 for index, benchmark in rule_benchmark_df[sum_optimizer_rule_durations.keys()].iterrows():
-    for rule_name, rule_duration in benchmark.iteritems():
+    for rule_name, rule_duration in benchmark.items():
         if rule_duration < threshold:
             rule_benchmark_df.loc[index, "Other Rules"] += rule_duration
             rule_benchmark_df.loc[index, rule_name] = None
@@ -116,13 +119,16 @@ rule_benchmark_df.dropna(how="all", axis=1, inplace=True)
 
 plt.figure()
 ax = rule_benchmark_df.plot.bar(x="Benchmark", stacked=True)
-ax.set_ylabel("Share of optimizer run time")
+ax.set_ylabel("Share of Optimizer Runtime")
 
-ax.set_yticklabels(["{:,.0%}".format(x) for x in ax.get_yticks()])
+y_ticks_loc = ax.get_yticks().tolist()
+ax.yaxis.set_major_locator(mplticker.FixedLocator(y_ticks_loc))
+ax.set_yticklabels([f"{x:,.0%}" for x in y_ticks_loc])
 
 # Reverse legend so that it matches the stacked bars
 handles, labels = ax.get_legend_handles_labels()
-ax.legend(reversed(handles), reversed(labels), bbox_to_anchor=(1.0, 1.0))
+ax.legend(reversed(handles), reversed(labels), bbox_to_anchor=(0.5, 1.05), loc="lower center", ncols=2)
+
 
 # Add total runtime to labels
 xlabels = ax.get_xticklabels()
@@ -131,4 +137,4 @@ for label_id, label in enumerate(xlabels):
 ax.set_xticklabels(xlabels)
 
 plt.tight_layout()
-plt.savefig(basename + "_optimizer_breakdown.png")
+plt.savefig(basename + "_optimizer_breakdown.pdf")


### PR DESCRIPTION
This PR updates the `plot_performance_breakdown.py` script:

- address Python warnings (see log below)
- generated PDF instead of PNG
- remove manual mangling handling (no longer necessary; tested with GCC and Clang)
- move legend to better show long rule names

<details>
<summary>Python warnings</summary>
```/hyrise/./scripts/plot_performance_breakdown.py:81: UserWarning: FixedFormatter should only be used together with FixedLocator
  ax.set_yticklabels(["{:,.0%}".format(x) for x in ax.get_yticks()])
/hyrise/./scripts/plot_performance_breakdown.py:111: FutureWarning: iteritems is deprecated and will be removed in a future version. Use .items instead.
  for rule_name, rule_duration in benchmark.iteritems():
/hyrise/./scripts/plot_performance_breakdown.py:121: UserWarning: FixedFormatter should only be used together with FixedLocator
  ax.set_yticklabels(["{:,.0%}".format(x) for x in ax.get_yticks()])```
</details>

## Results

### Old

![tpcc_optimizer_breakdown](https://github.com/hyrise/hyrise/assets/1745857/91aaeaa4-0091-449f-8539-30fe549cbda7)
![tpcc_breakdown](https://github.com/hyrise/hyrise/assets/1745857/37feff75-3705-4a7a-a1c2-ba6d0cb157be)

### New

[tpcc_optimizer_breakdown.pdf](https://github.com/hyrise/hyrise/files/11887176/tpcc_optimizer_breakdown.pdf)
[tpcc_breakdown.pdf](https://github.com/hyrise/hyrise/files/11887177/tpcc_breakdown.pdf)

