### PR TITLE
Make CI runs more stable

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -173,13 +173,13 @@ try {
                 sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-debug"
                 sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-debug"
                 sh "cd clang-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
-                sh "cd clang-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate visualization
+                sh "cd clang-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate cached data
                 sh "./scripts/test/hyriseConsole_test.py gcc-debug"
                 sh "./scripts/test/hyriseServer_test.py gcc-debug"
                 sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-debug"
                 sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-debug"
                 sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
-                sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate visualization
+                sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate cached data
 
               } else {
                 Utils.markStageSkippedForConditional("debugSystemTests")
@@ -297,22 +297,12 @@ try {
             }
           }
 
-          // We run these test in an own stage since we encountered issues with multiple concurrent calls to the external DB generators.
-          parallel debugSSBTest: {
-            stage("debugSSBTest") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "./scripts/test/hyriseBenchmarkStarSchema_test.py clang-debug"
-              } else {
-                Utils.markStageSkippedForConditional("debugSSBTest")
-              }
-            }
-          }, debugJCCHTest: {
-            stage("debugJCCHTest") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "./scripts/test/hyriseBenchmarkJCCH_test.py clang-debug"
-              } else {
-                Utils.markStageSkippedForConditional("debugJCCHTest")
-              }
+          // We run this test in an own stage since we encountered issues with multiple concurrent calls to the external DB generator.
+          stage("clangDebugSSBTest") {
+            if (env.BRANCH_NAME == 'master' || full_ci) {
+              sh "./scripts/test/hyriseBenchmarkStarSchema_test.py clang-debug"
+            } else {
+              Utils.markStageSkippedForConditional("clangDebugSSBTest")
             }
           }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -155,7 +155,6 @@ try {
                 sh "./scripts/test/hyriseConsole_test.py clang-release"
                 sh "./scripts/test/hyriseServer_test.py clang-release"
                 sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-release"
-                sh "./scripts/test/hyriseBenchmarkStarSchema_test.py clang-release"
                 sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-release"
                 sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
                 sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
@@ -172,14 +171,12 @@ try {
                 sh "./scripts/test/hyriseConsole_test.py clang-debug"
                 sh "./scripts/test/hyriseServer_test.py clang-debug"
                 sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-debug"
-                sh "./scripts/test/hyriseBenchmarkStarSchema_test.py clang-debug"
                 sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-debug"
                 sh "cd clang-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
                 sh "cd clang-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate visualization
                 sh "./scripts/test/hyriseConsole_test.py gcc-debug"
                 sh "./scripts/test/hyriseServer_test.py gcc-debug"
                 sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-debug"
-                sh "./scripts/test/hyriseBenchmarkStarSchema_test.py gcc-debug"
                 sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-debug"
                 sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
                 sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate visualization
@@ -245,7 +242,6 @@ try {
                 sh "./scripts/test/hyriseConsole_test.py gcc-release"
                 sh "./scripts/test/hyriseServer_test.py gcc-release"
                 sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-release"
-                sh "./scripts/test/hyriseBenchmarkStarSchema_test.py gcc-release"
                 sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-release"
                 sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
                 sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
@@ -297,6 +293,25 @@ try {
                 }
               } else {
                 Utils.markStageSkippedForConditional("clangDebugCoverage")
+              }
+            }
+          }
+
+          // We run these test in an own stage since we encountered issues with multiple concurrent calls to the external DB generators.
+          parallel debugSSBTest: {
+            stage("debugSSBTest") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "./scripts/test/hyriseBenchmarkStarSchema_test.py clang-debug"
+              } else {
+                Utils.markStageSkippedForConditional("debugSSBTest")
+              }
+            }
+          }, debugJCCHTest: {
+            stage("debugJCCHTest") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "./scripts/test/hyriseBenchmarkJCCH_test.py clang-debug"
+              } else {
+                Utils.markStageSkippedForConditional("debugJCCHTest")
               }
             }
           }

