### PR TITLE
Fix macOS wake up issues

### DIFF
--- a/src/benchmarklib/benchmark_runner.hpp
+++ b/src/benchmarklib/benchmark_runner.hpp
@@ -6,12 +6,13 @@
 #include <limits>
 #include <memory>
 #include <optional>
-#include <semaphore>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
+#include "concurrentqueue.h"  // The lightweight semaphore uses definitions of concurrentqueue.h.
 #include "cxxopts.hpp"
+#include "lightweightsemaphore.h"
 #include "nlohmann/json.hpp"
 
 #include "abstract_benchmark_item_runner.hpp"
@@ -108,7 +109,9 @@ class BenchmarkRunner : public Noncopyable {
   // We schedule as many items simultaneously as we have simulated clients. We use a counting semaphore for this
   // purpose. We initialize it to a maximum value of int32_t::max(), which should be sufficient for reasonable clients
   // counts.
-  std::counting_semaphore<std::numeric_limits<int32_t>::max()> _running_clients_semaphore{0};
+  // We are not using an `std::counting_semaphore` here as the semaphore of libc++ shipped with macOS 14 has wake up
+  // issues (see https://reviews.llvm.org/D114119).
+  moodycamel::LightweightSemaphore _running_clients_semaphore{0};
 
   // For BenchmarkMode::Shuffled, we count the number of runs executed across all items. This also includes items that
   // were unsuccessful (e.g., because of transaction aborts).

--- a/src/lib/scheduler/task_queue.hpp
+++ b/src/lib/scheduler/task_queue.hpp
@@ -61,6 +61,8 @@ class TaskQueue {
 
   /**
    * Semaphore to signal waiting workers for new tasks.
+   * When macOS ships a more recent libc++, this third-party semaphore can be replaced by std::counting_semaphore (see
+   * comment in benchmark_runner.hpp).
    */
   moodycamel::LightweightSemaphore semaphore;
 


### PR DESCRIPTION
This PR replaces the `std::counting_semaphore` with `moodycamel::LightweightSemaphore` (also used in the task queues). libc++ had an issue with semaphore wake ups (see https://reviews.llvm.org/D114119) and this change hasn't made it to the libc++ shipped with macOS so far.

On my notebook, it took several hours to reproduce the problem but on the macOS CI machine (I don't understand why to be honest), it happened quite frequently in `hyriseBenchmarkFileBased_test.py`.

I haven't tested the LLVM-shipped libc++ versions as I would like to keep Hyrise running on the default macOS setup.