### PR TITLE
[DYOD] Add generic implementation of Parallel Inplace Merge Sort

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -4,13 +4,13 @@
 | ------------------------- | ---------------- | -------- | ------------------------------------- |
 | autoconf                  | >= 2.69          |    All   |                                    No |
 | boost                     | >= 1.70.0        |    All   |                                    No |
-| clang                     | >= 11.0          |    All   |                 Yes, if gcc installed |
-| clang-format              | >= 11.0          |    All   |                      Yes (formatting) |
-| clang-tidy                | >= 11.0          |    All   |                         Yes (linting) |
+| clang                     | >= 13.0          |    All   |                 Yes, if gcc installed |
+| clang-format              | >= 13.0          |    All   |                      Yes (formatting) |
+| clang-tidy                | >= 13.0          |    All   |                         Yes (linting) |
 | coreutils                 | any              |    Mac   |                         Yes (scripts) |
 | cmake                     | >= 3.18          |    All   |                                    No |
 | dos2unix                  | any              |    All   |                         Yes (linting) |
-| gcc                       | >= 9.1           |    All   | Yes, if clang installed, not for OS X |
+| gcc                       | >= 10.0          |    All   | Yes, if clang installed, not for OS X |
 | gcovr                     | >= 3.2           |    All   |                        Yes (coverage) |
 | graphviz                  | any              |    All   |             Yes (query visualization) |
 | libnuma-dev               | any              |    Linux |                            Yes (numa) |

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,9 @@ RUN apt-get update \
         cmake \
         curl \
         dos2unix \
-        g++-9 \
+        g++-10 \
         g++-11 \
-        gcc-9 \
+        gcc-10 \
         gcc-11 \
         gcovr \
         git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
         autoconf \
         bash-completion \
         bc \
-        clang-11 \
+        clang-13 \
         clang-14 \
         clang-format-14 \
         clang-tidy-14 \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,7 +90,7 @@ try {
             clang = '-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++'
             clang11 = '-DCMAKE_C_COMPILER=clang-11 -DCMAKE_CXX_COMPILER=clang++-11'
             gcc = '-DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++'
-            gcc9 = '-DCMAKE_C_COMPILER=gcc-9 -DCMAKE_CXX_COMPILER=g++-9'
+            gcc10 = '-DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10'
 
             debug = '-DCMAKE_BUILD_TYPE=Debug'
             release = '-DCMAKE_BUILD_TYPE=Release'
@@ -114,7 +114,7 @@ try {
             mkdir gcc-debug && cd gcc-debug &&                                                           ${cmake} ${debug}          ${gcc}              .. &\
             mkdir gcc-release && cd gcc-release &&                                                       ${cmake} ${release}        ${gcc}              .. &\
             mkdir clang-11-debug && cd clang-11-debug &&                                                 ${cmake} ${debug}          ${clang11}          .. &\
-            mkdir gcc-9-debug && cd gcc-9-debug &&                                                       ${cmake} ${debug}          ${gcc9}             .. &\
+            mkdir gcc-10-debug && cd gcc-10-debug &&                                                       ${cmake} ${debug}          ${gcc10}             .. &\
             wait"
           }
 
@@ -133,10 +133,10 @@ try {
               sh "cd gcc-debug && make all -j \$(( \$(nproc) / 4))"
               sh "cd gcc-debug && ./hyriseTest"
             }
-          }, gcc9Debug: {
-            stage("gcc-9-debug") {
-              sh "cd gcc-9-debug && make all -j \$(( \$(nproc) / 4))"
-              sh "cd gcc-9-debug && ./hyriseTest"
+          }, gcc10Debug: {
+            stage("gcc-10-debug") {
+              sh "cd gcc-10-debug && make all -j \$(( \$(nproc) / 4))"
+              sh "cd gcc-10-debug && ./hyriseTest"
             }
           }, lint: {
             stage("Linting") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -272,29 +272,6 @@ try {
                 Utils.markStageSkippedForConditional("clangRelWithDebInfoThreadSanitizer")
               }
             }
-          }, clangDebugCoverage: {
-            stage("clang-debug-coverage") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "./scripts/coverage.sh --generate_badge=true"
-                sh "find coverage -type d -exec chmod +rx {} \\;"
-                archive 'coverage_badge.svg'
-                archive 'coverage_percent.txt'
-                publishHTML (target: [
-                  allowMissing: false,
-                  alwaysLinkToLastBuild: false,
-                  keepAll: true,
-                  reportDir: 'coverage',
-                  reportFiles: 'index.html',
-                  reportName: "Llvm-cov_Report"
-                ])
-                script {
-                  coverageChange = sh script: "./scripts/compare_coverage.sh", returnStdout: true
-                  githubNotify context: 'Coverage', description: "$coverageChange", status: 'SUCCESS', targetUrl: "${env.BUILD_URL}/RCov_20Report/index.html"
-                }
-              } else {
-                Utils.markStageSkippedForConditional("clangDebugCoverage")
-              }
-            }
           }
 
           // We run this test in an own stage since we encountered issues with multiple concurrent calls to the external DB generator.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,7 +88,7 @@ try {
             // If you want to upgrade compiler versions, please update install_dependencies.sh,  DEPENDENCIES.md, and
             // the documentation (README, Wiki).
             clang = '-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++'
