### PR TITLE
Add function prototypes in third-party DB generators

### DIFF
--- a/scripts/test/hyriseServer_test.py
+++ b/scripts/test/hyriseServer_test.py
@@ -49,9 +49,15 @@ def main():
 
     # Not using close_benchmark() here, as a server is started and a timeout of None would wait forever.
     client.close()
-    # Give the server a bit more time to shutdown, see https://github.com/pexpect/pexpect/issues/462
-    server.delayafterterminate = 1  # seconds
-    server.close()
+    
+    # Give the server a bit more time to shut down, see https://github.com/pexpect/pexpect/issues/462.
+    # We found hyriseServer on large machines, such as the CI server, to take a considerable amount of time to boot up
+    # and shut down (e.g., the used CI server in 2023 has 128 hardware threads and thus spawns 128 worker threads). We
+    # use `terminate()` instead of `close()` here. pexpect's `terminate` waits three times before raising a timeout
+    # error as it exposes the underlying PtyProcess's shutdown logic, allowing to modify the delay.
+    # `close` eventually also calls the same shutdown logic, but does not consider the increased delay.
+    server.delayafterterminate = 5  # 5 seconds * 3 tries = 15 seconds overall waiting.
+    server.terminate()
 
 
 if __name__ == "__main__":

--- a/scripts/test/hyriseServer_test.py
+++ b/scripts/test/hyriseServer_test.py
@@ -49,7 +49,7 @@ def main():
 
     # Not using close_benchmark() here, as a server is started and a timeout of None would wait forever.
     client.close()
