### PR TITLE
Use TPC-C in Console test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,7 @@ try {
       // Print the hostname to let us know on which node the docker image was executed for reproducibility.
       sh "hostname"
     }
-  
+
     // The empty '' results in using the default registry: https://index.docker.io/v1/
     docker.withRegistry('', 'docker') {
       def hyriseCI = docker.image('hyrise/hyrise-ci:22.04');
@@ -81,7 +81,7 @@ try {
 
             // We don't use unity builds with GCC 9 as it triggers https://github.com/google/googletest/issues/3552
             unity = '-DCMAKE_UNITY_BUILD=ON'
- 
+
             // With Hyrise, we aim to support the most recent compiler versions and do not invest a lot of work to
             // support older versions. We test the oldest LLVM version shipped with Ubuntu 22.04 (i.e., LLVM 11) and
             // GCC 9 (oldest version supported by Hyrise). We execute at least debug runs for them.
@@ -174,12 +174,14 @@ try {
                 sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-debug"
                 sh "cd clang-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
                 sh "cd clang-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate cached data
+                sh "cd clang-debug && ../scripts/test/hyriseBenchmarkStarSchema_test.py ." // Own folder to isolate cached data
                 sh "./scripts/test/hyriseConsole_test.py gcc-debug"
                 sh "./scripts/test/hyriseServer_test.py gcc-debug"
                 sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-debug"
                 sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-debug"
                 sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
                 sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate cached data
+                sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkStarSchema_test.py ." // Own folder to isolate cached data
 
               } else {
                 Utils.markStageSkippedForConditional("debugSystemTests")
@@ -294,15 +296,6 @@ try {
               } else {
                 Utils.markStageSkippedForConditional("clangDebugCoverage")
               }
-            }
-          }
-
-          // We run this test in an own stage since we encountered issues with multiple concurrent calls to the external DB generator.
-          stage("clangDebugSSBTest") {
-            if (env.BRANCH_NAME == 'master' || full_ci) {
-              sh "./scripts/test/hyriseBenchmarkStarSchema_test.py clang-debug"
-            } else {
-              Utils.markStageSkippedForConditional("clangDebugSSBTest")
             }
           }
 
@@ -425,7 +418,7 @@ try {
         if (env.BRANCH_NAME == 'master' || full_ci) {
           try {
             checkout scm
-            
+
             // We do not use install_dependencies.sh here as there is no way to run OS X in a Docker container
             sh "git submodule update --init --recursive --jobs 4 --depth=1"
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ Hyrise is developed for Linux (preferrably the most current Ubuntu version) and 
 ## Supported Benchmarks
 We support a number of benchmarks out of the box. This makes it easy to generate performance numbers without having to set up the data generation, loading CSVs, and finding a query runner. You can run them using the `./hyriseBenchmark*` binaries.
 
-Note that the query plans are generated in our CI pipeline with possibly many stages in parallel. Reported runtimes are not to be taken as solid benchmark performance numbers.
+Note that the query plans are generated in our CI pipeline with possibly many stages in parallel and different CI runs
+might be executed on different machines. Reported runtimes are not to be taken as solid benchmark performance numbers.
 
 | Benchmark   | Notes                                                                                                                    |
 | ----------- | ------------------------------------------------------------------------------------------------------------------------ |

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Hyrise is developed for Linux (preferrably the most current Ubuntu version) and 
 ## Supported Benchmarks
 We support a number of benchmarks out of the box. This makes it easy to generate performance numbers without having to set up the data generation, loading CSVs, and finding a query runner. You can run them using the `./hyriseBenchmark*` binaries.
 
+Note that the query plans are generated in our CI pipeline with possibly many stages in parallel. Reported runtimes are not to be taken as solid benchmark performance numbers.
+
 | Benchmark   | Notes                                                                                                                    |
 | ----------- | ------------------------------------------------------------------------------------------------------------------------ |
 | TPC-DS      | [Query Plans](https://hyrise-ci.epic-hpi.de/job/hyrise/job/hyrise/job/master/lastStableBuild/artifact/query_plans/tpcds) |

--- a/scripts/test/hyriseConsole_test.py
+++ b/scripts/test/hyriseConsole_test.py
@@ -130,8 +130,8 @@ def main():
     console.expect("0 rows total")
 
     # Test TPC-C generation. We also tried different benchmarks here. SSB and JCC-H are not thread-safe due to the
-    # external data generator, leading to problems since this test is executed multiple times. TPC-DS data generation is
-    # quite slow on SF 1 when the CI system is under pressure, causing timeouts regularly.
+    # external data generator, leading to problems since this test is executed multiple times. We consider TPC-DS data
+    # generation too slow to be run regularly within the CI pipeline.
     console.sendline("generate_tpcc 1")
     console.expect("Generating tables done", timeout=600)
     console.sendline("select * from meta_tables")

--- a/scripts/test/hyriseConsole_test.py
+++ b/scripts/test/hyriseConsole_test.py
@@ -112,11 +112,11 @@ def main():
     console.sendline("select sum(a) from test")
     console.expect("840")
 
-    # Test TPCH generation.
+    # Test TPC-H generation.
     console.sendline("generate_tpch     0.01   7")
     console.expect("Generating tables done", timeout=300)
 
-    # Test TPCH tables.
+    # Test TPC-H tables.
     console.sendline("select * from nation")
     console.expect("25 rows total")
 
@@ -129,11 +129,13 @@ def main():
     console.sendline("select * from meta_tables")
     console.expect("0 rows total")
 
-    # Test TPC-DS generation.
-    console.sendline("generate_tpcds 1")
+    # Test TPC-C generation. We also tried different benchmarks here. SSB and JCC-H are not thread-safe due to the
+    # external data generator, leading to problems since this test is executed multiple times. TPC-DS data generation is
+    # quite slow on SF 1 when the CI system is under pressure, causing timeouts regularly.
+    console.sendline("generate_tpcc 1")
     console.expect("Generating tables done", timeout=600)
     console.sendline("select * from meta_tables")
-    console.expect("24 rows total")
+    console.expect("9 rows total")
 
     # Test meta table modification.
     console.sendline("insert into meta_settings values ('foo', 'bar', 'baz')")

--- a/src/lib/statistics/statistics_objects/range_filter.cpp
+++ b/src/lib/statistics/statistics_objects/range_filter.cpp
@@ -78,7 +78,7 @@ std::shared_ptr<AbstractStatisticsObject> RangeFilter<T>::sliced(
       if (value <= iter->first) {
         sliced_ranges.emplace_back(*iter);
       } else {
-        sliced_ranges.emplace_back(std::pair<T, T>{value, iter->second});
+        sliced_ranges.emplace_back(value, iter->second);
       }
       ++iter;
 
@@ -149,10 +149,11 @@ std::unique_ptr<RangeFilter<T>> RangeFilter<T>::build_filter(const pmr_vector<T>
    * std::make_unsigned<T>::type would be possible to use for signed int types, but not for floating types.
    * Approach: take the min and max values and simply check if the distance between both might overflow.
    */
+  static_assert(std::is_signed_v<T>, "Expected a signed arithmetic type.");
   DebugAssert(std::is_sorted(dictionary.cbegin(), dictionary.cend()), "Dictionary must be sorted in ascending order.");
   const auto min = dictionary.front();
   const auto max = dictionary.back();
-  if ((min < 0) && (max > std::numeric_limits<T>::max() + min)) {
+  if ((min < 0) && (max >= std::numeric_limits<T>::max() + min)) {
     return std::make_unique<RangeFilter<T>>(std::vector<std::pair<T, T>>{{min, max}});
   }
 

--- a/src/lib/statistics/statistics_objects/range_filter.cpp
+++ b/src/lib/statistics/statistics_objects/range_filter.cpp
@@ -292,8 +292,8 @@ bool RangeFilter<T>::does_not_contain(const PredicateCondition predicate_conditi
 
       // Case (iii): The predicate can match the segment's values. However, the predicate values can be exactly in a gap
       //             between two ranges (e.g., a BETWEEN 5 AND 6).
-      //             We know that y >(=) 2. Thus, we find the range that starts at an element >= y. If we cannot find
-      //             such a range, y is greater than the maximum (and thus, in a gap).
+      //             We know that y >(=) 2. Thus, we find the range whose minimum is >= y. If we cannot find such a
+      //             range, y is greater than the segment's maximum (and thus, in a gap).
       const auto upper_bound_range =
           std::lower_bound(ranges.cbegin(), ranges.cend(), value2,
                            [](const auto& range, const auto compare_value) { return range.first < compare_value; });

--- a/src/lib/statistics/statistics_objects/range_filter.cpp
+++ b/src/lib/statistics/statistics_objects/range_filter.cpp
@@ -17,7 +17,7 @@ namespace hyrise {
 template <typename T>
 RangeFilter<T>::RangeFilter(std::vector<std::pair<T, T>> init_ranges)
     : AbstractStatisticsObject(data_type_from_type<T>()), ranges(std::move(init_ranges)) {
-  DebugAssert(!ranges.empty(), "Cannot construct empty RangeFilter");
+  DebugAssert(!ranges.empty(), "Cannot construct empty RangeFilter.");
 }
 
 template <typename T>
@@ -28,7 +28,7 @@ Cardinality RangeFilter<T>::estimate_cardinality(const PredicateCondition /*pred
   // is estimated assuming equi-distribution). For that, we would also need the cardinality of the underlying data.
   // Currently, as RangeFilters are on a per-segment basis and estimate_cardinality is called for an entire column,
   // there is no use for this.
-  Fail("Currently, RangeFilters cannot be used to estimate cardinalities");
+  Fail("Currently, RangeFilters cannot be used to estimate cardinalities.");
 }
 
 template <typename T>
@@ -103,8 +103,7 @@ std::shared_ptr<AbstractStatisticsObject> RangeFilter<T>::sliced(
       sliced_ranges = ranges;
   }
 
-  DebugAssert(!sliced_ranges.empty(), "As does_not_contain was false, the sliced_ranges should not be empty");
-
+  DebugAssert(!sliced_ranges.empty(), "As does_not_contain() was false, the sliced_ranges should not be empty.");
   return std::make_shared<RangeFilter<T>>(sliced_ranges);
 }
 
@@ -118,11 +117,10 @@ std::unique_ptr<RangeFilter<T>> RangeFilter<T>::build_filter(const pmr_vector<T>
                                                              uint32_t max_ranges_count) {
   // See #1536
   static_assert(std::is_arithmetic_v<T>, "Range filters are only allowed on arithmetic types.");
-
   DebugAssert(max_ranges_count > 0, "Number of ranges to create needs to be larger zero.");
 
+  // Empty dictionaries will, e.g., occur in segments with only NULLs - or empty segments.
   if (dictionary.empty()) {
-    // Empty dictionaries will, e.g., occur in segments with only NULLs - or empty segments.
     return nullptr;
   }
 
@@ -143,7 +141,7 @@ std::unique_ptr<RangeFilter<T>> RangeFilter<T>::build_filter(const pmr_vector<T>
   DebugAssert(std::is_sorted(dictionary.cbegin(), dictionary.cend()), "Dictionary must be sorted in ascending order.");
   const auto min = dictionary.front();
   const auto max = dictionary.back();
-  // max > std::numeric_limits<T>::max() + min would the correct mathematic assumption. However, it only works for
+  // max > std::numeric_limits<T>::max() + min would the mathematically correct assumption. However, it only works for
   // integral types. For floating-point types, the precision is not high enough to differentiate, e.g., max - 1 from
   // max. While in theory sacrificing one value, we account for this imprecision.
   if ((min < 0) && (max >= std::numeric_limits<T>::max() + min)) {
@@ -179,7 +177,7 @@ std::unique_ptr<RangeFilter<T>> RangeFilter<T>::build_filter(const pmr_vector<T>
   auto distances = std::vector<std::pair<T, size_t>>{};
   distances.reserve(dictionary.size() - 1);
   for (auto dict_it = dictionary.cbegin(); dict_it + 1 != dictionary.cend(); ++dict_it) {
-    auto dict_it_next = dict_it + 1;
+    const auto dict_it_next = dict_it + 1;
     distances.emplace_back(*dict_it_next - *dict_it, std::distance(dictionary.cbegin(), dict_it));
   }
 

--- a/src/lib/statistics/statistics_objects/range_filter.cpp
+++ b/src/lib/statistics/statistics_objects/range_filter.cpp
@@ -55,12 +55,12 @@ std::shared_ptr<AbstractStatisticsObject> RangeFilter<T>::sliced(
 
       // Copy all the ranges before the value.
       auto iter = ranges.cbegin();
-      for (; iter != ranges.cend(); ++iter) {
+      for (; iter != end_iter; ++iter) {
         sliced_ranges.emplace_back(*iter);
       }
 
       // If value is not in a gap, limit the last range's upper bound to value.
-      if (value >= iter->first) {
+      if (iter != ranges.cend() && value >= iter->first) {
         sliced_ranges.emplace_back(std::pair<T, T>{iter->first, value});
       }
     } break;

--- a/src/lib/statistics/statistics_objects/range_filter.cpp
+++ b/src/lib/statistics/statistics_objects/range_filter.cpp
@@ -130,7 +130,6 @@ std::unique_ptr<RangeFilter<T>> RangeFilter<T>::build_filter(const pmr_vector<T>
   static_assert(std::is_arithmetic_v<T>, "Range filters are only allowed on arithmetic types.");
 
   DebugAssert(max_ranges_count > 0, "Number of ranges to create needs to be larger zero.");
-  DebugAssert(std::is_sorted(dictionary.begin(), dictionary.cend()), "Dictionary must be sorted in ascending order.");
 
   if (dictionary.empty()) {
     // Empty dictionaries will, e.g., occur in segments with only NULLs - or empty segments.
@@ -148,9 +147,9 @@ std::unique_ptr<RangeFilter<T>> RangeFilter<T>::build_filter(const pmr_vector<T>
    * effectively degrades to a MinMaxFilter (i.e., stores only a single range).
    * While being rather unlikely for doubles, it's more likely to happen when Hyrise includes tinyint etc.
    * std::make_unsigned<T>::type would be possible to use for signed int types, but not for floating types.
-   * Approach: take the min and max values and simply check if the distance between both might overflow. We (debug-)
-   * asserted that the dictionary is sorted before, so we simply access its first and last element.
+   * Approach: take the min and max values and simply check if the distance between both might overflow.
    */
+  DebugAssert(std::is_sorted(dictionary.cbegin(), dictionary.cend()), "Dictionary must be sorted in ascending order.");
   const auto min = dictionary.front();
   const auto max = dictionary.back();
   if ((min < 0) && (max > std::numeric_limits<T>::max() + min)) {

--- a/src/lib/statistics/statistics_objects/range_filter.cpp
+++ b/src/lib/statistics/statistics_objects/range_filter.cpp
@@ -55,7 +55,7 @@ std::shared_ptr<AbstractStatisticsObject> RangeFilter<T>::sliced(
 
       // Copy all the ranges before the value.
       auto iter = ranges.cbegin();
-      for (; iter != end_iter; ++iter) {
+      for (; iter != ranges.cend(); ++iter) {
         sliced_ranges.emplace_back(*iter);
       }
 

--- a/src/lib/statistics/statistics_objects/range_filter.cpp
+++ b/src/lib/statistics/statistics_objects/range_filter.cpp
@@ -61,7 +61,7 @@ std::shared_ptr<AbstractStatisticsObject> RangeFilter<T>::sliced(
 
       // If value is not in a gap, limit the last range's upper bound to value.
       if (iter != ranges.cend() && value >= iter->first) {
-        sliced_ranges.emplace_back(std::pair<T, T>{iter->first, value});
+        sliced_ranges.emplace_back(iter->first, value);
       }
     } break;
     case PredicateCondition::GreaterThan:

--- a/src/lib/statistics/statistics_objects/range_filter.cpp
+++ b/src/lib/statistics/statistics_objects/range_filter.cpp
@@ -143,9 +143,9 @@ std::unique_ptr<RangeFilter<T>> RangeFilter<T>::build_filter(const pmr_vector<T>
   DebugAssert(std::is_sorted(dictionary.cbegin(), dictionary.cend()), "Dictionary must be sorted in ascending order.");
   const auto min = dictionary.front();
   const auto max = dictionary.back();
-  // max > std::numeric_limits<T>::max() + min would in theory be the correct assumption. However, it only works for
+  // max > std::numeric_limits<T>::max() + min would the correct mathematic assumption. However, it only works for
   // integral types. For floating-point types, the precision is not high enough to differentiate, e.g., max - 1 from
-  // max. While in sacrificing one value, we account for this imprecision.
+  // max. While in theory sacrificing one value, we account for this imprecision.
   if ((min < 0) && (max >= std::numeric_limits<T>::max() + min)) {
     return std::make_unique<RangeFilter<T>>(std::vector<std::pair<T, T>>{{min, max}});
   }

--- a/src/lib/statistics/statistics_objects/range_filter.cpp
+++ b/src/lib/statistics/statistics_objects/range_filter.cpp
@@ -126,7 +126,6 @@ std::unique_ptr<RangeFilter<T>> RangeFilter<T>::build_filter(const pmr_vector<T>
     return nullptr;
   }
 
-  DebugAssert(std::is_sorted(dictionary.cbegin(), dictionary.cend()), "Dictionary must be sorted in ascending order.");
   if (dictionary.size() == 1) {
     auto ranges = std::vector<std::pair<T, T>>{{dictionary.front(), dictionary.front()}};
     return std::make_unique<RangeFilter<T>>(std::move(ranges));
@@ -140,8 +139,8 @@ std::unique_ptr<RangeFilter<T>> RangeFilter<T>::build_filter(const pmr_vector<T>
    * std::make_unsigned<T>::type would be possible to use for signed int types, but not for floating types.
    * Approach: take the min and max values and simply check if the distance between both might overflow.
    */
-  // TODO: comment for >= (floating-point precision)
   static_assert(std::is_signed_v<T>, "Expected a signed arithmetic type.");
+  DebugAssert(std::is_sorted(dictionary.cbegin(), dictionary.cend()), "Dictionary must be sorted in ascending order.");
   const auto min = dictionary.front();
   const auto max = dictionary.back();
   // max > std::numeric_limits<T>::max() + min would in theory be the correct assumption. However, it only works for

--- a/src/lib/statistics/statistics_objects/range_filter.cpp
+++ b/src/lib/statistics/statistics_objects/range_filter.cpp
@@ -55,7 +55,7 @@ std::shared_ptr<AbstractStatisticsObject> RangeFilter<T>::sliced(
 
       // Copy all the ranges before the value.
       auto iter = ranges.cbegin();
-      for (; iter != end_iter; iter++) {
+      for (; iter != end_iter; ++iter) {
         sliced_ranges.emplace_back(*iter);
       }
 

--- a/src/lib/statistics/statistics_objects/range_filter.cpp
+++ b/src/lib/statistics/statistics_objects/range_filter.cpp
@@ -141,8 +141,8 @@ std::unique_ptr<RangeFilter<T>> RangeFilter<T>::build_filter(const pmr_vector<T>
   DebugAssert(std::is_sorted(dictionary.cbegin(), dictionary.cend()), "Dictionary must be sorted in ascending order.");
   const auto min = dictionary.front();
   const auto max = dictionary.back();
-  // max > std::numeric_limits<T>::max() + min would the mathematically correct assumption. However, it only works for
-  // integral types. For floating-point types, the precision is not high enough to differentiate, e.g., max - 1 from
+  // max > std::numeric_limits<T>::max() + min would be the mathematically correct assumption. However, it only works
+  // for integral types. For floating-point types, the precision is not high enough to differentiate, e.g., max - 1 from
   // max. While in theory sacrificing one value, we account for this imprecision.
   if ((min < 0) && (max >= std::numeric_limits<T>::max() + min)) {
     return std::make_unique<RangeFilter<T>>(std::vector<std::pair<T, T>>{{min, max}});

--- a/src/lib/strong_typedef.hpp
+++ b/src/lib/strong_typedef.hpp
@@ -65,6 +65,9 @@
     static typename std::enable_if_t<std::is_arithmetic_v<T>, ::hyrise::D> max() {                                \
       return ::hyrise::D(numeric_limits<T>::max());                                                               \
     }                                                                                                             \
+    static typename std::enable_if_t<std::is_arithmetic_v<T>, ::hyrise::D> lowest() {                             \
+      return ::hyrise::D(numeric_limits<T>::lowest());                                                            \
+    }                                                                                                             \
   };                                                                                                              \
   } /* NOLINT */                                                                                                  \
   namespace hyrise {                                                                                              \

--- a/src/test/lib/statistics/statistics_objects/range_filter_test.cpp
+++ b/src/test/lib/statistics/statistics_objects/range_filter_test.cpp
@@ -19,8 +19,8 @@ template <typename T>
 class RangeFilterTest : public BaseTest {
  protected:
   void SetUp() override {
-    // Manually created vector. Largest exlusive gap (only gap when gap_count == 1) will
-    // be 103-123456, second largest -1000 to 2, third 17-100.
+    // Manually created vector. Largest exclusive gap (only gap when gap_count == 1) will be 103-123456, second largest
+    // -1000 to 2, third 17-100.
     _values = pmr_vector<T>{-1000, 2, 3, 4, 7, 8, 10, 17, 100, 101, 102, 103, 123456};
 
     _min_value = *std::min_element(std::begin(_values), std::end(_values));
@@ -28,8 +28,8 @@ class RangeFilterTest : public BaseTest {
 
     // `_value_in_gap` in a value in the largest gap of the test data.
     _value_in_gap = T{1024};
-    _value_smaller_than_minimum = _min_value - 1;  // value smaller than the minimum
-    _value_larger_than_maximum = _max_value + 1;   // value larger than the maximum
+    _value_smaller_than_minimum = _min_value - 1;  // Value smaller than the minimum.
+    _value_larger_than_maximum = _max_value + 1;   // Value larger than the maximum.
   }
 
   pmr_vector<T> _values;
@@ -46,9 +46,9 @@ TYPED_TEST(RangeFilterTest, ValueRangeTooLarge) {
   const pmr_vector<TypeParam> test_vector{static_cast<TypeParam>(0.9 * lowest), static_cast<TypeParam>(0.8 * lowest),
                                           static_cast<TypeParam>(0.8 * max), static_cast<TypeParam>(0.9 * max)};
 
-  // The filter will not create 5 ranges due to potential overflow problems when calculating
-  // distances. In this case, only a filter with a single range is built.
-  auto filter = RangeFilter<TypeParam>::build_filter(test_vector, 5);
+  // The filter will not create 5 ranges due to potential overflow problems when calculating distances. In this case,
+  // only a filter with a single range is built.
+  const auto filter = RangeFilter<TypeParam>::build_filter(test_vector, 5);
   // Having only one range means the filter cannot prune 0 right in the largest gap.
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Equals, TypeParam{0}));
 
@@ -61,14 +61,14 @@ TYPED_TEST(RangeFilterTest, ThrowOnUnsortedData) {
     GTEST_SKIP();
   }
 
-  const pmr_vector<TypeParam> test_vector{std::numeric_limits<TypeParam>::max(),
-                                          std::numeric_limits<TypeParam>::lowest()};
+  const auto test_vector =
+      pmr_vector<TypeParam>{std::numeric_limits<TypeParam>::max(), std::numeric_limits<TypeParam>::lowest()};
 
   // Additional parantheses needed for template macro expansion.
   EXPECT_THROW((RangeFilter<TypeParam>::build_filter(test_vector, 5)), std::logic_error);
 }
 
-// a single range is basically a min/max filter
+// A single range is basically a min/max filter.
 TYPED_TEST(RangeFilterTest, SingleRange) {
   const auto filter = RangeFilter<TypeParam>::build_filter(this->_values, 1);
 
@@ -76,11 +76,11 @@ TYPED_TEST(RangeFilterTest, SingleRange) {
     EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Equals, {value}));
   }
 
-  // testing for interval bounds
+  // Testing for interval bounds.
   EXPECT_TRUE(filter->does_not_contain(PredicateCondition::LessThan, {this->_min_value}));
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::GreaterThan, {this->_min_value}));
 
-  // cannot prune values in between, even though non-existent
+  // Cannot prune values in between, even though non-existent.
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Equals, TypeParam{this->_value_in_gap}));
 
   EXPECT_TRUE(filter->does_not_contain(PredicateCondition::BetweenInclusive, TypeParam{-3000}, TypeParam{-2000}));
@@ -89,7 +89,7 @@ TYPED_TEST(RangeFilterTest, SingleRange) {
   EXPECT_TRUE(filter->does_not_contain(PredicateCondition::GreaterThan, {this->_max_value}));
 }
 
-// create range filters with varying number of ranges/gaps
+// Create range filters with varying number of ranges/gaps.
 TYPED_TEST(RangeFilterTest, MultipleRanges) {
   const auto first_gap_min = TypeParam{104};
   const auto first_gap_max = TypeParam{123455};
@@ -119,7 +119,7 @@ TYPED_TEST(RangeFilterTest, MultipleRanges) {
 
     EXPECT_FALSE(filter->does_not_contain(PredicateCondition::BetweenInclusive, third_gap_min, third_gap_max));
   }
-  // starting with 4 ranges, all tested gaps should be covered
+  // Starting with four ranges, all tested gaps should be covered.
   for (const auto range_count : {4, 5, 100, 1'000}) {
     {
       const auto filter = RangeFilter<TypeParam>::build_filter(this->_values, range_count);
@@ -142,7 +142,7 @@ TYPED_TEST(RangeFilterTest, MultipleRanges) {
   }
 }
 
-// create more ranges than distinct values in the test data
+// Create more ranges than distinct values in the test data.
 TYPED_TEST(RangeFilterTest, MoreRangesThanValues) {
   const auto filter = RangeFilter<TypeParam>::build_filter(this->_values, 10'000);
 
@@ -158,8 +158,8 @@ TYPED_TEST(RangeFilterTest, MoreRangesThanValues) {
   EXPECT_TRUE(filter->does_not_contain(PredicateCondition::GreaterThan, TypeParam{this->_max_value}));
 }
 
-// this test checks the correct pruning on the bounds (min/max) of the test data for various predicate conditions
-// for better understanding, see min_max_filter_test.cpp
+// This test checks the correct pruning on the bounds (min/max) of the test data for various predicate conditions
+// For better understanding, see min_max_filter_test.cpp.
 TYPED_TEST(RangeFilterTest, CanPruneOnBounds) {
   const auto filter = RangeFilter<TypeParam>::build_filter(this->_values);
 
@@ -216,12 +216,13 @@ TYPED_TEST(RangeFilterTest, Between) {
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::BetweenInclusive, TypeParam{101}, TypeParam{103}));
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::BetweenInclusive, TypeParam{102}, TypeParam{1004}));
 
-  // SQL's between is inclusive
+  // SQL's between is inclusive.
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::BetweenInclusive, TypeParam{103}, TypeParam{123456}));
 
-  // TODO(bensk1): as soon as non-inclusive between predicates are implemented, testing
-  // a non-inclusive between with the bounds exactly on the value bounds would be humongous:
-  //  EXPECT_TRUE(filter->does_not_contain(PredicateCondition::BetweenNONINCLUSIVE, TypeParam{103}, TypeParam{123456}));
+  // TODO(dey4ss): Implement.
+  // EXPECT_TRUE(filter->does_not_contain(PredicateCondition::BetweenExclusive, TypeParam{103}, TypeParam{123456}));
+  // EXPECT_TRUE(filter->does_not_contain(PredicateCondition::BetweenLowerExclusive, TypeParam{103}, TypeParam{123455}));  // NOLINT(whitespace/line_length)
+  // EXPECT_TRUE(filter->does_not_contain(PredicateCondition::BetweenUpperExclusive, TypeParam{104}, TypeParam{123456}));  // NOLINT(whitespace/line_length)
 }
 
 // Test larger value ranges.
@@ -229,14 +230,15 @@ TYPED_TEST(RangeFilterTest, LargeValueRange) {
   const auto lowest = std::numeric_limits<TypeParam>::lowest();
   const auto max = std::numeric_limits<TypeParam>::max();
 
-  const pmr_vector<TypeParam> values{static_cast<TypeParam>(0.4 * lowest),  static_cast<TypeParam>(0.38 * lowest),
-                                     static_cast<TypeParam>(0.36 * lowest), static_cast<TypeParam>(0.30 * lowest),
-                                     static_cast<TypeParam>(0.28 * lowest), static_cast<TypeParam>(0.36 * max),
-                                     static_cast<TypeParam>(0.38 * max),    static_cast<TypeParam>(0.4 * max)};
+  const auto values =
+      pmr_vector<TypeParam>{static_cast<TypeParam>(0.4 * lowest),  static_cast<TypeParam>(0.38 * lowest),
+                            static_cast<TypeParam>(0.36 * lowest), static_cast<TypeParam>(0.30 * lowest),
+                            static_cast<TypeParam>(0.28 * lowest), static_cast<TypeParam>(0.36 * max),
+                            static_cast<TypeParam>(0.38 * max),    static_cast<TypeParam>(0.4 * max)};
 
   const auto filter = RangeFilter<TypeParam>::build_filter(values, 3);
 
-  // A filter with 3 ranges, has two gaps: (i) 0.28*lowest-0.36*max and (ii) 0.36*lowest-0.30*lowest
+  // A filter with three ranges has two gaps: (i) 0.28*lowest-0.36*max and (ii) 0.36*lowest-0.30*lowest
   EXPECT_TRUE(filter->does_not_contain(PredicateCondition::BetweenInclusive, static_cast<TypeParam>(0.27 * lowest),
                                        static_cast<TypeParam>(0.35 * max)));
   EXPECT_TRUE(filter->does_not_contain(PredicateCondition::BetweenInclusive, static_cast<TypeParam>(0.35 * lowest),
@@ -317,9 +319,37 @@ TYPED_TEST(RangeFilterTest, SliceWithPredicateReturnsNullptr) {
   EXPECT_EQ(filter->sliced(PredicateCondition::GreaterThan, this->_max_value), nullptr);
 }
 
+TYPED_TEST(RangeFilterTest, HugeGaps) {
+  // We build the RangeFilter by calculating distances between values. By definition, these differences are positive.
+  // Thus, we fall back to a MinMaxFilter (RangeFilter with one range) if the requested min and max values have a
+  // distance that is larger than the maximal possible value of the data type.
+
+  // min() is not(!) the smallest value for floating-point types, see
+  // https://en.cppreference.com/w/cpp/types/numeric_limits/min
+  const auto min = std::numeric_limits<TypeParam>::lowest();
+  const auto max = std::numeric_limits<TypeParam>::max();
+
+  // The distance from min to max is obviously larger than max, so fall back.
+  const auto range_min_to_max = pmr_vector<TypeParam>{min, min + TypeParam{1}, max - TypeParam{1}, max};
+  auto range_filter = RangeFilter<TypeParam>::build_filter(range_min_to_max);
+  auto expected_range = std::vector<std::pair<TypeParam, TypeParam>>{{min, max}};
+  EXPECT_EQ(range_filter->ranges, expected_range);
+
+  // The same is true for [min, ... , 1] and [-1, ... , max].
+  const auto range_min_to_one = pmr_vector<TypeParam>{min, min + TypeParam{1}, TypeParam{-1}, TypeParam{1}};
+  range_filter = RangeFilter<TypeParam>::build_filter(range_min_to_one);
+  expected_range = std::vector<std::pair<TypeParam, TypeParam>>{{min, TypeParam{1}}};
+  EXPECT_EQ(range_filter->ranges, expected_range);
+
+  const auto range_minus_one_to_max = pmr_vector<TypeParam>{TypeParam{-1}, TypeParam{1}, max - TypeParam{1}, max};
+  range_filter = RangeFilter<TypeParam>::build_filter(range_minus_one_to_max);
+  expected_range = std::vector<std::pair<TypeParam, TypeParam>>{{TypeParam{-1}, max}};
+  EXPECT_EQ(range_filter->ranges, expected_range);
+}
+
 class RangeFilterTestUntyped : public BaseTest {};
 
-// Test predicates which are not supported by the range filter
+// Test predicates which are not supported by the range filter.
 TEST_F(RangeFilterTestUntyped, DoNotPruneUnsupportedPredicates) {
   const pmr_vector<int> values{-1000, -900, 900, 1000};
   const auto filter = RangeFilter<int>::build_filter(values);

--- a/src/test/lib/statistics/statistics_objects/range_filter_test.cpp
+++ b/src/test/lib/statistics/statistics_objects/range_filter_test.cpp
@@ -351,18 +351,24 @@ TYPED_TEST(RangeFilterTest, SlicedWithUnmatchingPredicates) {
 
   EXPECT_FALSE(filter->sliced(PredicateCondition::LessThan, this->_min_value));
   EXPECT_TRUE(filter->sliced(PredicateCondition::LessThanEquals, this->_min_value));
+  EXPECT_FALSE(filter->sliced(PredicateCondition::LessThanEquals, lower_bound));
   EXPECT_TRUE(filter->sliced(PredicateCondition::GreaterThanEquals, this->_max_value));
+  EXPECT_FALSE(filter->sliced(PredicateCondition::GreaterThanEquals, upper_bound));
   EXPECT_FALSE(filter->sliced(PredicateCondition::GreaterThan, this->_max_value));
 
   EXPECT_FALSE(filter->sliced(PredicateCondition::BetweenExclusive, lower_bound, this->_min_value));
   EXPECT_TRUE(filter->sliced(PredicateCondition::BetweenInclusive, lower_bound, this->_min_value));
+  EXPECT_FALSE(filter->sliced(PredicateCondition::BetweenInclusive, lower_bound, lower_bound));
   EXPECT_TRUE(filter->sliced(PredicateCondition::BetweenLowerExclusive, lower_bound, this->_min_value));
+  EXPECT_FALSE(filter->sliced(PredicateCondition::BetweenLowerExclusive, lower_bound, lower_bound));
   EXPECT_FALSE(filter->sliced(PredicateCondition::BetweenUpperExclusive, lower_bound, this->_min_value));
 
   EXPECT_FALSE(filter->sliced(PredicateCondition::BetweenExclusive, this->_max_value, upper_bound));
   EXPECT_TRUE(filter->sliced(PredicateCondition::BetweenInclusive, this->_max_value, upper_bound));
+  EXPECT_FALSE(filter->sliced(PredicateCondition::BetweenInclusive, upper_bound, upper_bound));
   EXPECT_FALSE(filter->sliced(PredicateCondition::BetweenLowerExclusive, this->_max_value, upper_bound));
   EXPECT_TRUE(filter->sliced(PredicateCondition::BetweenUpperExclusive, this->_max_value, upper_bound));
+  EXPECT_FALSE(filter->sliced(PredicateCondition::BetweenUpperExclusive, upper_bound, upper_bound));
 }
 
 class RangeFilterTestUntyped : public BaseTest {};

--- a/src/test/lib/statistics/statistics_objects/range_filter_test.cpp
+++ b/src/test/lib/statistics/statistics_objects/range_filter_test.cpp
@@ -338,21 +338,27 @@ TYPED_TEST(RangeFilterTest, Sliced) {
   EXPECT_EQ(min_max_filter->max, 7);
 }
 
-TYPED_TEST(RangeFilterTest, SliceWithUnmatchingPredicates) {
+TYPED_TEST(RangeFilterTest, SlicedWithUnmatchingPredicates) {
   const auto filter = RangeFilter<TypeParam>::build_filter(this->_values, 5);
+  const auto lower_bound = this->_min_value - TypeParam{1};
+  const auto upper_bound = this->_max_value + TypeParam{1};
+
+  EXPECT_FALSE(filter->sliced(PredicateCondition::Equals, lower_bound));
+  EXPECT_FALSE(filter->sliced(PredicateCondition::Equals, upper_bound));
+
+  const auto one_element_filter = RangeFilter<TypeParam>::build_filter({TypeParam{1}});
+  EXPECT_FALSE(one_element_filter->sliced(PredicateCondition::NotEquals, TypeParam{1}));
 
   EXPECT_FALSE(filter->sliced(PredicateCondition::LessThan, this->_min_value));
   EXPECT_TRUE(filter->sliced(PredicateCondition::LessThanEquals, this->_min_value));
   EXPECT_TRUE(filter->sliced(PredicateCondition::GreaterThanEquals, this->_max_value));
   EXPECT_FALSE(filter->sliced(PredicateCondition::GreaterThan, this->_max_value));
 
-  const auto lower_bound = this->_min_value - TypeParam{1};
   EXPECT_FALSE(filter->sliced(PredicateCondition::BetweenExclusive, lower_bound, this->_min_value));
   EXPECT_TRUE(filter->sliced(PredicateCondition::BetweenInclusive, lower_bound, this->_min_value));
   EXPECT_TRUE(filter->sliced(PredicateCondition::BetweenLowerExclusive, lower_bound, this->_min_value));
   EXPECT_FALSE(filter->sliced(PredicateCondition::BetweenUpperExclusive, lower_bound, this->_min_value));
 
-  const auto upper_bound = this->_max_value + TypeParam{1};
   EXPECT_FALSE(filter->sliced(PredicateCondition::BetweenExclusive, this->_max_value, upper_bound));
   EXPECT_TRUE(filter->sliced(PredicateCondition::BetweenInclusive, this->_max_value, upper_bound));
   EXPECT_FALSE(filter->sliced(PredicateCondition::BetweenLowerExclusive, this->_max_value, upper_bound));


### PR DESCRIPTION
We encountered several timeout issues with TPC-DS generation in the Console test. This PR replaces TPC-DS with TPC-C, hoping for faster generation times.

Furthermore, the SSB test is now moved to the system test stage, where it should not be executed in parallel.

Finally, this PR refactors range filters and their tests a bit, adding pruning with between exclusive predicates.