-            clang11 = '-DCMAKE_C_COMPILER=clang-11 -DCMAKE_CXX_COMPILER=clang++-11'
+            clang13 = '-DCMAKE_C_COMPILER=clang-13 -DCMAKE_CXX_COMPILER=clang++-13'
             gcc = '-DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++'
             gcc10 = '-DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10'
 
@@ -113,7 +113,7 @@ try {
             mkdir clang-relwithdebinfo-thread-sanitizer && cd clang-relwithdebinfo-thread-sanitizer &&   ${cmake} ${relwithdebinfo} ${clang}            -DENABLE_THREAD_SANITIZATION=ON .. &\
             mkdir gcc-debug && cd gcc-debug &&                                                           ${cmake} ${debug}          ${gcc}              .. &\
             mkdir gcc-release && cd gcc-release &&                                                       ${cmake} ${release}        ${gcc}              .. &\
-            mkdir clang-11-debug && cd clang-11-debug &&                                                 ${cmake} ${debug}          ${clang11}          .. &\
+            mkdir clang-13-debug && cd clang-13-debug &&                                                 ${cmake} ${debug}          ${clang13}          .. &\
             mkdir gcc-10-debug && cd gcc-10-debug &&                                                       ${cmake} ${debug}          ${gcc10}             .. &\
             wait"
           }
@@ -123,10 +123,10 @@ try {
               sh "cd clang-debug && make all -j \$(( \$(nproc) / 4))"
               sh "./clang-debug/hyriseTest clang-debug"
             }