--- a/scripts/test/hyriseBenchmarkJCCH_test.py
+++ b/scripts/test/hyriseBenchmarkJCCH_test.py
@@ -6,7 +6,7 @@ from hyriseBenchmarkCore import close_benchmark, check_exit_status, initialize, 
 def main():
     build_dir = initialize()
 
-    # Run JCC-H and validate its output using pexpect and check if all queries were successfully verified with sqlite.
+    # Run JCC-H, validate its output using pexpect, and check if all queries were successfully verified with sqlite.
     arguments = {}
     arguments["--scale"] = ".01"
     arguments["--chunk_size"] = "10000"
@@ -33,6 +33,9 @@ def main():
     benchmark.expect_exact("Max runs per item is 100")
     benchmark.expect_exact("Max duration per item is 10 seconds")
     benchmark.expect_exact("Warmup duration per item is 10 seconds")
+    benchmark.expect_exact(
+        "- Automatically verifying results with SQLite. This will make the performance numbers invalid."
+    )
     benchmark.expect_exact("Benchmarking Queries: [ 2, 4, 6 ]")
     benchmark.expect_exact("JCC-H scale factor is 0.01")
     benchmark.expect_exact("Using prepared statements: no")

--- a/scripts/test/hyriseBenchmarkStarSchema_test.py
+++ b/scripts/test/hyriseBenchmarkStarSchema_test.py
@@ -6,7 +6,7 @@ from hyriseBenchmarkCore import close_benchmark, check_exit_status, initialize, 
 def main():
     build_dir = initialize()
 
-    # RunSSB and validate its output using pexpect and check if all queries were successfully verified with sqlite.
+    # Run SSB, validate its output using pexpect, and check if all queries were successfully verified with sqlite.
     arguments = {}
     arguments["--queries"] = "'1.1,1.2,2.2,3.3'"
     arguments["--scale"] = "0.01"

--- a/scripts/test/hyriseConsole_test.py
+++ b/scripts/test/hyriseConsole_test.py
@@ -129,11 +129,11 @@ def main():
     console.sendline("select * from meta_tables")
     console.expect("0 rows total")
 
-    # Test SSB generation.
-    console.sendline("generate_ssb 0.01")
-    console.expect("Generating tables done")
+    # Test TPC-DS generation.
+    console.sendline("generate_tpcds 1")
+    console.expect("Generating tables done", timeout=300)
     console.sendline("select * from meta_tables")
-    console.expect("5 rows total")
+    console.expect("24 rows total")
 
     # Test meta table modification.
     console.sendline("insert into meta_settings values ('foo', 'bar', 'baz')")

--- a/scripts/test/hyriseConsole_test.py
+++ b/scripts/test/hyriseConsole_test.py
@@ -131,7 +131,7 @@ def main():
 
     # Test TPC-DS generation.
     console.sendline("generate_tpcds 1")
-    console.expect("Generating tables done", timeout=300)
+    console.expect("Generating tables done", timeout=600)
     console.sendline("select * from meta_tables")
     console.expect("24 rows total")
 

