### PR TITLE
Fix for benchmark_all.sh output

### DIFF
--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -3,11 +3,17 @@
 import json
 import math
 import numpy as np
+import os
 import re
 import sys
 from terminaltables import AsciiTable
 from termcolor import colored
 from scipy.stats import ttest_ind
+
+# We enforce colored output. When calling this script from another script (e.g., from `benchmark_all.sh`), termcolor
+# recognizes that colors are not supported. However, our post-processing for github markdown output uses the color
+# information. We thus always enforce colored output.
+os.environ["FORCE_COLOR"] = "1"
 
 p_value_significance_threshold = 0.001
 min_iterations = 10


### PR DESCRIPTION
The output of `benchmark_all.sh` uses the `--github` flag (enables GitHub's diff format that shows improving queries in green, regressing queries in red).
The `compare_benchmark.py` (called by `benchmark_all.sh`) uses a post-processing step in which the color coding is checked to add GitHub markdown accordingly. But when the script is called from `benchmark_all.sh`, no color codes are emitted as the used `termcolor` package checks for a terminal that supports colors.
This PR changes the `compare_benchmark.py` script to force a colorful output in all situations.