-          }, clang11Debug: {
-            stage("clang-11-debug") {
-              sh "cd clang-11-debug && make all -j \$(( \$(nproc) / 4))"
-              sh "./clang-11-debug/hyriseTest clang-11-debug"
+          }, clang13Debug: {
+            stage("clang-13-debug") {
+              sh "cd clang-13-debug && make all -j \$(( \$(nproc) / 4))"
+              sh "./clang-13-debug/hyriseTest clang-13-debug"
             }
           }, gccDebug: {
             stage("gcc-debug") {

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -50,7 +50,7 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
             echo "Installing dependencies (this may take a while)..."
             if sudo apt-get update >/dev/null; then
                 # Packages added here should also be added to the Dockerfile
-                sudo apt-get install --no-install-recommends -y autoconf bash-completion bc clang-11 clang-14 clang-format-14 clang-tidy-14 cmake curl dos2unix g++-9 gcc-9 g++-11 gcc-11 gcovr git graphviz libboost-all-dev libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld man parallel postgresql-server-dev-all python3 python3-pip valgrind &
+                sudo apt-get install --no-install-recommends -y autoconf bash-completion bc clang-11 clang-14 clang-format-14 clang-tidy-14 cmake curl dos2unix g++-10 gcc-10 g++-11 gcc-11 gcovr git graphviz libboost-all-dev libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld man parallel postgresql-server-dev-all python3 python3-pip valgrind &
 
                 if ! git submodule update --jobs 5 --init --recursive; then
                     echo "Error during git fetching submodules."

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -70,8 +70,8 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
                 fi
 
                 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 90 --slave /usr/bin/g++ g++ /usr/bin/g++-11
-                # we use llvm-profdata-11 and llvm-cov-11 due to an unresolved issue with coverage under clang14 (https://github.com/llvm/llvm-project/issues/54907)
-                sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-14 90 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-14 --slave /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-14 --slave /usr/bin/llvm-profdata llvm-profdata /usr/bin/llvm-profdata-11 --slave /usr/bin/llvm-cov llvm-cov /usr/bin/llvm-cov-11 --slave /usr/bin/clang-format clang-format /usr/bin/clang-format-14
+                # we use llvm-profdata-13 and llvm-cov-13 due to an unresolved issue with coverage under clang14 (https://github.com/llvm/llvm-project/issues/54907)
+                sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-14 90 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-14 --slave /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-14 --slave /usr/bin/llvm-profdata llvm-profdata /usr/bin/llvm-profdata-13 --slave /usr/bin/llvm-cov llvm-cov /usr/bin/llvm-cov-13 --slave /usr/bin/clang-format clang-format /usr/bin/clang-format-14
             else
                 echo "Error during installation."
                 exit 1

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -50,7 +50,7 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
             echo "Installing dependencies (this may take a while)..."
             if sudo apt-get update >/dev/null; then
                 # Packages added here should also be added to the Dockerfile
-                sudo apt-get install --no-install-recommends -y autoconf bash-completion bc clang-11 clang-14 clang-format-14 clang-tidy-14 cmake curl dos2unix g++-10 gcc-10 g++-11 gcc-11 gcovr git graphviz libboost-all-dev libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld man parallel postgresql-server-dev-all python3 python3-pip valgrind &
+                sudo apt-get install --no-install-recommends -y autoconf bash-completion bc clang-13 clang-14 clang-format-14 clang-tidy-14 cmake curl dos2unix g++-10 gcc-10 g++-11 gcc-11 gcovr git graphviz libboost-all-dev libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld man parallel postgresql-server-dev-all python3 python3-pip valgrind &
 
                 if ! git submodule update --jobs 5 --init --recursive; then
                     echo "Error during git fetching submodules."

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -33,16 +33,16 @@ fi
 mkdir -p build-coverage
 cd build-coverage
 
-# We use clang 11 for the coverage check as clang 14 (the default clang version for Ubuntu 22.04) has an unresolved
+# We use clang 13 for the coverage check as clang 14 (the default clang version for Ubuntu 22.04) has an unresolved
 # issue (see https://github.com/llvm/llvm-project/issues/54907).
 path_to_compiler=''
-c_compiler='clang-11'
-cxx_compiler='clang++-11'
+c_compiler='clang-13'
+cxx_compiler='clang++-13'
 
 unamestr=$(uname)
 if [[ "$unamestr" == 'Darwin' ]]; then
    # Use homebrew clang for OS X
-   path_to_compiler="$(brew --prefix llvm@11)/bin/"
+   path_to_compiler="$(brew --prefix llvm@13)/bin/"
    c_compiler='clang'
    cxx_compiler='clang++'
 fi

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -657,6 +657,7 @@ set(
     utils/singleton.hpp
     utils/size_estimation_utils.hpp
     utils/small_min_heap.hpp
+    utils/sort_utils.hpp
     utils/sqlite_add_indices.cpp
     utils/sqlite_add_indices.hpp
     utils/sqlite_wrapper.cpp

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -656,6 +656,7 @@ set(
     utils/settings_manager.hpp
     utils/singleton.hpp
     utils/size_estimation_utils.hpp
+    utils/small_min_heap.hpp
     utils/sqlite_add_indices.cpp
     utils/sqlite_add_indices.hpp
     utils/sqlite_wrapper.cpp

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -591,6 +591,7 @@ set(
     utils/assert.hpp
     utils/check_table_equal.cpp
     utils/check_table_equal.hpp
+    utils/comparator_concepts.hpp
     utils/copyable_atomic.hpp
     utils/date_time_utils.cpp
     utils/date_time_utils.hpp

--- a/src/lib/utils/comparator_concepts.hpp
+++ b/src/lib/utils/comparator_concepts.hpp
@@ -8,11 +8,13 @@ namespace hyrise {
 template <typename Comparator, typename T>
 concept BooleanComparator = requires(Comparator comparator, const T& lhs, const T& rhs) {
                               { comparator(lhs, rhs) } -> std::same_as<bool>;
+                              // NOLINTNEXTLINE(readability/braces)
                             };
 
 template <typename Comparator, typename T>
 concept ThreeWayComparator = requires(Comparator comparator, const T& lhs, const T& rhs) {
                                { comparator(lhs, rhs) } -> std::convertible_to<std::partial_ordering>;
+                               // NOLINTNEXTLINE(readability/braces)
                              };
 
 }  // namespace hyrise

--- a/src/lib/utils/comparator_concepts.hpp
+++ b/src/lib/utils/comparator_concepts.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <compare>
+#include <type_traits>
+
+namespace hyrise {
+
+template <typename Comparator, typename T>
+concept BooleanComparator = requires(Comparator comparator, const T& lhs, const T& rhs) {
+                              { comparator(lhs, rhs) } -> std::same_as<bool>;
+                            };
+
+template <typename Comparator, typename T>
+concept ThreeWayComparator = requires(Comparator comparator, const T& lhs, const T& rhs) {
+                               { comparator(lhs, rhs) } -> std::convertible_to<std::partial_ordering>;
+                             };
+
+}  // namespace hyrise

--- a/src/lib/utils/small_min_heap.hpp
+++ b/src/lib/utils/small_min_heap.hpp
@@ -3,8 +3,8 @@
 #include <array>
 #include <cstdint>
 #include <functional>
-#include <ranges>
-#include <span>
+#include <ranges>  // NOLINT(build/include_order)
+#include <span>    // NOLINT(build/include_order)
 
 #include "assert.hpp"
 #include "comparator_concepts.hpp"

--- a/src/lib/utils/small_min_heap.hpp
+++ b/src/lib/utils/small_min_heap.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <functional>

--- a/src/lib/utils/small_min_heap.hpp
+++ b/src/lib/utils/small_min_heap.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
 #include <functional>
 #include <ranges>
+#include <span>
 
 #include "assert.hpp"
 #include "comparator_concepts.hpp"

--- a/src/lib/utils/small_min_heap.hpp
+++ b/src/lib/utils/small_min_heap.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <array>
+#include <functional>
+#include <ranges>
+
+#include "assert.hpp"
+#include "comparator_concepts.hpp"
+
+namespace hyrise {
+
+// Min-Heap optimized for small number of elements that are cheap to move around. Instead of using a complicated layout,
+// the elements of the heap are stored in order in an array and moved back and forth in linear time.
+template <uint8_t max_size, typename T, BooleanComparator<T> Compare = std::less<T>>
+class SmallMinHeap {
+ public:
+  // Constructs a `SmallMinHeap` from a range of initial elements.
+  template <typename R>
+    requires std::ranges::input_range<R> && std::ranges::sized_range<R>
+  explicit SmallMinHeap(R&& initial_elements, Compare init_compare = {}) : _compare(std::move(init_compare)) {
+    const auto size = std::ranges::size(initial_elements);
+    Assert(size <= max_size, "SmallMinHeap got more than max_size initial elements.");
+    _size = static_cast<uint8_t>(size);
+    std::ranges::move(initial_elements, _elements.begin());
+    std::ranges::sort(std::span(_elements).subspan(0, _size), _compare);
+  }
+
+  // Constructs an empty `SmallMinHeap`.
+  explicit SmallMinHeap(Compare init_compare = {}) : SmallMinHeap(std::array<T, 0>{}, std::move(init_compare)) {}
+
+  // Returns the number of elements. Runs in constant time.
+  uint8_t size() const {
+    return _size;
+  }
+
+  // Returns true, if the heap contains any elements. Runs in constant time.
+  bool empty() const {
+    return size() == 0;
+  }
+
+  // Adds an element to the heap. Uses `O(size())` many moves of `T` and `O(log(size()))` many calls to `compare`.
+  void push(T element) {
+    DebugAssert(size() < max_size, "Pushed into already full SmallMinHeap");
+
+    const auto insertion_point =
+        std::ranges::partition_point(_elements.begin(), _elements.begin() + _size,
+                                     [&](const auto& contained) { return !_compare(element, contained); });
+    std::ranges::move_backward(insertion_point, _elements.begin() + _size, _elements.begin() + _size + 1);
+    *insertion_point = std::move(element);
+    ++_size;
+  }
+
+  // Returns the minimal element according to `compare`. Runs in constant time.
+  const T& top() const {
+    return _elements.front();
+  }
+
+  // Removes and returns the top element (see `top()`). Uses `O(size())` many moves of `T`.
+  T pop() {
+    DebugAssert(size() > 0, "Popped from empty SmallMinHeap");
+    auto result = std::move(_elements.front());
+    std::ranges::move(_elements.begin() + 1, _elements.begin() + _size, _elements.begin());
+    --_size;
+    return result;
+  }
+
+ private:
+  std::array<T, max_size> _elements;
+  Compare _compare;
+  uint8_t _size;
+};
+
+}  // namespace hyrise

--- a/src/lib/utils/sort_utils.hpp
+++ b/src/lib/utils/sort_utils.hpp
@@ -1,0 +1,148 @@
+#pragma once
+
+#include <array>
+#include <compare>
+#include <cstdint>
+#include <ranges>
+#include <span>
+#include <utility>
+#include <vector>
+
+#include "assert.hpp"
+#include "comparator_concepts.hpp"
+#include "hyrise.hpp"
+#include "scheduler/job_task.hpp"
+#include "small_min_heap.hpp"
+
+namespace hyrise {
+
+namespace parallel_merge_sort_impl {
+
+// Merges the (evenly spaced, `sublist_count` many) sorted sublists of `input` into one sorted list in the `output`
+// buffer. To provide a stable merge, a three-way comparator needs to be provided, so that in case of equal elements,
+// the list index is used. As `sublist_count` is expected to be small, a `SmallMinHeap` is used instead of a
+// `std::priority_queue`.
+template <typename T, uint8_t sublist_count>
+void multiway_merge_into(const std::span<T> input, const std::span<T> output, ThreeWayComparator<T> auto comparator) {
+  const auto sublist_size = input.size() / sublist_count;
+
+  DebugAssert(sublist_size > 0, "Tried to merge too small lists (at most one is non-empty).");
+
+  auto sublists = std::array<std::span<T>, sublist_count>{};
+  for (auto i = 0; i < sublist_count - 1; ++i) {
+    sublists[i] = input.subspan(i * sublist_size, sublist_size);
+  }
+  const auto last_sublist_start = (sublist_count - 1) * sublist_size;
+  sublists[sublist_count - 1] = input.subspan(last_sublist_start);
+
+  const auto sublist_compare = [&](auto lhs, auto rhs) {
+    DebugAssert(!sublists[lhs].empty(), "Sublist of lhs is empty.");
+    DebugAssert(!sublists[rhs].empty(), "Sublist of rhs is empty.");
+    const auto value_ordering = comparator(sublists[lhs].front(), sublists[rhs].front());
+    if (std::is_eq(value_ordering)) {
+      // Break ties by sorting smaller index first - this is important for stability.
+      return lhs < rhs;
+    }
+    return std::is_lt(value_ordering);
+  };
+
+  auto heap = SmallMinHeap<sublist_count, uint8_t, decltype(sublist_compare)>(sublist_compare);
+  for (auto i = static_cast<uint8_t>(0); i < sublist_count; ++i) {
+    heap.push(i);
+  }
+
+  auto output_iterator = output.begin();
+
+  while (heap.size() > 1) {
+    const auto list_index = heap.pop();
+    auto& list = sublists[list_index];
+    *output_iterator++ = std::move(list.front());
+    list = list.subspan(1);
+    if (!list.empty()) {
+      heap.push(list_index);
+    }
+  }
+
+  if (!heap.empty()) {
+    const auto list_index = heap.pop();
+    DebugAssert(static_cast<ssize_t>(sublists[list_index].size()) == std::distance(output_iterator, output.end()),
+                "Final list size does not match output iterator position.");
+    std::ranges::move(sublists[list_index], output_iterator);
+  } else {
+    DebugAssert(output_iterator == output.end(), "Output iterator at unexpected position.");
+  }
+}
+
+enum class OutputMode {
+  InInput,
+  InScratch,
+};
+
+// The main function of the parallel multiway merge sort. The data from `input` is divided into `fan_out` evenly spaced
+// sublists that are sorted recursively and then merged using the function above. If the input contains at most
+// `base_size` many elements, the recursion stops and a sorting algorithm from the standard library is used. To reduce
+// the number of allocations for merging, there is some scratch space that is kept throughout the entire sorting and
+// reused in the recursive calls. To allow the merging step to only move every value once, the recursive steps need to
+// alternate between moving the data from `input` to `scratch` and keeping it in `input` (that is, moving the
+// recursively sorted data from `scratch` back into `input`).
+template <typename T, uint8_t fan_out, size_t base_size, OutputMode output_mode>
+void sort(const std::span<T> input, const std::span<T> scratch, ThreeWayComparator<T> auto comparator) {
+  // Otherwise, we recurse indefinitely.
+  static_assert(fan_out >= 2);
+
+  if (input.size() <= base_size) {
+    // NOTE: The "stable" is needed for tests (against sqlite) to pass, but I think that it is not actually required by
+    //       the specification.
+    std::ranges::stable_sort(
+        input, [&comparator](const auto& lhs, const auto& rhs) { return std::is_lt(comparator(lhs, rhs)); });
+
+    if constexpr (output_mode == OutputMode::InScratch) {
+      std::ranges::move(input, scratch.begin());
+    }
+
+    return;
+  }
+
+  const auto sublist_size = input.size() / fan_out;
+  // Since input.size() > base_size >= fan_out, we get that sublist_size > 0.
+  static_assert(base_size >= fan_out);
+
+  auto tasks = std::vector<std::shared_ptr<AbstractTask>>(fan_out, nullptr);
+  for (auto i = 0; i < fan_out; ++i) {
+    tasks[i] = std::make_shared<JobTask>([input, scratch, i, sublist_size, &comparator]() {
+      const auto start = i * sublist_size;
+      // The last sublist does not use the rounded-down size.
+      const auto size = i + 1 < fan_out ? sublist_size : input.size() - (fan_out - 1) * sublist_size;
+
+      constexpr auto other_output_mode =
+          output_mode == OutputMode::InInput ? OutputMode::InScratch : OutputMode::InInput;
+
+      sort<T, fan_out, base_size, other_output_mode>(input.subspan(start, size), scratch.subspan(start, size),
+                                                     comparator);
+    });
+  }
+
+  Hyrise::get().scheduler()->schedule_and_wait_for_tasks(tasks);
+
+  if constexpr (output_mode == OutputMode::InInput) {
+    multiway_merge_into<T, fan_out>(scratch, input, comparator);
+  } else {
+    multiway_merge_into<T, fan_out>(input, scratch, comparator);
+  }
+}
+
+}  // namespace parallel_merge_sort_impl
+
+// Stable-sorts `data` in-place (using one extra allocation of scratch space) according to `comparator`.
+//
+// If `data` contains at most `base_size` many elements, a sorting algorithm from the standard library is used,
+// otherwise `fan_out` many sublists are sorted recursively and merged.
+template <typename T, uint8_t fan_out = 2, size_t base_size = 1u << 10u>
+void parallel_inplace_merge_sort(const std::span<T> data, ThreeWayComparator<T> auto comparator) {
+  using namespace parallel_merge_sort_impl;
+
+  auto scratch = std::vector<T>(data.size());
+  sort<T, fan_out, base_size, OutputMode::InInput>(data, scratch, comparator);
+}
+
+}  // namespace hyrise

--- a/src/lib/utils/sort_utils.hpp
+++ b/src/lib/utils/sort_utils.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
 #include <array>
-#include <compare>
+#include <compare>  // NOLINT(build/include_order)
 #include <cstdint>
-#include <ranges>
-#include <span>
+#include <ranges>  // NOLINT(build/include_order)
+#include <span>    // NOLINT(build/include_order)
 #include <utility>
 #include <vector>
 
@@ -139,7 +139,8 @@ void sort(const std::span<T> input, const std::span<T> scratch, ThreeWayComparat
 // otherwise `fan_out` many sublists are sorted recursively and merged.
 template <typename T, uint8_t fan_out = 2, size_t base_size = 1u << 10u>
 void parallel_inplace_merge_sort(const std::span<T> data, ThreeWayComparator<T> auto comparator) {
-  using namespace parallel_merge_sort_impl;
+  using parallel_merge_sort_impl::OutputMode;
+  using parallel_merge_sort_impl::sort;
 
   auto scratch = std::vector<T>(data.size());
   sort<T, fan_out, base_size, OutputMode::InInput>(data, scratch, comparator);

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -241,6 +241,7 @@ set(
     lib/utils/setting_test.cpp
     lib/utils/settings_manager_test.cpp
     lib/utils/singleton_test.cpp
+    lib/utils/small_min_heap_test.cpp
     lib/utils/size_estimation_utils_test.cpp
     lib/utils/string_utils_test.cpp
     plugins/mvcc_delete_plugin_test.cpp

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -242,6 +242,7 @@ set(
     lib/utils/settings_manager_test.cpp
     lib/utils/singleton_test.cpp
     lib/utils/small_min_heap_test.cpp
+    lib/utils/sort_utils_test.cpp
     lib/utils/size_estimation_utils_test.cpp
     lib/utils/string_utils_test.cpp
     plugins/mvcc_delete_plugin_test.cpp

--- a/src/test/lib/utils/small_min_heap_test.cpp
+++ b/src/test/lib/utils/small_min_heap_test.cpp
@@ -1,0 +1,40 @@
+#include "base_test.hpp"
+
+#include "utils/small_min_heap.hpp"
+
+namespace hyrise {
+
+class SmallMinHeapTest : public BaseTest {};
+
+TEST_F(SmallMinHeapTest, Constructor) {
+  const auto heap = SmallMinHeap<8, int>(std::array{4, 1});
+  EXPECT_EQ(heap.size(), 2);
+  EXPECT_EQ(heap.top(), 1);
+}
+
+TEST_F(SmallMinHeapTest, Pop) {
+  auto heap = SmallMinHeap<8, int>(std::array{4, 2});
+  EXPECT_EQ(heap.top(), 2);
+  EXPECT_EQ(heap.pop(), 2);
+  EXPECT_EQ(heap.size(), 1);
+  EXPECT_EQ(heap.top(), 4);
+  EXPECT_EQ(heap.pop(), 4);
+  EXPECT_EQ(heap.size(), 0);
+}
+
+TEST_F(SmallMinHeapTest, Push) {
+  auto heap = SmallMinHeap<8, int>(std::array{4, 2});
+  heap.push(3);
+  EXPECT_EQ(heap.size(), 3);
+  EXPECT_EQ(heap.top(), 2);
+  heap.push(1);
+  EXPECT_EQ(heap.size(), 4);
+  EXPECT_EQ(heap.top(), 1);
+  EXPECT_EQ(heap.pop(), 1);
+  EXPECT_EQ(heap.pop(), 2);
+  EXPECT_EQ(heap.pop(), 3);
+  EXPECT_EQ(heap.pop(), 4);
+  EXPECT_EQ(heap.size(), 0);
+}
+
+}  // namespace hyrise

--- a/src/test/lib/utils/sort_utils_test.cpp
+++ b/src/test/lib/utils/sort_utils_test.cpp
@@ -1,4 +1,3 @@
-#include <random>
 #include <ranges>  // NOLINT(build/include_order)
 #include <vector>
 
@@ -10,15 +9,8 @@ namespace hyrise {
 
 class ParallelInplaceMergeSortTest : public BaseTest {};
 
-TEST_F(ParallelInplaceMergeSortTest, Million) {
-  auto gen = std::mt19937_64(42);
-  auto dist = std::uniform_int_distribution<>(-42, 20'000);
-
-  auto data = std::vector<int>(1'000'000);
-
-  for (auto& element : data) {
-    element = dist(gen);
-  }
+TEST_F(ParallelInplaceMergeSortTest, Ten) {
+  auto data = std::array{23, -3, 10, 3, -23, -31, 5, 36, 0, 25};
 
   const auto comparator3way = [](const auto& lhs, const auto& rhs) { return (lhs + 5) <=> (rhs + 5); };
   const auto comparator = [&comparator3way](const auto& lhs, const auto& rhs) {

--- a/src/test/lib/utils/sort_utils_test.cpp
+++ b/src/test/lib/utils/sort_utils_test.cpp
@@ -1,0 +1,35 @@
+#include <random>
+#include <ranges>
+#include <vector>
+
+#include "base_test.hpp"
+
+#include "utils/sort_utils.hpp"
+
+namespace hyrise {
+
+class ParallelInplaceMergeSortTest : public BaseTest {};
+
+TEST_F(ParallelInplaceMergeSortTest, Million) {
+  auto gen = std::mt19937_64(42);
+  auto dist = std::uniform_int_distribution<>(-42, 20'000);
+
+  auto data = std::vector<int>(1'000'000);
+
+  for (auto& element : data) {
+    element = dist(gen);
+  }
+
+  const auto comparator3way = [](const auto& lhs, const auto& rhs) { return (lhs + 5) <=> (rhs + 5); };
+  const auto comparator = [&comparator3way](const auto& lhs, const auto& rhs) {
+    return std::is_lt(comparator3way(lhs, rhs));
+  };
+
+  auto std_sorted_data = data;
+  std::ranges::sort(std_sorted_data, comparator);
+
+  parallel_inplace_merge_sort<int, 8, 256>(data, comparator3way);
+  EXPECT_EQ(data, std_sorted_data);
+}
+
+}  // namespace hyrise

--- a/src/test/lib/utils/sort_utils_test.cpp
+++ b/src/test/lib/utils/sort_utils_test.cpp
@@ -1,5 +1,5 @@
 #include <random>
-#include <ranges>
+#include <ranges>  // NOLINT(build/include_order)
 #include <vector>
 
 #include "base_test.hpp"


### PR DESCRIPTION
These changes are extracted into a separate PR from our project work on the window function operator, as discussed with supervisors. The main PR will be opened later :)

I broke down the changes into three clean commits, so that you can keep them if you want, but feel free to squash anyways if you feel like it.

Since this uses `span` (and other C++20 features) again, gcc-9 doesn't work. Should I also include the commit updating it here, or open another PR, or do something completely different?