-    
+
     # Give the server a bit more time to shut down, see https://github.com/pexpect/pexpect/issues/462.
     # We found hyriseServer on large machines, such as the CI server, to take a considerable amount of time to boot up
     # and shut down (e.g., the used CI server in 2023 has 128 hardware threads and thus spawns 128 worker threads). We

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -38,9 +38,9 @@ BenchmarkRunner::BenchmarkRunner(const BenchmarkConfig& config,
   if (!_config.pipeline_metrics) {
     Hyrise::get().default_pqp_cache = std::make_shared<SQLPhysicalPlanCache>();
     Hyrise::get().default_lqp_cache = std::make_shared<SQLLogicalPlanCache>();
-    std::cout << " - SQL plan caching switched on." << std::endl;
+    std::cout << "- SQL plan caching switched on." << std::endl;
   } else {
-    std::cout << " - SQL plan caching switched off since SQL pipeline metrics tracking is requested." << std::endl;
+    std::cout << "- SQL plan caching switched off since SQL pipeline metrics tracking is requested." << std::endl;
   }
 
   // Initialise the scheduler if the benchmark was requested to run multi-threaded.

--- a/src/lib/expression/evaluation/like_matcher.hpp
+++ b/src/lib/expression/evaluation/like_matcher.hpp
@@ -1,9 +1,13 @@
 #pragma once
 
-#include <experimental/functional>
+#include <functional>
 #include <regex>
 #include <utility>
 #include <variant>
+
+#ifndef __cpp_lib_boyer_moore_searcher
+#include <experimental/functional>
+#endif
 
 #include "types.hpp"
 

--- a/src/lib/expression/evaluation/like_matcher.hpp
+++ b/src/lib/expression/evaluation/like_matcher.hpp
@@ -5,10 +5,6 @@
 #include <utility>
 #include <variant>
 
-#ifndef __cpp_lib_boyer_moore_searcher
-#include <experimental/functional>
-#endif
-
 #include "types.hpp"
 
 namespace hyrise {
@@ -21,11 +17,7 @@ namespace hyrise {
  */
 class LikeMatcher {
   // A faster search algorithm than the typical byte-wise search if we can reuse the searcher.
-#ifdef __cpp_lib_boyer_moore_searcher
   using Searcher = std::boyer_moore_searcher<pmr_string::const_iterator>;
-#else
-  using Searcher = std::experimental::boyer_moore_searcher<pmr_string::const_iterator>;
-#endif
 
  public:
   /**

--- a/third_party/tpch-dbgen/driver.c
+++ b/third_party/tpch-dbgen/driver.c
@@ -55,7 +55,8 @@
 
 #define DECLARER				/* EXTERN references get defined here */
 #define NO_FUNC (int (*) ()) NULL	/* to clean up tdefs */
-#define NO_LFUNC (long (*) ()) NULL		/* to clean up tdefs */
+// HYRISE: Add parameter prototype (C2x compatibility).
+#define NO_LFUNC (long (*) (int, DSS_HUGE)) NULL		/* to clean up tdefs */
 
 #include "config.h"
 #include "release.h"
@@ -154,16 +155,17 @@ static int bTableSet = 0;
 /*
 * flat file print functions; used with -F(lat) option
 */
-int pr_cust (customer_t * c, int mode);
-int pr_line (order_t * o, int mode);
-int pr_order (order_t * o, int mode);
-int pr_part (part_t * p, int mode);
-int pr_psupp (part_t * p, int mode);
-int pr_supp (supplier_t * s, int mode);
-int pr_order_line (order_t * o, int mode);
-int pr_part_psupp (part_t * p, int mode);
-int pr_nation (code_t * c, int mode);
-int pr_region (code_t * c, int mode);
+// HYRISE: change first parameter to void pointer so the tdef loader member can have a function prototype (C2x compatibility).
+int pr_cust (void * t, int mode);
+int pr_line (void * t, int mode);
+int pr_order (void * t, int mode);
+int pr_part (void * t, int mode);
+int pr_psupp (void * t, int mode);
+int pr_supp (void * t, int mode);
+int pr_order_line (void * t, int mode);
+int pr_part_psupp (void * t, int mode);
+int pr_nation (void * t, int mode);
+int pr_region (void * t, int mode);
 
 /*
 * seed generation functions; used with '-O s' option

--- a/third_party/tpch-dbgen/dss.h
+++ b/third_party/tpch-dbgen/dss.h
@@ -164,8 +164,9 @@ typedef struct
    char     *name;
    char     *comment;
    DSS_HUGE      base;
-   int       (*loader) ();
-   long      (*gen_seed)();
+   // HYRISE: add function protopytes (C2x compatibility).
+   int       (*loader) (void*, int);
+   long      (*gen_seed)(int, DSS_HUGE);
    int       child;
    DSS_HUGE vtotal;
 }         tdef;

--- a/third_party/tpch-dbgen/dss.h
+++ b/third_party/tpch-dbgen/dss.h
@@ -164,8 +164,8 @@ typedef struct
    char     *name;
    char     *comment;
    DSS_HUGE      base;
-   // HYRISE: add function protopytes (C2x compatibility).
-   int       (*loader) (void*, int);
+   // HYRISE: add function prototypes (C2x compatibility).
+   int       (*loader) (void *, int);
    long      (*gen_seed)(int, DSS_HUGE);
    int       child;
    DSS_HUGE vtotal;

--- a/third_party/tpch-dbgen/dsstypes.h
+++ b/third_party/tpch-dbgen/dsstypes.h
@@ -53,7 +53,8 @@ typedef struct
 }               customer_t;
 /* customers.c */
 long mk_cust   PROTO((DSS_HUGE n_cust, customer_t * c));
-int pr_cust    PROTO((customer_t * c, int mode));
+// HYRISE: change first parameter to void pointer so the tdef loader member can have a function prototype (C2x compatibility).
+int pr_cust    PROTO((void * c, int mode));
 int ld_cust    PROTO((customer_t * c, int mode));
 
 typedef struct
@@ -95,7 +96,8 @@ typedef struct
 
 /* order.c */
 long	mk_order	PROTO((DSS_HUGE index, order_t * o, long upd_num));
-int		pr_order	PROTO((order_t * o, int mode));
+// HYRISE: change first parameter to void pointer so the tdef loader member can have a function prototype (C2x compatibility).
+int		pr_order	PROTO((void * o, int mode));
 int		ld_order	PROTO((order_t * o, int mode));
 void	mk_sparse	PROTO((DSS_HUGE index, DSS_HUGE *ok, long seq));
 
@@ -144,7 +146,8 @@ typedef struct
 }               supplier_t;
 /* supplier.c */
 long mk_supp   PROTO((DSS_HUGE index, supplier_t * s));
-int pr_supp    PROTO((supplier_t * supp, int mode));
+// HYRISE: change first parameter to void pointer so the tdef loader member can have a function prototype (C2x compatibility).
+int pr_supp    PROTO((void * supp, int mode));
 int ld_supp    PROTO((supplier_t * supp, int mode));
 
 typedef struct
@@ -174,9 +177,10 @@ typedef struct
 
 /* code table */
 int mk_nation   PROTO((DSS_HUGE i, code_t * c));
-int pr_nation    PROTO((code_t * c, int mode));
+// HYRISE: change first parameter to void pointer so the tdef loader member can have a function prototype (C2x compatibility).
+int pr_nation    PROTO((void * c, int mode));
 int ld_nation    PROTO((code_t * c, int mode));
 int mk_region   PROTO((DSS_HUGE i, code_t * c));
-int pr_region    PROTO((code_t * c, int mode));
+// HYRISE: change first parameter to void pointer so the tdef loader member can have a function prototype (C2x compatibility).
+int pr_region    PROTO((void * c, int mode));
 int ld_region    PROTO((code_t * c, int mode));
-

--- a/third_party/tpch-dbgen/print.c
+++ b/third_party/tpch-dbgen/print.c
@@ -151,9 +151,10 @@ dbg_print(int format, FILE *target, void *data, int len, int sep)
 }
 
 int
-pr_cust(customer_t *c, int mode)
+pr_cust(void *t, int mode)
 {
-static FILE *fp = NULL;
+   static FILE *fp = NULL;
+   customer_t *c = (customer_t *) t;
         
    if (fp == NULL)
         fp = print_prep(CUST, 0);
@@ -179,10 +180,11 @@ static FILE *fp = NULL;
  * print the numbered order 
  */
 int
-pr_order(order_t *o, int mode)
+pr_order(void *t, int mode)
 {
     static FILE *fp_o = NULL;
     static int last_mode = 0;
+    order_t *o = (order_t *) t;
         
     if (fp_o == NULL || mode != last_mode)
         {
@@ -210,11 +212,12 @@ pr_order(order_t *o, int mode)
  * print an order's lineitems
  */
 int
-pr_line(order_t *o, int mode)
+pr_line(void *t, int mode)
 {
     static FILE *fp_l = NULL;
     static int last_mode = 0;
     long      i;
+    order_t *o = (order_t *) t;
         
     if (fp_l == NULL || mode != last_mode)
         {
@@ -253,7 +256,7 @@ pr_line(order_t *o, int mode)
  * print the numbered order *and* its associated lineitems
  */
 int
-pr_order_line(order_t *o, int mode)
+pr_order_line(void *o, int mode)
 {
     tdefs[ORDER].name = tdefs[ORDER_LINE].name;
     pr_order(o, mode);
@@ -266,9 +269,10 @@ pr_order_line(order_t *o, int mode)
  * print the given part
  */
 int
-pr_part(part_t *part, int mode)
+pr_part(void *t, int mode)
 {
-static FILE *p_fp = NULL;
+    static FILE *p_fp = NULL;
+    part_t *part = (part_t *) t;
 
     if (p_fp == NULL)
         p_fp = print_prep(PART, 0);
@@ -292,10 +296,11 @@ static FILE *p_fp = NULL;
  * print the given part's suppliers
  */
 int
-pr_psupp(part_t *part, int mode)
+pr_psupp(void *t, int mode)
 {
     static FILE *ps_fp = NULL;
     long      i;
+    part_t *part = (part_t *) t;
 
     if (ps_fp == NULL)
         ps_fp = print_prep(PSUPP, mode);
@@ -318,7 +323,7 @@ pr_psupp(part_t *part, int mode)
  * print the given part *and* its suppliers
  */
 int
-pr_part_psupp(part_t *part, int mode)
+pr_part_psupp(void *part, int mode)
 {
     tdefs[PART].name = tdefs[PART_PSUPP].name;
     pr_part(part, mode);
@@ -328,9 +333,10 @@ pr_part_psupp(part_t *part, int mode)
 }
 
 int
-pr_supp(supplier_t *supp, int mode)
+pr_supp(void *t, int mode)
 {
-static FILE *fp = NULL;
+   static FILE *fp = NULL;
+   supplier_t *supp = (supplier_t *) t;
         
    if (fp == NULL)
         fp = print_prep(SUPP, mode);
@@ -349,9 +355,10 @@ static FILE *fp = NULL;
 }
 
 int
-pr_nation(code_t *c, int mode)
+pr_nation(void *t, int mode)
 {
-static FILE *fp = NULL;
+   static FILE *fp = NULL;
+   code_t *c = (code_t *) t;
         
    if (fp == NULL)
         fp = print_prep(NATION, mode);
@@ -367,9 +374,10 @@ static FILE *fp = NULL;
 }
 
 int
-pr_region(code_t *c, int mode)
+pr_region(void *t, int mode)
 {
-static FILE *fp = NULL;
+   static FILE *fp = NULL;
+   code_t *c = (code_t *) t;
         
    if (fp == NULL)
         fp = print_prep(REGION, mode);


### PR DESCRIPTION
Clang-16 complained about missing prototypes in the TPC-DS and TPC-H data generators (deprecated in C2x). This PR adds them if necessary. Furthermore, the `experimental/functional` header is not included anymore in the like matcher. The experimental version is not provided by clang-17 (libc++) anymore, leading to a compilation error (and all CI stages use compilers where the experimental header is not necessary).

Includes hyrise-mp/tpcds-kit#1.
