### PR TITLE
[DYOD] Maintain UCCs in face of potentially changing data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ tpch_cached_tables/
 imdb_data/
 jcch_data/
 ssb_data/
+
+# Python poetry
+poetry.lock
+pyproject.toml

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Contact: firstname.lastname@hpi.de
 -   Lawrence  Benson
 -   Jasper    Blum
 -   Lukas     Budach
+-   Margarete Dippel
 -   Timo      Djürken
 -   Alexander Dubrawski
 -   Fabian    Dumke
@@ -177,6 +178,7 @@ Contact: firstname.lastname@hpi.de
 -   Johannes  Frohnhofen
 -   Pascal    Führlich
 -   Carl      Gödecken
+-   Jan-Eric  Hellenberg
 -   Adrian    Holfter
 -   Theresa   Hradilak
 -   Ben       Hurdelhey
@@ -215,6 +217,7 @@ Contact: firstname.lastname@hpi.de
 -   Daniel    Stolpe
 -   Jonathan  Striebel
 -   Nils      Thamm
+-   Kathrin   Thenhausen
 -   Hendrik   Tjabben
 -   Justin    Trautmann
 -   Carsten   Walther

--- a/src/lib/storage/constraints/table_key_constraint.cpp
+++ b/src/lib/storage/constraints/table_key_constraint.cpp
@@ -5,14 +5,32 @@
 namespace hyrise {
 
 TableKeyConstraint::TableKeyConstraint(const std::set<ColumnID>& columns, const KeyConstraintType key_type)
-    : _key_type{key_type}, _columns{columns} {}
+    : TableKeyConstraint(columns, key_type, INVALID_COMMIT_ID) {}
+
+TableKeyConstraint::TableKeyConstraint(const std::set<ColumnID>& columns, const KeyConstraintType key_type,
+                                       CommitID last_validated_on)
+    : _columns{columns}, _key_type{key_type}, _last_validated_on(last_validated_on) {}
+
+const std::set<ColumnID>& TableKeyConstraint::columns() const {
+  return _columns;
+}
 
 KeyConstraintType TableKeyConstraint::key_type() const {
   return _key_type;
 }
 
-const std::set<ColumnID>& TableKeyConstraint::columns() const {
-  return _columns;
+bool TableKeyConstraint::can_become_invalid() const {
+  return _last_validated_on != INVALID_COMMIT_ID;
+}
+
+CommitID TableKeyConstraint::last_validated_on() const {
+  return _last_validated_on;
+}
+
+void TableKeyConstraint::revalidated_on(CommitID revalidation_commit_id) const {
+  DebugAssert(revalidation_commit_id >= _last_validated_on,
+              "Key constraint was already validated for larger commit id.");
+  _last_validated_on = revalidation_commit_id;
 }
 
 size_t TableKeyConstraint::hash() const {

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -401,6 +401,10 @@ void Table::create_chunk_index(const std::vector<ColumnID>& column_ids, const st
   _chunk_indexes_statistics.emplace_back(ChunkIndexStatistics{column_ids, name, chunk_index_type});
 }
 
+const TableKeyConstraints& Table::soft_key_constraints() const {
+  return _table_key_constraints;
+}
+
 void Table::add_soft_key_constraint(const TableKeyConstraint& table_key_constraint) {
   Assert(_type == TableType::Data, "TableKeyConstraints are not tracked for reference tables across the PQP.");
 
@@ -432,8 +436,8 @@ void Table::add_soft_key_constraint(const TableKeyConstraint& table_key_constrai
   _table_key_constraints.insert(table_key_constraint);
 }
 
-const TableKeyConstraints& Table::soft_key_constraints() const {
-  return _table_key_constraints;
+void Table::delete_key_constraint(const TableKeyConstraint& constraint) {
+  _table_key_constraints.erase(constraint);
 }
 
 void Table::add_soft_foreign_key_constraint(const ForeignKeyConstraint& foreign_key_constraint) {

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -206,6 +206,12 @@ class Table : private Noncopyable {
   const TableKeyConstraints& soft_key_constraints() const;
   void add_soft_key_constraint(const TableKeyConstraint& table_key_constraint);
   void delete_key_constraint(const TableKeyConstraint& constraint);
+  /**
+   * Check if MVCC data tells us that the existing UCC is guaranteed to be still valid.
+   * To do this, we can simply check if the table chunks have seen any inserts/deletions since the last validation
+   * of the UCC. This is information is contained in the MVCC data of the chunks.
+   */
+  bool constraint_guaranteed_to_be_valid(const TableKeyConstraint& table_key_constraint) const;
 
   // Adds foreign key constraint so it can be retrieved by soft_foreign_key_constraints() of this table and by
   // referenced_foreign_key_constraints() of the table that has the primary key columns.

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -203,8 +203,9 @@ class Table : private Noncopyable {
    * NOTE: constraints are currently NOT ENFORCED and are only used to develop optimization rules.
    * We call them "soft" constraints to draw attention to that.
    */
-  void add_soft_key_constraint(const TableKeyConstraint& table_key_constraint);
   const TableKeyConstraints& soft_key_constraints() const;
+  void add_soft_key_constraint(const TableKeyConstraint& table_key_constraint);
+  void delete_key_constraint(const TableKeyConstraint& constraint);
 
   // Adds foreign key constraint so it can be retrieved by soft_foreign_key_constraints() of this table and by
   // referenced_foreign_key_constraints() of the table that has the primary key columns.

--- a/src/lib/types.hpp
+++ b/src/lib/types.hpp
@@ -140,6 +140,8 @@ constexpr CpuID INVALID_CPU_ID{std::numeric_limits<CpuID::base_type>::max()};
 constexpr WorkerID INVALID_WORKER_ID{std::numeric_limits<WorkerID::base_type>::max()};
 constexpr ColumnID INVALID_COLUMN_ID{std::numeric_limits<ColumnID::base_type>::max()};
 
+constexpr CommitID INVALID_COMMIT_ID{std::numeric_limits<CommitID::base_type>::max()};
+
 // TransactionID = 0 means "not set" in the MVCC data. This is the case if the row has (a) just been reserved, but not
 // yet filled with content, (b) been inserted, committed and not marked for deletion, or (c) inserted but deleted in
 // the same transaction (which has not yet committed)

--- a/src/plugins/ucc_discovery_plugin.hpp
+++ b/src/plugins/ucc_discovery_plugin.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "concurrency/transaction_context.hpp"
 #include "expression/abstract_expression.hpp"
 #include "logical_query_plan/abstract_lqp_node.hpp"
 #include "storage/table.hpp"
@@ -80,7 +81,9 @@ class UccDiscoveryPlugin : public AbstractPlugin {
    * there must be a duplicate and return false. Otherwise, returns true.
    */
   template <typename ColumnDataType>
-  static bool _uniqueness_holds_across_segments(const std::shared_ptr<const Table>& table, const ColumnID column_id);
+  static bool _uniqueness_holds_across_segments(const std::shared_ptr<const Table>& table, const std::string table_name,
+                                                const ColumnID column_id,
+                                                const std::shared_ptr<TransactionContext>& transaction_context);
 
   /**
    * Extracts columns as candidates for UCC validation from a given aggregate node that is used in a groupby operation.

--- a/src/test/lib/storage/constraints/table_key_constraint_test.cpp
+++ b/src/test/lib/storage/constraints/table_key_constraint_test.cpp
@@ -167,4 +167,12 @@ TEST_F(TableKeyConstraintTest, OrderIndependence) {
   EXPECT_EQ(*std::next(key_constraints_a.begin()), *std::next(key_constraints_b.begin()));
 }
 
+TEST_F(TableKeyConstraintTest, CanBecomeInvalid) {
+  const auto key_constraint_invalid = TableKeyConstraint{{ColumnID{0}}, KeyConstraintType::UNIQUE, CommitID{0}};
+  const auto key_constraint_valid = TableKeyConstraint{{ColumnID{0}}, KeyConstraintType::UNIQUE};
+
+  EXPECT_EQ(key_constraint_invalid.can_become_invalid(), true);
+  EXPECT_EQ(key_constraint_valid.can_become_invalid(), false);
+}
+
 }  // namespace hyrise


### PR DESCRIPTION
`UCCs` (Unique Column Combinations) indicate the uniqueness across all entries of a column (or a set of columns). UCCs can be given by the schema (a primary key guarantees uniqueness), but also happen "incidentally" in real-world data.

Because UCCs can be used for query optimization, we want to detect these "incidental" UCCs as well, because, for optimization purposes, we can use them just as we would use a primary key constraint.

Before this PR, hyrise was already capable to detect such UCCs. It did so by actually generating `UNIQUE` constraints on a table, which are translated into UCCs during query optimization. However, this discovery happened under the assumption that the data of the table never changes. This means, if the data of the table *were* to change and violate the previously discovered "incidental" UCC by creating a duplicate value in the targeted column, this using the UCC for query optimization would lead to incorrect query results.

Therefore, in this MR, we assign a validation `commit ID` to the TableKeyConstraint (UCC) such that it may be only used for optimization if the table has not seen any changes since this `commit ID` (note that every modifying transaction increments the global `commit ID`). We will then regularly revalidate the UCC and see if we can expand the constraint to larger commit IDs.

For optimization purposes, we also make use of the `MVCC` (Multi-Version Concurrency Control) data of chunks, which includes but is not limited to the `commit IDs` of when any data was last inserted to or deleted from the chunk (note that hyrise models modifications as delete+insert).

_Note that this PR currently targets the `dey4ss/set_cids` branch, because we depend on the changes Daniel made for us in there. Targeting this branch should make the review a bit easier since you won't have to care about his changes :) We will change the PR to target master before merging._