--- a/src/lib/logical_query_plan/stored_table_node.cpp
+++ b/src/lib/logical_query_plan/stored_table_node.cpp
@@ -61,8 +61,7 @@ void StoredTableNode::set_pruned_column_ids(const std::vector<ColumnID>& pruned_
 
   _pruned_column_ids = pruned_column_ids;
 
-  // Rebuilding this lazily the next time `output_expressions()` is called
-  _output_expressions.reset();
+  _set_output_expressions();
 }
 
 const std::vector<ColumnID>& StoredTableNode::pruned_column_ids() const {
@@ -81,28 +80,8 @@ std::string StoredTableNode::description(const DescriptionMode /*mode*/) const {
 }
 
 std::vector<std::shared_ptr<AbstractExpression>> StoredTableNode::output_expressions() const {
-  // Need to initialize the expressions lazily because (a) they will have a weak_ptr to this node and we can't obtain
-  // that in the constructor and (b) because we don't have column pruning information in the constructor
   if (!_output_expressions) {
-    const auto table = Hyrise::get().storage_manager.get_table(table_name);
-
-    // Build `_expression` with respect to the `_pruned_column_ids`
-    const auto num_unpruned_columns = table->column_count() - _pruned_column_ids.size();
-    _output_expressions = std::vector<std::shared_ptr<AbstractExpression>>(num_unpruned_columns);
-
-    auto pruned_column_ids_iter = _pruned_column_ids.begin();
-    auto output_column_id = ColumnID{0};
-    for (auto stored_column_id = ColumnID{0}; stored_column_id < table->column_count(); ++stored_column_id) {
-      // Skip `stored_column_id` if it is in the sorted vector `_pruned_column_ids`
-      if (pruned_column_ids_iter != _pruned_column_ids.end() && stored_column_id == *pruned_column_ids_iter) {
-        ++pruned_column_ids_iter;
-        continue;
-      }
-
-      (*_output_expressions)[output_column_id] =
-          std::make_shared<LQPColumnExpression>(shared_from_this(), stored_column_id);
-      ++output_column_id;
-    }
+    _set_output_expressions();
   }
 
   return *_output_expressions;
@@ -197,6 +176,29 @@ bool StoredTableNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNo
   const auto& stored_table_node = static_cast<const StoredTableNode&>(rhs);
   return table_name == stored_table_node.table_name && _pruned_chunk_ids == stored_table_node._pruned_chunk_ids &&
          _pruned_column_ids == stored_table_node._pruned_column_ids;
+}
+
+void StoredTableNode::_set_output_expressions() const {
+  const auto& table = Hyrise::get().storage_manager.get_table(table_name);
+  const auto stored_column_count = table->column_count();
+
+  // Create `_output_expressions` sized with respect to the `_pruned_column_ids`
+  const auto unpruned_column_count = stored_column_count - _pruned_column_ids.size();
+  _output_expressions = std::vector<std::shared_ptr<AbstractExpression>>(unpruned_column_count);
+
+  auto pruned_column_ids_iter = _pruned_column_ids.begin();
+  auto output_column_id = ColumnID{0};
+  for (auto stored_column_id = ColumnID{0}; stored_column_id < stored_column_count; ++stored_column_id) {
+    // Skip `stored_column_id` if it is in the sorted vector `_pruned_column_ids`.
+    if (pruned_column_ids_iter != _pruned_column_ids.end() && stored_column_id == *pruned_column_ids_iter) {
+      ++pruned_column_ids_iter;
+      continue;
+    }
+
+    (*_output_expressions)[output_column_id] =
+        std::make_shared<LQPColumnExpression>(shared_from_this(), stored_column_id);
+    ++output_column_id;
+  }
 }
 
 }  // namespace hyrise

--- a/src/lib/logical_query_plan/stored_table_node.hpp
+++ b/src/lib/logical_query_plan/stored_table_node.hpp
@@ -54,6 +54,8 @@ class StoredTableNode : public EnableMakeForLQPNode<StoredTableNode>, public Abs
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const override;
   bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& /*node_mapping*/) const override;
 
+  void _set_output_expressions() const;
+
  private:
   mutable std::optional<std::vector<std::shared_ptr<AbstractExpression>>> _output_expressions;
   std::vector<ChunkID> _pruned_chunk_ids;


### PR DESCRIPTION
Recently, we encountered many CI issues with SSB tests that called the dbgen in in parallel. This PR moves execution of `hyriseBenchmarkStarSchema_test.py` to an own stage and removes SSB data generation from `hyriseConsole_test.py`. Furthermore, an issue with concurrent writes of `StoredtableNode`'s cached output expressions for cached PQPs has been resolved by @Bouncner.