### PR TITLE
Fix for clang 14: issues with `\n` in comments

### DIFF
--- a/src/lib/expression/evaluation/like_matcher.hpp
+++ b/src/lib/expression/evaluation/like_matcher.hpp
@@ -92,7 +92,7 @@ class LikeMatcher {
    * The functor will be called with a concrete matcher.
    * Usage example:
    *    LikeMatcher{"%hello%"}.resolve(false, [](const auto& matcher) {
-   *        std::cout << matcher("He said hello!") << '\n';
+   *        std::cout << matcher("He said hello!");
    *    }
    */
   template <typename Functor>

--- a/src/lib/utils/performance_warning.hpp
+++ b/src/lib/utils/performance_warning.hpp
@@ -17,7 +17,7 @@
  *
  * {
  *   const auto performance_warning_disabler = PerformanceWarningDisabler{};
- *   std::cout << abstract_segment[5] << '\n';  // This does not cause a warning.
+ *   std::cout << abstract_segment[5];  // This does not cause a warning.
  * }
  * // warnings are enabled again
  *


### PR DESCRIPTION
Mini PR to fix an issue that Clang 14 has with `\n` in certain comments. It is a known issue with clang 14 (https://stackoverflow.com/q/25197299/1147726).

I consider this change to make sense since:
 * the new lines in the examples do provide any value
 * clang 14 is not that old and used on several of our servers
 * modifying make files to ignore certain errors of this particular clang version is not worth it as newer versions do not complain