### PR TITLE
Turn on scheduler and benchmark data caching in Console

### DIFF
--- a/scripts/test/hyriseConsole_test.py
+++ b/scripts/test/hyriseConsole_test.py
@@ -52,6 +52,11 @@ def main():
     console.sendline("print test")
     console.expect("Table does not exist in StorageManager")
 
+    # Test changing a setting. Also, turn binary caching off to avoid problems with cached binaries (e.g.,
+    # `hyriseServer_test.py` requires a different chunk size for TPC-H).
+    console.sendline("setting binary_caching off")
+    console.expect("Binary caching turned off")
+
     # Test load command.
     console.sendline("load resources/test_data/tbl/10_ints.tbl test")
     console.expect('Loading .*tbl/10_ints.tbl into table "test"')

--- a/src/benchmark/file_based_benchmark.cpp
+++ b/src/benchmark/file_based_benchmark.cpp
@@ -40,7 +40,7 @@ int main(int argc, char* argv[]) {
   table_path = cli_parse_result["table_path"].as<std::string>();
   queries_str = cli_parse_result["queries"].as<std::string>();
 
-  benchmark_config = std::make_shared<BenchmarkConfig>(CLIConfigParser::parse_cli_options(cli_parse_result));
+  benchmark_config = CLIConfigParser::parse_cli_options(cli_parse_result);
 
   // Check that the options "query_path" and "table_path" were specified
   if (query_path.empty() || table_path.empty()) {

--- a/src/benchmark/join_order_benchmark.cpp
+++ b/src/benchmark/join_order_benchmark.cpp
@@ -172,7 +172,7 @@ int main(int argc, char* argv[]) {
   table_path = cli_parse_result["table_path"].as<std::string>();
   queries_str = cli_parse_result["queries"].as<std::string>();
 
-  benchmark_config = std::make_shared<BenchmarkConfig>(CLIConfigParser::parse_cli_options(cli_parse_result));
+  benchmark_config = CLIConfigParser::parse_cli_options(cli_parse_result);
 
   // Check that the options "query_path" and "table_path" were specified
   if (query_path.empty() || table_path.empty()) {

--- a/src/benchmark/star_schema_benchmark.cpp
+++ b/src/benchmark/star_schema_benchmark.cpp
@@ -38,7 +38,7 @@ int main(int argc, char* argv[]) {
 
   const auto queries_str = cli_parse_result["queries"].as<std::string>();
   const auto scale_factor = cli_parse_result["scale"].as<float>();
-  const auto config = std::make_shared<BenchmarkConfig>(CLIConfigParser::parse_cli_options(cli_parse_result));
+  const auto config = CLIConfigParser::parse_cli_options(cli_parse_result);
 
   auto query_subset = std::optional<std::unordered_set<std::string>>{};
   if (queries_str == "all") {

--- a/src/benchmark/tpcc_benchmark.cpp
+++ b/src/benchmark/tpcc_benchmark.cpp
@@ -57,7 +57,7 @@ int main(int argc, char* argv[]) {
   num_warehouses = cli_parse_result["scale"].as<size_t>();
   consistency_checks = cli_parse_result["consistency_checks"].as<bool>();
 
-  config = std::make_shared<BenchmarkConfig>(CLIConfigParser::parse_cli_options(cli_parse_result));
+  config = CLIConfigParser::parse_cli_options(cli_parse_result);
 
   // As TPC-C procedures may run into conflicts on both the Hyrise and the SQLite side, we cannot guarantee that the
   // two databases stay in sync.

--- a/src/benchmark/tpcds_benchmark.cpp
+++ b/src/benchmark/tpcds_benchmark.cpp
@@ -56,7 +56,7 @@ int main(int argc, char* argv[]) {
   }
   scale_factor = cli_parse_result["scale"].as<int32_t>();
 
-  config = std::make_shared<BenchmarkConfig>(CLIConfigParser::parse_cli_options(cli_parse_result));
+  config = CLIConfigParser::parse_cli_options(cli_parse_result);
 
   std::cout << "- TPC-DS scale factor is " << scale_factor << '\n';
 

--- a/src/benchmark/tpch_benchmark.cpp
+++ b/src/benchmark/tpch_benchmark.cpp
@@ -74,7 +74,7 @@ int main(int argc, char* argv[]) {
 
   scale_factor = cli_parse_result["scale"].as<float>();
 
-  config = std::make_shared<BenchmarkConfig>(CLIConfigParser::parse_cli_options(cli_parse_result));
+  config = CLIConfigParser::parse_cli_options(cli_parse_result);
 
   use_prepared_statements = cli_parse_result["use_prepared_statements"].as<bool>();
   jcch = cli_parse_result.count("jcch");

--- a/src/benchmark/tpch_data_micro_benchmark.cpp
+++ b/src/benchmark/tpch_data_micro_benchmark.cpp
@@ -27,21 +27,17 @@ using namespace expression_functional;  // NOLINT(build/namespaces)
 
 class TableWrapper;
 
-// Defining the base fixture class
+// Defining the base fixture class.
 class TPCHDataMicroBenchmarkFixture : public MicroBenchmarkBasicFixture {
  public:
   void SetUp(::benchmark::State& state) override {
     auto& sm = Hyrise::get().storage_manager;
     const auto scale_factor = 10.0f;
-    const auto default_encoding = EncodingType::Dictionary;
-
     const auto benchmark_config = std::make_shared<BenchmarkConfig>();
-    // TODO(anyone): setup benchmark_config with the given default_encoding
-    // benchmark_config.encoding_config = EncodingConfig{SegmentEncodingSpec{default_encoding}};
 
     if (!sm.has_table("lineitem")) {
-      std::cout << "Generating TPC-H data set with scale factor " << scale_factor << " and " << default_encoding
-                << " encoding:\n";
+      std::cout << "Generating TPC-H data set with scale factor " << scale_factor << " and "
+                << benchmark_config->encoding_config.default_encoding_spec << " encoding:\n";
       TPCHTableGenerator(scale_factor, ClusteringConfiguration::None, benchmark_config).generate_and_store();
     }
 

--- a/src/benchmark/tpch_data_micro_benchmark.cpp
+++ b/src/benchmark/tpch_data_micro_benchmark.cpp
@@ -35,16 +35,14 @@ class TPCHDataMicroBenchmarkFixture : public MicroBenchmarkBasicFixture {
     const auto scale_factor = 10.0f;
     const auto default_encoding = EncodingType::Dictionary;
 
-    auto benchmark_config = BenchmarkConfig::get_default_config();
+    const auto benchmark_config = std::make_shared<BenchmarkConfig>();
     // TODO(anyone): setup benchmark_config with the given default_encoding
     // benchmark_config.encoding_config = EncodingConfig{SegmentEncodingSpec{default_encoding}};
 
     if (!sm.has_table("lineitem")) {
       std::cout << "Generating TPC-H data set with scale factor " << scale_factor << " and " << default_encoding
                 << " encoding:\n";
-      TPCHTableGenerator(scale_factor, ClusteringConfiguration::None,
-                         std::make_shared<BenchmarkConfig>(benchmark_config))
-          .generate_and_store();
+      TPCHTableGenerator(scale_factor, ClusteringConfiguration::None, benchmark_config).generate_and_store();
     }
 
     _table_wrapper_map = create_table_wrappers(sm);

--- a/src/benchmark/tpch_table_generator_benchmark.cpp
+++ b/src/benchmark/tpch_table_generator_benchmark.cpp
@@ -7,11 +7,11 @@
 namespace hyrise {
 
 /**
- * This benchmark can only be use as a starting point for investigating TPCHTableGenerator performance, since secondary
+ * This benchmark can only be used as a starting point for investigating TPCHTableGenerator performance, since secondary
  * invocations of 'TPCHTableGenerator(scale_factor, 1000).generate();' will profit from cached data in tpch-dbgen
  * @param state
  */
-static void BM_TPCHTableGenerator(benchmark::State& state) {  // NOLINT
+static void BM_TPCHTableGenerator(benchmark::State& state) {
   for (auto _ : state) {
     TPCHTableGenerator(0.5f, ClusteringConfiguration::None, ChunkOffset{1000}).generate_and_store();
     Hyrise::reset();

--- a/src/benchmark/tpch_table_generator_benchmark.cpp
+++ b/src/benchmark/tpch_table_generator_benchmark.cpp
@@ -9,7 +9,7 @@ namespace hyrise {
 /**
  * This benchmark can only be used as a starting point for investigating TPCHTableGenerator performance, since secondary
  * invocations of 'TPCHTableGenerator(scale_factor, 1000).generate();' will profit from cached data in tpch-dbgen
- * @param state
+ * @param state.
  */
 static void BM_TPCHTableGenerator(benchmark::State& state) {
   for (auto _ : state) {

--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -348,11 +348,10 @@ void AbstractTableGenerator::generate_and_store() {
   Hyrise::get().set_scheduler(initial_scheduler);
 }
 
-std::shared_ptr<BenchmarkConfig> AbstractTableGenerator::create_benchmark_config_with_chunk_size(ChunkOffset chunk_size,
-                                                                                                 bool binary_caching) {
+std::shared_ptr<BenchmarkConfig> AbstractTableGenerator::create_benchmark_config_with_chunk_size(
+    ChunkOffset chunk_size) {
   auto config = BenchmarkConfig::get_default_config();
   config.chunk_size = chunk_size;
-  config.cache_binary_tables = binary_caching;
   return std::make_shared<BenchmarkConfig>(config);
 }
 

--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -348,13 +348,6 @@ void AbstractTableGenerator::generate_and_store() {
   Hyrise::get().set_scheduler(initial_scheduler);
 }
 
-std::shared_ptr<BenchmarkConfig> AbstractTableGenerator::create_benchmark_config_with_chunk_size(
-    ChunkOffset chunk_size) {
-  auto config = BenchmarkConfig::get_default_config();
-  config.chunk_size = chunk_size;
-  return std::make_shared<BenchmarkConfig>(config);
-}
-
 void AbstractTableGenerator::_create_chunk_indexes(
     std::unordered_map<std::string, BenchmarkTableInfo>& table_info_by_name) {
   auto timer = Timer{};

--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -348,10 +348,11 @@ void AbstractTableGenerator::generate_and_store() {
   Hyrise::get().set_scheduler(initial_scheduler);
 }
 
-std::shared_ptr<BenchmarkConfig> AbstractTableGenerator::create_benchmark_config_with_chunk_size(
-    ChunkOffset chunk_size) {
+std::shared_ptr<BenchmarkConfig> AbstractTableGenerator::create_benchmark_config_with_chunk_size(ChunkOffset chunk_size,
+                                                                                                 bool binary_caching) {
   auto config = BenchmarkConfig::get_default_config();
   config.chunk_size = chunk_size;
+  config.cache_binary_tables = binary_caching;
   return std::make_shared<BenchmarkConfig>(config);
 }
 

--- a/src/benchmarklib/abstract_table_generator.hpp
+++ b/src/benchmarklib/abstract_table_generator.hpp
@@ -66,8 +66,6 @@ class AbstractTableGenerator {
 
   TableGenerationMetrics metrics;
 
-  static std::shared_ptr<BenchmarkConfig> create_benchmark_config_with_chunk_size(ChunkOffset chunk_size);
-
  protected:
   // Creates chunk indexes. Expects the table to have been added to the StorageManager and, if requested, encoded.
   void _create_chunk_indexes(std::unordered_map<std::string, BenchmarkTableInfo>& table_info_by_name);

--- a/src/benchmarklib/abstract_table_generator.hpp
+++ b/src/benchmarklib/abstract_table_generator.hpp
@@ -66,7 +66,8 @@ class AbstractTableGenerator {
 
   TableGenerationMetrics metrics;
 
-  static std::shared_ptr<BenchmarkConfig> create_benchmark_config_with_chunk_size(ChunkOffset chunk_size);
+  static std::shared_ptr<BenchmarkConfig> create_benchmark_config_with_chunk_size(ChunkOffset chunk_size,
+                                                                                  bool binary_caching = false);
 
  protected:
   // Creates chunk indexes. Expects the table to have been added to the StorageManager and, if requested, encoded.

--- a/src/benchmarklib/abstract_table_generator.hpp
+++ b/src/benchmarklib/abstract_table_generator.hpp
@@ -66,8 +66,7 @@ class AbstractTableGenerator {
 
   TableGenerationMetrics metrics;
 
-  static std::shared_ptr<BenchmarkConfig> create_benchmark_config_with_chunk_size(ChunkOffset chunk_size,
-                                                                                  bool binary_caching = false);
+  static std::shared_ptr<BenchmarkConfig> create_benchmark_config_with_chunk_size(ChunkOffset chunk_size);
 
  protected:
   // Creates chunk indexes. Expects the table to have been added to the StorageManager and, if requested, encoded.

--- a/src/benchmarklib/benchmark_config.cpp
+++ b/src/benchmarklib/benchmark_config.cpp
@@ -10,6 +10,8 @@
 
 namespace hyrise {
 
+BenchmarkConfig::BenchmarkConfig(const ChunkOffset init_chunk_size) : chunk_size{init_chunk_size} {}
+
 BenchmarkConfig::BenchmarkConfig(const BenchmarkMode init_benchmark_mode, const ChunkOffset init_chunk_size,
                                  const EncodingConfig& init_encoding_config, const bool init_chunk_indexes,
                                  const bool init_table_indexes, const int64_t init_max_runs,
@@ -39,9 +41,5 @@ BenchmarkConfig::BenchmarkConfig(const BenchmarkMode init_benchmark_mode, const 
       system_metrics(init_system_metrics),
       pipeline_metrics(init_pipeline_metrics),
       plugins(init_plugins) {}
-
-BenchmarkConfig BenchmarkConfig::get_default_config() {
-  return BenchmarkConfig{};
-}
 
 }  // namespace hyrise

--- a/src/benchmarklib/benchmark_config.cpp
+++ b/src/benchmarklib/benchmark_config.cpp
@@ -12,6 +12,9 @@ namespace hyrise {
 
 BenchmarkConfig::BenchmarkConfig(const ChunkOffset init_chunk_size) : chunk_size{init_chunk_size} {}
 
+BenchmarkConfig::BenchmarkConfig(const ChunkOffset init_chunk_size, const bool init_cache_binary_tables)
+    : chunk_size{init_chunk_size}, cache_binary_tables{init_cache_binary_tables} {}
+
 BenchmarkConfig::BenchmarkConfig(const BenchmarkMode init_benchmark_mode, const ChunkOffset init_chunk_size,
                                  const EncodingConfig& init_encoding_config, const bool init_chunk_indexes,
                                  const bool init_table_indexes, const int64_t init_max_runs,
@@ -22,24 +25,24 @@ BenchmarkConfig::BenchmarkConfig(const BenchmarkMode init_benchmark_mode, const 
                                  const bool init_enable_visualization, const bool init_verify,
                                  const bool init_cache_binary_tables, const bool init_system_metrics,
                                  const bool init_pipeline_metrics, const std::vector<std::string>& init_plugins)
-    : benchmark_mode(init_benchmark_mode),
-      chunk_size(init_chunk_size),
-      encoding_config(init_encoding_config),
-      chunk_indexes(init_chunk_indexes),
-      table_indexes(init_table_indexes),
-      max_runs(init_max_runs),
-      max_duration(init_max_duration),
-      warmup_duration(init_warmup_duration),
-      output_file_path(init_output_file_path),
-      enable_scheduler(init_enable_scheduler),
-      cores(init_cores),
-      data_preparation_cores(init_data_preparation_cores),
-      clients(init_clients),
-      enable_visualization(init_enable_visualization),
-      verify(init_verify),
-      cache_binary_tables(init_cache_binary_tables),
-      system_metrics(init_system_metrics),
-      pipeline_metrics(init_pipeline_metrics),
-      plugins(init_plugins) {}
+    : benchmark_mode{init_benchmark_mode},
+      chunk_size{init_chunk_size},
+      encoding_config{init_encoding_config},
+      chunk_indexes{init_chunk_indexes},
+      table_indexes{init_table_indexes},
+      max_runs{init_max_runs},
+      max_duration{init_max_duration},
+      warmup_duration{init_warmup_duration},
+      output_file_path{init_output_file_path},
+      enable_scheduler{init_enable_scheduler},
+      cores{init_cores},
+      data_preparation_cores{init_data_preparation_cores},
+      clients{init_clients},
+      enable_visualization{init_enable_visualization},
+      verify{init_verify},
+      cache_binary_tables{init_cache_binary_tables},
+      system_metrics{init_system_metrics},
+      pipeline_metrics{init_pipeline_metrics},
+      plugins{init_plugins} {}
 
 }  // namespace hyrise

--- a/src/benchmarklib/benchmark_config.hpp
+++ b/src/benchmarklib/benchmark_config.hpp
@@ -10,13 +10,13 @@
 namespace hyrise {
 
 /**
- * "Ordered" runs each item a number of times and then the next one
- * "Shuffled" runs the items in a random order
+ * "Ordered" runs each item a number of times and then the next one.
+ * "Shuffled" runs the items in a random order.
  */
 enum class BenchmarkMode { Ordered, Shuffled };
 
 using Duration = std::chrono::nanoseconds;
-// steady_clock guarantees that the clock is not adjusted while benchmarking
+// `steady_clock guarantees that the clock is not adjusted while benchmarking.
 using TimePoint = std::chrono::steady_clock::time_point;
 
 class BenchmarkConfig {
@@ -24,6 +24,8 @@ class BenchmarkConfig {
   BenchmarkConfig() = default;
 
   explicit BenchmarkConfig(const ChunkOffset init_chunk_size);
+
+  BenchmarkConfig(const ChunkOffset init_chunk_size, const bool init_cache_binary_tables);
 
   BenchmarkConfig(const BenchmarkMode init_benchmark_mode, const ChunkOffset init_chunk_size,
                   const EncodingConfig& init_encoding_config, const bool init_chunk_indexes,
@@ -50,8 +52,9 @@ class BenchmarkConfig {
   uint32_t clients{1};
   bool enable_visualization{false};
   bool verify{false};
-  bool cache_binary_tables{
-      false};  // Defaults to false for internal use, but CLI and console set it to true by default.
+  // Defaults to false for internal use, but benchmark, console, and server binaries set caching of benchmark data as
+  // binary files to true by default.
+  bool cache_binary_tables{false};
   bool system_metrics{false};
   bool pipeline_metrics{false};
   std::vector<std::string> plugins{};

--- a/src/benchmarklib/benchmark_config.hpp
+++ b/src/benchmarklib/benchmark_config.hpp
@@ -21,6 +21,10 @@ using TimePoint = std::chrono::steady_clock::time_point;
 
 class BenchmarkConfig {
  public:
+  BenchmarkConfig() = default;
+
+  explicit BenchmarkConfig(const ChunkOffset init_chunk_size);
+
   BenchmarkConfig(const BenchmarkMode init_benchmark_mode, const ChunkOffset init_chunk_size,
                   const EncodingConfig& init_encoding_config, const bool init_chunk_indexes,
                   const bool init_table_indexes, const int64_t init_max_runs, const Duration& init_max_duration,
@@ -30,8 +34,6 @@ class BenchmarkConfig {
                   const bool init_enable_visualization, const bool init_verify, const bool init_cache_binary_tables,
                   const bool init_system_metrics, const bool init_pipeline_metrics,
                   const std::vector<std::string>& init_plugins);
-
-  static BenchmarkConfig get_default_config();
 
   BenchmarkMode benchmark_mode{BenchmarkMode::Ordered};
   ChunkOffset chunk_size{Chunk::DEFAULT_SIZE};
@@ -48,13 +50,11 @@ class BenchmarkConfig {
   uint32_t clients{1};
   bool enable_visualization{false};
   bool verify{false};
-  bool cache_binary_tables{false};  // Defaults to false for internal use, but the CLI sets it to true by default.
+  bool cache_binary_tables{
+      false};  // Defaults to false for internal use, but CLI and console set it to true by default.
   bool system_metrics{false};
   bool pipeline_metrics{false};
   std::vector<std::string> plugins{};
-
- private:
-  BenchmarkConfig() = default;
 };
 
 }  // namespace hyrise

--- a/src/benchmarklib/benchmark_config.hpp
+++ b/src/benchmarklib/benchmark_config.hpp
@@ -16,7 +16,7 @@ namespace hyrise {
 enum class BenchmarkMode { Ordered, Shuffled };
 
 using Duration = std::chrono::nanoseconds;
-// `steady_clock guarantees that the clock is not adjusted while benchmarking.
+// `steady_clock` guarantees that the clock is not adjusted while benchmarking.
 using TimePoint = std::chrono::steady_clock::time_point;
 
 class BenchmarkConfig {
@@ -52,7 +52,7 @@ class BenchmarkConfig {
   uint32_t clients{1};
   bool enable_visualization{false};
   bool verify{false};
-  // Defaults to false for internal use, but benchmark, console, and server binaries set caching of benchmark data as
+  // Defaults to false for internal use. Benchmark, console, and server binaries set caching of benchmark data using
   // binary files to true by default.
   bool cache_binary_tables{false};
   bool system_metrics{false};

--- a/src/benchmarklib/cli_config_parser.hpp
+++ b/src/benchmarklib/cli_config_parser.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <filesystem>
+#include <memory>
 #include <string>
 
 #include "cxxopts.hpp"
@@ -12,7 +12,7 @@ namespace hyrise {
 
 class CLIConfigParser {
  public:
-  static BenchmarkConfig parse_cli_options(const cxxopts::ParseResult& parse_result);
+  static std::shared_ptr<BenchmarkConfig> parse_cli_options(const cxxopts::ParseResult& parse_result);
 
   static EncodingConfig parse_encoding_config(const std::string& encoding_file_str);
 

--- a/src/benchmarklib/jcch/jcch_table_generator.cpp
+++ b/src/benchmarklib/jcch/jcch_table_generator.cpp
@@ -18,7 +18,7 @@ namespace hyrise {
 JCCHTableGenerator::JCCHTableGenerator(const std::string& dbgen_path, const std::string& data_path, float scale_factor,
                                        ClusteringConfiguration clustering_configuration, ChunkOffset chunk_size)
     : JCCHTableGenerator(dbgen_path, data_path, scale_factor, clustering_configuration,
-                         create_benchmark_config_with_chunk_size(chunk_size)) {}
+                         std::make_shared<BenchmarkConfig>(chunk_size)) {}
 
 JCCHTableGenerator::JCCHTableGenerator(const std::string& dbgen_path, const std::string& data_path, float scale_factor,
                                        ClusteringConfiguration clustering_configuration,

--- a/src/benchmarklib/ssb/ssb_table_generator.cpp
+++ b/src/benchmarklib/ssb/ssb_table_generator.cpp
@@ -20,7 +20,7 @@ const auto ssb_table_names = std::vector<std::string>{"part", "customer", "suppl
 SSBTableGenerator::SSBTableGenerator(const std::string& dbgen_path, const std::string& csv_meta_path,
                                      const std::string& data_path, float scale_factor, ChunkOffset chunk_size)
     : SSBTableGenerator(dbgen_path, csv_meta_path, data_path, scale_factor,
-                        create_benchmark_config_with_chunk_size(chunk_size)) {}
+                        std::make_shared<BenchmarkConfig>(chunk_size)) {}
 
 SSBTableGenerator::SSBTableGenerator(const std::string& dbgen_path, const std::string& csv_meta_path,
                                      const std::string& data_path, float scale_factor,

--- a/src/benchmarklib/ssb/ssb_table_generator.cpp
+++ b/src/benchmarklib/ssb/ssb_table_generator.cpp
@@ -18,10 +18,9 @@ namespace hyrise {
 const auto ssb_table_names = std::vector<std::string>{"part", "customer", "supplier", "date", "lineorder"};
 
 SSBTableGenerator::SSBTableGenerator(const std::string& dbgen_path, const std::string& csv_meta_path,
-                                     const std::string& data_path, float scale_factor, ChunkOffset chunk_size,
-                                     bool binary_caching)
+                                     const std::string& data_path, float scale_factor, ChunkOffset chunk_size)
     : SSBTableGenerator(dbgen_path, csv_meta_path, data_path, scale_factor,
-                        create_benchmark_config_with_chunk_size(chunk_size, binary_caching)) {}
+                        create_benchmark_config_with_chunk_size(chunk_size)) {}
 
 SSBTableGenerator::SSBTableGenerator(const std::string& dbgen_path, const std::string& csv_meta_path,
                                      const std::string& data_path, float scale_factor,

--- a/src/benchmarklib/ssb/ssb_table_generator.cpp
+++ b/src/benchmarklib/ssb/ssb_table_generator.cpp
@@ -18,9 +18,10 @@ namespace hyrise {
 const auto ssb_table_names = std::vector<std::string>{"part", "customer", "supplier", "date", "lineorder"};
 
 SSBTableGenerator::SSBTableGenerator(const std::string& dbgen_path, const std::string& csv_meta_path,
-                                     const std::string& data_path, float scale_factor, ChunkOffset chunk_size)
+                                     const std::string& data_path, float scale_factor, ChunkOffset chunk_size,
+                                     bool binary_caching)
     : SSBTableGenerator(dbgen_path, csv_meta_path, data_path, scale_factor,
-                        create_benchmark_config_with_chunk_size(chunk_size)) {}
+                        create_benchmark_config_with_chunk_size(chunk_size, binary_caching)) {}
 
 SSBTableGenerator::SSBTableGenerator(const std::string& dbgen_path, const std::string& csv_meta_path,
                                      const std::string& data_path, float scale_factor,

--- a/src/benchmarklib/ssb/ssb_table_generator.hpp
+++ b/src/benchmarklib/ssb/ssb_table_generator.hpp
@@ -14,7 +14,7 @@ class SSBTableGenerator : virtual public FileBasedTableGenerator {
   // Convenience constructor for creating a SSBTableGenerator without a benchmarking context.
   explicit SSBTableGenerator(const std::string& dbgen_path, const std::string& csv_meta_path,
                              const std::string& data_path, float scale_factor,
-                             ChunkOffset chunk_size = Chunk::DEFAULT_SIZE);
+                             ChunkOffset chunk_size = Chunk::DEFAULT_SIZE, bool binary_caching = false);
 
   // Constructor for creating a SSBTableGenerator in a benchmark.
   explicit SSBTableGenerator(const std::string& dbgen_path, const std::string& csv_meta_path,

--- a/src/benchmarklib/ssb/ssb_table_generator.hpp
+++ b/src/benchmarklib/ssb/ssb_table_generator.hpp
@@ -14,7 +14,7 @@ class SSBTableGenerator : virtual public FileBasedTableGenerator {
   // Convenience constructor for creating a SSBTableGenerator without a benchmarking context.
   explicit SSBTableGenerator(const std::string& dbgen_path, const std::string& csv_meta_path,
                              const std::string& data_path, float scale_factor,
-                             ChunkOffset chunk_size = Chunk::DEFAULT_SIZE, bool binary_caching = false);
+                             ChunkOffset chunk_size = Chunk::DEFAULT_SIZE);
 
   // Constructor for creating a SSBTableGenerator in a benchmark.
   explicit SSBTableGenerator(const std::string& dbgen_path, const std::string& csv_meta_path,

--- a/src/benchmarklib/tpcc/tpcc_table_generator.cpp
+++ b/src/benchmarklib/tpcc/tpcc_table_generator.cpp
@@ -30,7 +30,7 @@ TPCCTableGenerator::TPCCTableGenerator(size_t num_warehouses, const std::shared_
     : AbstractTableGenerator(benchmark_config), _num_warehouses(num_warehouses) {}
 
 TPCCTableGenerator::TPCCTableGenerator(size_t num_warehouses, ChunkOffset chunk_size)
-    : AbstractTableGenerator(create_benchmark_config_with_chunk_size(chunk_size)), _num_warehouses(num_warehouses) {}
+    : AbstractTableGenerator(std::make_shared<BenchmarkConfig>(chunk_size)), _num_warehouses(num_warehouses) {}
 
 std::shared_ptr<Table> TPCCTableGenerator::generate_item_table() {
   auto cardinalities = std::make_shared<std::vector<size_t>>(std::initializer_list<size_t>{NUM_ITEMS});

--- a/src/benchmarklib/tpcc/tpcc_table_generator.cpp
+++ b/src/benchmarklib/tpcc/tpcc_table_generator.cpp
@@ -29,8 +29,9 @@ namespace hyrise {
 TPCCTableGenerator::TPCCTableGenerator(size_t num_warehouses, const std::shared_ptr<BenchmarkConfig>& benchmark_config)
     : AbstractTableGenerator(benchmark_config), _num_warehouses(num_warehouses) {}
 
-TPCCTableGenerator::TPCCTableGenerator(size_t num_warehouses, ChunkOffset chunk_size)
-    : AbstractTableGenerator(create_benchmark_config_with_chunk_size(chunk_size)), _num_warehouses(num_warehouses) {}
+TPCCTableGenerator::TPCCTableGenerator(size_t num_warehouses, ChunkOffset chunk_size, bool binary_caching)
+    : AbstractTableGenerator(create_benchmark_config_with_chunk_size(chunk_size, binary_caching)),
+      _num_warehouses(num_warehouses) {}
 
 std::shared_ptr<Table> TPCCTableGenerator::generate_item_table() {
   auto cardinalities = std::make_shared<std::vector<size_t>>(std::initializer_list<size_t>{NUM_ITEMS});

--- a/src/benchmarklib/tpcc/tpcc_table_generator.cpp
+++ b/src/benchmarklib/tpcc/tpcc_table_generator.cpp
@@ -29,9 +29,8 @@ namespace hyrise {
 TPCCTableGenerator::TPCCTableGenerator(size_t num_warehouses, const std::shared_ptr<BenchmarkConfig>& benchmark_config)
     : AbstractTableGenerator(benchmark_config), _num_warehouses(num_warehouses) {}
 
-TPCCTableGenerator::TPCCTableGenerator(size_t num_warehouses, ChunkOffset chunk_size, bool binary_caching)
-    : AbstractTableGenerator(create_benchmark_config_with_chunk_size(chunk_size, binary_caching)),
-      _num_warehouses(num_warehouses) {}
+TPCCTableGenerator::TPCCTableGenerator(size_t num_warehouses, ChunkOffset chunk_size)
+    : AbstractTableGenerator(create_benchmark_config_with_chunk_size(chunk_size)), _num_warehouses(num_warehouses) {}
 
 std::shared_ptr<Table> TPCCTableGenerator::generate_item_table() {
   auto cardinalities = std::make_shared<std::vector<size_t>>(std::initializer_list<size_t>{NUM_ITEMS});

--- a/src/benchmarklib/tpcc/tpcc_table_generator.hpp
+++ b/src/benchmarklib/tpcc/tpcc_table_generator.hpp
@@ -25,9 +25,8 @@ class TPCCTableGenerator : public AbstractTableGenerator {
  public:
   TPCCTableGenerator(size_t num_warehouses, const std::shared_ptr<BenchmarkConfig>& benchmark_config);
 
-  // Convenience constructor for creating a TPCCTableGenerator without a benchmarking context
-  explicit TPCCTableGenerator(size_t num_warehouses, ChunkOffset chunk_size = Chunk::DEFAULT_SIZE,
-                              bool binary_caching = false);
+  // Convenience constructor for creating a TPCCTableGenerator without a benchmarking context.
+  explicit TPCCTableGenerator(size_t num_warehouses, ChunkOffset chunk_size = Chunk::DEFAULT_SIZE);
 
   std::shared_ptr<Table> generate_item_table();
 

--- a/src/benchmarklib/tpcc/tpcc_table_generator.hpp
+++ b/src/benchmarklib/tpcc/tpcc_table_generator.hpp
@@ -26,7 +26,8 @@ class TPCCTableGenerator : public AbstractTableGenerator {
   TPCCTableGenerator(size_t num_warehouses, const std::shared_ptr<BenchmarkConfig>& benchmark_config);
 
   // Convenience constructor for creating a TPCCTableGenerator without a benchmarking context
-  explicit TPCCTableGenerator(size_t num_warehouses, ChunkOffset chunk_size = Chunk::DEFAULT_SIZE);
+  explicit TPCCTableGenerator(size_t num_warehouses, ChunkOffset chunk_size = Chunk::DEFAULT_SIZE,
+                              bool binary_caching = false);
 
   std::shared_ptr<Table> generate_item_table();
 

--- a/src/benchmarklib/tpcds/tpcds_table_generator.cpp
+++ b/src/benchmarklib/tpcds/tpcds_table_generator.cpp
@@ -286,10 +286,8 @@ const auto web_site_column_names = boost::hana::make_tuple("web_site_sk" , "web_
 
 namespace hyrise {
 
-TPCDSTableGenerator::TPCDSTableGenerator(uint32_t scale_factor, ChunkOffset chunk_size, bool binary_caching,
-                                         int rng_seed)
-    : AbstractTableGenerator(create_benchmark_config_with_chunk_size(chunk_size, binary_caching)),
-      _scale_factor{scale_factor} {
+TPCDSTableGenerator::TPCDSTableGenerator(uint32_t scale_factor, ChunkOffset chunk_size, int rng_seed)
+    : AbstractTableGenerator(create_benchmark_config_with_chunk_size(chunk_size)), _scale_factor{scale_factor} {
   init_tpcds_tools(scale_factor, rng_seed);
 }
 

--- a/src/benchmarklib/tpcds/tpcds_table_generator.cpp
+++ b/src/benchmarklib/tpcds/tpcds_table_generator.cpp
@@ -287,7 +287,7 @@ const auto web_site_column_names = boost::hana::make_tuple("web_site_sk" , "web_
 namespace hyrise {
 
 TPCDSTableGenerator::TPCDSTableGenerator(uint32_t scale_factor, ChunkOffset chunk_size, int rng_seed)
-    : AbstractTableGenerator(create_benchmark_config_with_chunk_size(chunk_size)), _scale_factor{scale_factor} {
+    : AbstractTableGenerator(std::make_shared<BenchmarkConfig>(chunk_size)), _scale_factor{scale_factor} {
   init_tpcds_tools(scale_factor, rng_seed);
 }
 

--- a/src/benchmarklib/tpcds/tpcds_table_generator.cpp
+++ b/src/benchmarklib/tpcds/tpcds_table_generator.cpp
@@ -286,8 +286,10 @@ const auto web_site_column_names = boost::hana::make_tuple("web_site_sk" , "web_
 
 namespace hyrise {
 
-TPCDSTableGenerator::TPCDSTableGenerator(uint32_t scale_factor, ChunkOffset chunk_size, int rng_seed)
-    : AbstractTableGenerator(create_benchmark_config_with_chunk_size(chunk_size)), _scale_factor{scale_factor} {
+TPCDSTableGenerator::TPCDSTableGenerator(uint32_t scale_factor, ChunkOffset chunk_size, bool binary_caching,
+                                         int rng_seed)
+    : AbstractTableGenerator(create_benchmark_config_with_chunk_size(chunk_size, binary_caching)),
+      _scale_factor{scale_factor} {
   init_tpcds_tools(scale_factor, rng_seed);
 }
 

--- a/src/benchmarklib/tpcds/tpcds_table_generator.hpp
+++ b/src/benchmarklib/tpcds/tpcds_table_generator.hpp
@@ -27,14 +27,14 @@ namespace hyrise {
  *
  * NOT thread safe because the underlying dsdgen is probably not (assuming it has the same issues as the tpch dbgen).
  * There is a tpcds_cleanup() function in third_party/tpcds-kit/r_params.c, but after calling tpcds_cleanup, TPC-DS 
- * data can no longer be generated. We decided that being able to generate tpcds data multiple times in for example a
+ * data can no longer be generated. We decided that being able to generate tpcds data multiple times in, for example, a
  * hyriseConsole session is more important than fixing these small memory leaks (<1MB for 1GB of generated data).
  */
 class TPCDSTableGenerator final : public AbstractTableGenerator {
  public:
-  // rng seed 19620718 is the same dsdgen uses as default
+  // rng seed 19620718 is the same dsdgen uses as default.
   explicit TPCDSTableGenerator(uint32_t scale_factor, ChunkOffset chunk_size = Chunk::DEFAULT_SIZE,
-                               int rng_seed = 19620718);
+                               bool binary_caching = false, int rng_seed = 19620718);
   TPCDSTableGenerator(uint32_t scale_factor, const std::shared_ptr<BenchmarkConfig>& benchmark_config,
                       int rng_seed = 19620718);
 

--- a/src/benchmarklib/tpcds/tpcds_table_generator.hpp
+++ b/src/benchmarklib/tpcds/tpcds_table_generator.hpp
@@ -34,7 +34,7 @@ class TPCDSTableGenerator final : public AbstractTableGenerator {
  public:
   // rng seed 19620718 is the same dsdgen uses as default.
   explicit TPCDSTableGenerator(uint32_t scale_factor, ChunkOffset chunk_size = Chunk::DEFAULT_SIZE,
-                               bool binary_caching = false, int rng_seed = 19620718);
+                               int rng_seed = 19620718);
   TPCDSTableGenerator(uint32_t scale_factor, const std::shared_ptr<BenchmarkConfig>& benchmark_config,
                       int rng_seed = 19620718);
 

--- a/src/benchmarklib/tpch/tpch_table_generator.cpp
+++ b/src/benchmarklib/tpch/tpch_table_generator.cpp
@@ -128,7 +128,7 @@ const std::unordered_map<TPCHTable, std::string> tpch_table_names = {
 
 TPCHTableGenerator::TPCHTableGenerator(float scale_factor, ClusteringConfiguration clustering_configuration,
                                        ChunkOffset chunk_size)
-    : TPCHTableGenerator(scale_factor, clustering_configuration, create_benchmark_config_with_chunk_size(chunk_size)) {}
+    : TPCHTableGenerator(scale_factor, clustering_configuration, std::make_shared<BenchmarkConfig>(chunk_size)) {}
 
 TPCHTableGenerator::TPCHTableGenerator(float scale_factor, ClusteringConfiguration clustering_configuration,
                                        const std::shared_ptr<BenchmarkConfig>& benchmark_config)

--- a/src/benchmarklib/tpch/tpch_table_generator.cpp
+++ b/src/benchmarklib/tpch/tpch_table_generator.cpp
@@ -127,9 +127,8 @@ const std::unordered_map<TPCHTable, std::string> tpch_table_names = {
     {TPCHTable::Nation, "nation"},     {TPCHTable::Region, "region"}};
 
 TPCHTableGenerator::TPCHTableGenerator(float scale_factor, ClusteringConfiguration clustering_configuration,
-                                       ChunkOffset chunk_size, bool binary_caching)
-    : TPCHTableGenerator(scale_factor, clustering_configuration,
-                         create_benchmark_config_with_chunk_size(chunk_size, binary_caching)) {}
+                                       ChunkOffset chunk_size)
+    : TPCHTableGenerator(scale_factor, clustering_configuration, create_benchmark_config_with_chunk_size(chunk_size)) {}
 
 TPCHTableGenerator::TPCHTableGenerator(float scale_factor, ClusteringConfiguration clustering_configuration,
                                        const std::shared_ptr<BenchmarkConfig>& benchmark_config)

--- a/src/benchmarklib/tpch/tpch_table_generator.cpp
+++ b/src/benchmarklib/tpch/tpch_table_generator.cpp
@@ -127,8 +127,9 @@ const std::unordered_map<TPCHTable, std::string> tpch_table_names = {
     {TPCHTable::Nation, "nation"},     {TPCHTable::Region, "region"}};
 
 TPCHTableGenerator::TPCHTableGenerator(float scale_factor, ClusteringConfiguration clustering_configuration,
-                                       ChunkOffset chunk_size)
-    : TPCHTableGenerator(scale_factor, clustering_configuration, create_benchmark_config_with_chunk_size(chunk_size)) {}
+                                       ChunkOffset chunk_size, bool binary_caching)
+    : TPCHTableGenerator(scale_factor, clustering_configuration,
+                         create_benchmark_config_with_chunk_size(chunk_size, binary_caching)) {}
 
 TPCHTableGenerator::TPCHTableGenerator(float scale_factor, ClusteringConfiguration clustering_configuration,
                                        const std::shared_ptr<BenchmarkConfig>& benchmark_config)

--- a/src/benchmarklib/tpch/tpch_table_generator.hpp
+++ b/src/benchmarklib/tpch/tpch_table_generator.hpp
@@ -32,7 +32,7 @@ class TPCHTableGenerator : virtual public AbstractTableGenerator {
  public:
   // Convenience constructor for creating a TPCHTableGenerator without a benchmarking context
   explicit TPCHTableGenerator(float scale_factor, ClusteringConfiguration clustering_configuration,
-                              ChunkOffset chunk_size = Chunk::DEFAULT_SIZE, bool binary_caching = false);
+                              ChunkOffset chunk_size = Chunk::DEFAULT_SIZE);
 
   // Constructor for creating a TPCHTableGenerator in a benchmark
   explicit TPCHTableGenerator(float scale_factor, ClusteringConfiguration clustering_configuration,

--- a/src/benchmarklib/tpch/tpch_table_generator.hpp
+++ b/src/benchmarklib/tpch/tpch_table_generator.hpp
@@ -32,7 +32,7 @@ class TPCHTableGenerator : virtual public AbstractTableGenerator {
  public:
   // Convenience constructor for creating a TPCHTableGenerator without a benchmarking context
   explicit TPCHTableGenerator(float scale_factor, ClusteringConfiguration clustering_configuration,
-                              ChunkOffset chunk_size = Chunk::DEFAULT_SIZE);
+                              ChunkOffset chunk_size = Chunk::DEFAULT_SIZE, bool binary_caching = false);
 
   // Constructor for creating a TPCHTableGenerator in a benchmark
   explicit TPCHTableGenerator(float scale_factor, ClusteringConfiguration clustering_configuration,

--- a/src/benchmarklib/tpch/tpch_table_generator.hpp
+++ b/src/benchmarklib/tpch/tpch_table_generator.hpp
@@ -32,7 +32,7 @@ class TPCHTableGenerator : virtual public AbstractTableGenerator {
  public:
   // Convenience constructor for creating a TPCHTableGenerator without a benchmarking context
   explicit TPCHTableGenerator(float scale_factor, ClusteringConfiguration clustering_configuration,
-                              ChunkOffset chunk_size = Chunk::DEFAULT_SIZE);
+                             ChunkOffset chunk_size = Chunk::DEFAULT_SIZE);
 
   // Constructor for creating a TPCHTableGenerator in a benchmark
   explicit TPCHTableGenerator(float scale_factor, ClusteringConfiguration clustering_configuration,

--- a/src/benchmarklib/tpch/tpch_table_generator.hpp
+++ b/src/benchmarklib/tpch/tpch_table_generator.hpp
@@ -32,7 +32,7 @@ class TPCHTableGenerator : virtual public AbstractTableGenerator {
  public:
   // Convenience constructor for creating a TPCHTableGenerator without a benchmarking context
   explicit TPCHTableGenerator(float scale_factor, ClusteringConfiguration clustering_configuration,
-                             ChunkOffset chunk_size = Chunk::DEFAULT_SIZE);
+                              ChunkOffset chunk_size = Chunk::DEFAULT_SIZE);
 
   // Constructor for creating a TPCHTableGenerator in a benchmark
   explicit TPCHTableGenerator(float scale_factor, ClusteringConfiguration clustering_configuration,

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -514,8 +514,7 @@ int Console::_generate_tpcc(const std::string& args) {
   }
 
   out("Generating all TPCC tables (this might take a while) ...\n");
-  const auto config = std::make_shared<BenchmarkConfig>(chunk_size);
-  config->cache_binary_tables = _binary_caching;
+  const auto config = std::make_shared<BenchmarkConfig>(chunk_size, _binary_caching);
   TPCCTableGenerator{num_warehouses, config}.generate_and_store();
 
   return ReturnCode::Ok;
@@ -541,8 +540,7 @@ int Console::_generate_tpch(const std::string& args) {
   }
 
   out("Generating all TPCH tables (this might take a while) ...\n");
-  const auto config = std::make_shared<BenchmarkConfig>(chunk_size);
-  config->cache_binary_tables = _binary_caching;
+  const auto config = std::make_shared<BenchmarkConfig>(chunk_size, _binary_caching);
   TPCHTableGenerator{scale_factor, ClusteringConfiguration::None, config}.generate_and_store();
 
   return ReturnCode::Ok;
@@ -567,8 +565,7 @@ int Console::_generate_tpcds(const std::string& args) {
   }
 
   out("Generating all TPC-DS tables (this might take a while) ...\n");
-  const auto config = std::make_shared<BenchmarkConfig>(chunk_size);
-  config->cache_binary_tables = _binary_caching;
+  const auto config = std::make_shared<BenchmarkConfig>(chunk_size, _binary_caching);
   TPCDSTableGenerator{scale_factor, config}.generate_and_store();
 
   return ReturnCode::Ok;
@@ -608,8 +605,7 @@ int Console::_generate_ssb(const std::string& args) {
   std::filesystem::create_directories(ssb_data_path.str());
 
   out("Generating all SSB tables (this might take a while) ...\n");
-  const auto config = std::make_shared<BenchmarkConfig>(chunk_size);
-  config->cache_binary_tables = _binary_caching;
+  const auto config = std::make_shared<BenchmarkConfig>(chunk_size, _binary_caching);
   SSBTableGenerator{ssb_dbgen_path, csv_meta_path, ssb_data_path.str(), scale_factor, config}.generate_and_store();
 
   return ReturnCode::Ok;

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -515,7 +515,7 @@ int Console::_generate_tpcc(const std::string& args) {
 
   out("Generating all TPCC tables (this might take a while) ...\n");
   const auto config = std::make_shared<BenchmarkConfig>(chunk_size);
-  config->cache_binary_tables = true;
+  config->cache_binary_tables = _binary_caching;
   TPCCTableGenerator{num_warehouses, config}.generate_and_store();
 
   return ReturnCode::Ok;
@@ -542,7 +542,7 @@ int Console::_generate_tpch(const std::string& args) {
 
   out("Generating all TPCH tables (this might take a while) ...\n");
   const auto config = std::make_shared<BenchmarkConfig>(chunk_size);
-  config->cache_binary_tables = true;
+  config->cache_binary_tables = _binary_caching;
   TPCHTableGenerator{scale_factor, ClusteringConfiguration::None, config}.generate_and_store();
 
   return ReturnCode::Ok;
@@ -568,7 +568,7 @@ int Console::_generate_tpcds(const std::string& args) {
 
   out("Generating all TPC-DS tables (this might take a while) ...\n");
   const auto config = std::make_shared<BenchmarkConfig>(chunk_size);
-  config->cache_binary_tables = true;
+  config->cache_binary_tables = _binary_caching;
   TPCDSTableGenerator{scale_factor, config}.generate_and_store();
 
   return ReturnCode::Ok;
@@ -609,7 +609,7 @@ int Console::_generate_ssb(const std::string& args) {
 
   out("Generating all SSB tables (this might take a while) ...\n");
   const auto config = std::make_shared<BenchmarkConfig>(chunk_size);
-  config->cache_binary_tables = true;
+  config->cache_binary_tables = _binary_caching;
   SSBTableGenerator{ssb_dbgen_path, csv_meta_path, ssb_data_path.str(), scale_factor, config}.generate_and_store();
 
   return ReturnCode::Ok;

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -486,7 +486,7 @@ int Console::_help(const std::string& /*args*/) {
   out("  help                                      - Show this message\n");
   out("  setting [property] [value]                - Change a runtime setting\n");
   out("           scheduler (on|off)               - Turn the scheduler on (default) or off\n");
-  out("           binary_caching (on|off)          - Use cached binaries for benchmarks (default) or not\n");
+  out("           binary_caching (on|off)          - Use cached binary tables for benchmarks (default) or not\n");
   out("  reset                                     - Clear all stored tables and cached query plans\n\n");
   // clang-format on
 

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -486,7 +486,7 @@ int Console::_help(const std::string& /*args*/) {
   out("  help                                      - Show this message\n");
   out("  setting [property] [value]                - Change a runtime setting\n");
   out("           scheduler (on|off)               - Turn the scheduler on (default) or off\n");
-  out("           binary_caching (on|off)          - Use cached binaries for benchmarks (default) or not\n")
+  out("           binary_caching (on|off)          - Use cached binaries for benchmarks (default) or not\n");
   out("  reset                                     - Clear all stored tables and cached query plans\n\n");
   // clang-format on
 

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -32,7 +32,7 @@
 #include "SQLParser.h"
 #include "SQLParserResult.h"
 
-#include "abstract_table_generator.hpp"
+#include "benchmark_config.hpp"
 #include "hyrise.hpp"
 #include "logical_query_plan/lqp_utils.hpp"
 #include "operators/export.hpp"

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -898,10 +898,10 @@ int Console::_change_runtime_setting(const std::string& input) {
   if (property == "scheduler") {
     if (value == "on") {
       Hyrise::get().set_scheduler(std::make_shared<NodeQueueScheduler>());
-      out("Scheduler turned on.\n");
+      out("Scheduler turned on\n");
     } else if (value == "off") {
       Hyrise::get().set_scheduler(std::make_shared<ImmediateExecutionScheduler>());
-      out("Scheduler turned off.\n");
+      out("Scheduler turned off\n");
     } else {
       out("Usage: scheduler (on|off)\n");
       return 1;
@@ -912,10 +912,10 @@ int Console::_change_runtime_setting(const std::string& input) {
   if (property == "binary_caching") {
     if (value == "on") {
       _binary_caching = true;
-      out("Binary caching turned on.\n");
+      out("Binary caching turned on\n");
     } else if (value == "off") {
       _binary_caching = false;
-      out("Binary caching turned off.\n");
+      out("Binary caching turned off\n");
     } else {
       out("Usage: binary_caching (on|off)\n");
       return 1;

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -151,6 +151,9 @@ Console::Console()
   Hyrise::get().default_pqp_cache = _pqp_cache;
   Hyrise::get().default_lqp_cache = _lqp_cache;
 
+  // Use scheduler.
+  Hyrise::get().set_scheduler(std::make_shared<NodeQueueScheduler>());
+
   // Register default commands.
   register_command("exit", std::bind(&Console::_exit, this, std::placeholders::_1));
   register_command("quit", std::bind(&Console::_exit, this, std::placeholders::_1));
@@ -483,6 +486,7 @@ int Console::_help(const std::string& /*args*/) {
   out("  help                                      - Show this message\n");
   out("  setting [property] [value]                - Change a runtime setting\n");
   out("           scheduler (on|off)               - Turn the scheduler on (default) or off\n");
+  out("           binary_caching (on|off)          - Use cached binaries for benchmarks (default) or not\n")
   out("  reset                                     - Clear all stored tables and cached query plans\n\n");
   // clang-format on
 
@@ -509,7 +513,7 @@ int Console::_generate_tpcc(const std::string& args) {
   }
 
   out("Generating all TPCC tables (this might take a while) ...\n");
-  TPCCTableGenerator{num_warehouses, chunk_size}.generate_and_store();
+  TPCCTableGenerator{num_warehouses, chunk_size, _binary_caching}.generate_and_store();
 
   return ReturnCode::Ok;
 }
@@ -534,7 +538,7 @@ int Console::_generate_tpch(const std::string& args) {
   }
 
   out("Generating all TPCH tables (this might take a while) ...\n");
-  TPCHTableGenerator{scale_factor, ClusteringConfiguration::None, chunk_size}.generate_and_store();
+  TPCHTableGenerator{scale_factor, ClusteringConfiguration::None, chunk_size, _binary_caching}.generate_and_store();
 
   return ReturnCode::Ok;
 }
@@ -558,7 +562,7 @@ int Console::_generate_tpcds(const std::string& args) {
   }
 
   out("Generating all TPC-DS tables (this might take a while) ...\n");
-  TPCDSTableGenerator{scale_factor, chunk_size}.generate_and_store();
+  TPCDSTableGenerator{scale_factor, chunk_size, _binary_caching}.generate_and_store();
 
   return ReturnCode::Ok;
 }
@@ -597,7 +601,8 @@ int Console::_generate_ssb(const std::string& args) {
   std::filesystem::create_directories(ssb_data_path.str());
 
   out("Generating all SSB tables (this might take a while) ...\n");
-  SSBTableGenerator{ssb_dbgen_path, csv_meta_path, ssb_data_path.str(), scale_factor, chunk_size}.generate_and_store();
+  SSBTableGenerator{ssb_dbgen_path, csv_meta_path, ssb_data_path.str(), scale_factor, chunk_size, _binary_caching}
+      .generate_and_store();
 
   return ReturnCode::Ok;
 }
@@ -891,6 +896,20 @@ int Console::_change_runtime_setting(const std::string& input) {
       out("Scheduler turned off\n");
     } else {
       out("Usage: scheduler (on|off)\n");
+      return 1;
+    }
+    return 0;
+  }
+
+  if (property == "binary_caching") {
+    if (value == "on") {
+      _binary_caching = true;
+      out("Binary caching turned on\n");
+    } else if (value == "off") {
+      _binary_caching = false;
+      out("Binary caching off\n");
+    } else {
+      out("Usage: binary_caching (on|off)\n");
       return 1;
     }
     return 0;

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -514,7 +514,7 @@ int Console::_generate_tpcc(const std::string& args) {
   }
 
   out("Generating all TPCC tables (this might take a while) ...\n");
-  const auto config = AbstractTableGenerator::create_benchmark_config_with_chunk_size(chunk_size);
+  const auto config = std::make_shared<BenchmarkConfig>(chunk_size);
   config->cache_binary_tables = true;
   TPCCTableGenerator{num_warehouses, config}.generate_and_store();
 
@@ -541,7 +541,7 @@ int Console::_generate_tpch(const std::string& args) {
   }
 
   out("Generating all TPCH tables (this might take a while) ...\n");
-  const auto config = AbstractTableGenerator::create_benchmark_config_with_chunk_size(chunk_size);
+  const auto config = std::make_shared<BenchmarkConfig>(chunk_size);
   config->cache_binary_tables = true;
   TPCHTableGenerator{scale_factor, ClusteringConfiguration::None, config}.generate_and_store();
 
@@ -567,7 +567,7 @@ int Console::_generate_tpcds(const std::string& args) {
   }
 
   out("Generating all TPC-DS tables (this might take a while) ...\n");
-  const auto config = AbstractTableGenerator::create_benchmark_config_with_chunk_size(chunk_size);
+  const auto config = std::make_shared<BenchmarkConfig>(chunk_size);
   config->cache_binary_tables = true;
   TPCDSTableGenerator{scale_factor, config}.generate_and_store();
 
@@ -608,7 +608,7 @@ int Console::_generate_ssb(const std::string& args) {
   std::filesystem::create_directories(ssb_data_path.str());
 
   out("Generating all SSB tables (this might take a while) ...\n");
-  const auto config = AbstractTableGenerator::create_benchmark_config_with_chunk_size(chunk_size);
+  const auto config = std::make_shared<BenchmarkConfig>(chunk_size);
   config->cache_binary_tables = true;
   SSBTableGenerator{ssb_dbgen_path, csv_meta_path, ssb_data_path.str(), scale_factor, config}.generate_and_store();
 

--- a/src/bin/console/console.hpp
+++ b/src/bin/console/console.hpp
@@ -154,6 +154,7 @@ class Console : public Singleton<Console> {
   bool _verbose;
   bool _pagination_active;
   std::string _path;
+  bool _binary_caching{true};
 
   std::unique_ptr<SQLPipeline> _sql_pipeline;
   std::shared_ptr<TransactionContext> _explicitly_created_transaction_context;

--- a/src/bin/server.cpp
+++ b/src/bin/server.cpp
@@ -28,34 +28,36 @@
 
 namespace {
 
+using namespace hyrise;  // NOLINT(build/namespaces)
+
 void generate_benchmark_data(std::string argument_string) {
-  // Remove unnecessary white spaces
+  // Remove unnecessary whitespaces.
   boost::trim_if(argument_string, boost::is_any_of(":"));
 
-  // Remove dashes and convert to lower case to unify different writings of benchmarks ("TPC-H", "tpch", or "tpc-h")
+  // Remove dashes and convert to lower case to unify different writings of benchmarks ("TPC-H", "tpch", or "tpc-h").
   boost::replace_all(argument_string, "-", "");
   boost::to_lower(argument_string);
 
   auto benchmark_data_config = std::vector<std::string>{};
-  // Split benchmark name and sizing factor
+  // Split benchmark name and scale factor.
   boost::split(benchmark_data_config, argument_string, boost::is_any_of(":"), boost::token_compress_on);
   Assert(benchmark_data_config.size() == 2,
-         "Malformed input for benchmark data generation. Expecting a benchmark name and a sizing factor.");
+         "Malformed input for benchmark data generation. Expecting <benchmark name>:<scale factor>.");
 
   const auto benchmark_name = benchmark_data_config[0];
-  const auto sizing_factor = boost::lexical_cast<float, std::string>(benchmark_data_config[1]);
+  const auto scale_factor = boost::lexical_cast<float, std::string>(benchmark_data_config[1]);
 
   Assert(benchmark_name == "tpch" || benchmark_name == "tpcds" || benchmark_name == "tpcc",
          "Benchmark data generation is only supported for TPC-C, TPC-DS, and TPC-H.");
 
-  auto config = std::make_shared<hyrise::BenchmarkConfig>();
-  config->cache_binary_tables = true;
+  constexpr auto cache_binary_tables = true;
+  const auto config = std::make_shared<BenchmarkConfig>(Chunk::DEFAULT_SIZE, cache_binary_tables);
   if (benchmark_name == "tpcc") {
-    hyrise::TPCCTableGenerator{static_cast<uint32_t>(sizing_factor), config}.generate_and_store();
+    TPCCTableGenerator{static_cast<uint32_t>(scale_factor), config}.generate_and_store();
   } else if (benchmark_name == "tpcds") {
-    hyrise::TPCDSTableGenerator{static_cast<uint32_t>(sizing_factor), config}.generate_and_store();
+    TPCDSTableGenerator{static_cast<uint32_t>(scale_factor), config}.generate_and_store();
   } else if (benchmark_name == "tpch") {
-    hyrise::TPCHTableGenerator{sizing_factor, ClusteringConfiguration::None, config}.generate_and_store();
+    TPCHTableGenerator{scale_factor, ClusteringConfiguration::None, config}.generate_and_store();
   } else {
     Fail("Unexpected benchmark name passed in parameter 'benchmark_data'.");
   }
@@ -64,19 +66,19 @@ void generate_benchmark_data(std::string argument_string) {
 }  // namespace
 
 cxxopts::Options get_server_cli_options() {
-  cxxopts::Options cli_options("./hyriseServer", "Starts Hyrise server in order to accept network requests.");
+  auto cli_options = cxxopts::Options{"./hyriseServer", "Starts Hyrise server in order to accept network requests."};
 
   // clang-format off
   cli_options.add_options()
-    ("help", "Display this help and exit") // NOLINT
-    ("address", "Specify the address to run on", cxxopts::value<std::string>()->default_value("0.0.0.0"))  // NOLINT
-    ("p,port", "Specify the port number. 0 means randomly select an available one. If no port is specified, the the server will start on PostgreSQL's official port", cxxopts::value<uint16_t>()->default_value("5432"))  // NOLINT
+    ("help", "Display this help and exit")
+    ("address", "Specify the address to run on", cxxopts::value<std::string>()->default_value("0.0.0.0"))
+    ("p,port", "Specify the port number. 0 means randomly select an available one. If no port is specified, the "
+               "server will start on PostgreSQL's official port", cxxopts::value<uint16_t>()->default_value("5432"))
     ("benchmark_data", "Optional for benchmarking purposes: specify the benchmark name and sizing factor to generate "
                        "at server start (e.g., \"TPC-C:5\", \"TPC-DS:5\", or \"TPC-H:10\"). Supported are TPC-C, "
                        "TPC-DS, and TPC-H. The sizing factor determines the scale factor in TPC-DS and TPC-H, and the "
-                       "warehouse count in TPC-C.", cxxopts::value<std::string>()) // NOLINT
-    ("execution_info", "Send execution information after statement execution", cxxopts::value<bool>()->default_value("false")) // NOLINT
-    ;  // NOLINT
+                       "warehouse count in TPC-C.", cxxopts::value<std::string>())
+    ("execution_info", "Send execution information after statement execution", cxxopts::value<bool>()->default_value("false"));  // NOLINT(whitespace/line_length)
   // clang-format on
 
   return cli_options;
@@ -86,19 +88,19 @@ int main(int argc, char* argv[]) {
   auto cli_options = get_server_cli_options();
   const auto parsed_options = cli_options.parse(argc, argv);
 
-  // Print help and exit
+  // Print help and exit.
   if (parsed_options.count("help") > 0) {
     std::cout << cli_options.help() << '\n';
     return 0;
   }
 
   /**
-    * The optional parameter `benchmark_data` allows users to generate benchmark data when starting the hyrise server.
+    * The optional parameter `benchmark_data` allows users to generate benchmark data when starting the Hyrise server.
     * This is not an ideal solution, but due to several users' requests and our goal to facilitate easy evaluation of
     * Hyrise, we decided to integrate the data generation into the server nonetheless.
     *
     * We do not plan on exposing other parameters, such as the encoding or the chunk size via this facility. You can
-    * change the modify the config object as needed.
+    * modify the config object as needed.
     */
   if (parsed_options.count("benchmark_data") > 0) {
     generate_benchmark_data(parsed_options["benchmark_data"].as<std::string>());

--- a/src/bin/server.cpp
+++ b/src/bin/server.cpp
@@ -48,7 +48,7 @@ void generate_benchmark_data(std::string argument_string) {
   Assert(benchmark_name == "tpch" || benchmark_name == "tpcds" || benchmark_name == "tpcc",
          "Benchmark data generation is only supported for TPC-C, TPC-DS, and TPC-H.");
 
-  auto config = std::make_shared<hyrise::BenchmarkConfig>(hyrise::BenchmarkConfig::get_default_config());
+  auto config = std::make_shared<hyrise::BenchmarkConfig>();
   config->cache_binary_tables = true;
   if (benchmark_name == "tpcc") {
     hyrise::TPCCTableGenerator{static_cast<uint32_t>(sizing_factor), config}.generate_and_store();

--- a/src/bin/server.cpp
+++ b/src/bin/server.cpp
@@ -50,8 +50,8 @@ void generate_benchmark_data(std::string argument_string) {
   Assert(benchmark_name == "tpch" || benchmark_name == "tpcds" || benchmark_name == "tpcc",
          "Benchmark data generation is only supported for TPC-C, TPC-DS, and TPC-H.");
 
-  constexpr auto cache_binary_tables = true;
-  const auto config = std::make_shared<BenchmarkConfig>(Chunk::DEFAULT_SIZE, cache_binary_tables);
+  constexpr auto CACHE_BINARY_TABLES = true;
+  const auto config = std::make_shared<BenchmarkConfig>(Chunk::DEFAULT_SIZE, CACHE_BINARY_TABLES);
   if (benchmark_name == "tpcc") {
     TPCCTableGenerator{static_cast<uint32_t>(scale_factor), config}.generate_and_store();
   } else if (benchmark_name == "tpcds") {

--- a/src/test/benchmarklib/tpcc/tpcc_test.cpp
+++ b/src/test/benchmarklib/tpcc/tpcc_test.cpp
@@ -15,7 +15,7 @@ namespace hyrise {
 class TPCCTest : public BaseTest {
  public:
   static void SetUpTestCase() {
-    auto benchmark_config = std::make_shared<BenchmarkConfig>(BenchmarkConfig::get_default_config());
+    auto benchmark_config = std::make_shared<BenchmarkConfig>();
     auto table_generator = TPCCTableGenerator{NUM_WAREHOUSES, benchmark_config};
 
     tables = table_generator.generate();

--- a/src/test/lib/concurrency/stress_test.cpp
+++ b/src/test/lib/concurrency/stress_test.cpp
@@ -419,10 +419,9 @@ TEST_F(StressTest, NodeQueueSchedulerSemaphoreIncrementsDependentTasks) {
 // NUMA-bound benchmarks on a server. To catch such issues, this test executes a comparatively complex TPC-H query for
 // different fake NUMA topologies.
 TEST_F(StressTest, NodeQueueSchedulerMultiNumaNodeTPCHQ13) {
-  const auto benchmark_config = BenchmarkConfig::get_default_config();
+  const auto benchmark_config = std::make_shared<BenchmarkConfig>();
 
-  TPCHTableGenerator(0.1f, ClusteringConfiguration::None, std::make_shared<BenchmarkConfig>(benchmark_config))
-      .generate_and_store();
+  TPCHTableGenerator(0.1f, ClusteringConfiguration::None, benchmark_config).generate_and_store();
 
   auto topologies = FAKE_SINGLE_NODE_NUMA_TOPOLOGIES;
   topologies.insert(topologies.end(), FAKE_SINGLE_NODE_NUMA_TOPOLOGIES.begin(), FAKE_SINGLE_NODE_NUMA_TOPOLOGIES.end());

--- a/src/test/lib/utils/plugin_manager_test.cpp
+++ b/src/test/lib/utils/plugin_manager_test.cpp
@@ -177,8 +177,7 @@ TEST_F(PluginManagerTest, CallBenchmarkHooks) {
   auto& sm = Hyrise::get().storage_manager;
   auto& lm = Hyrise::get().log_manager;
   const std::unique_ptr<AbstractBenchmarkItemRunner> benchmark_item_runner = std::make_unique<TPCHBenchmarkItemRunner>(
-      std::make_shared<BenchmarkConfig>(BenchmarkConfig::get_default_config()), false, 1,
-      ClusteringConfiguration::None);
+      std::make_shared<BenchmarkConfig>(), false, 1, ClusteringConfiguration::None);
 
   pm.load_plugin(build_dylib_path("libhyriseTestPlugin"));
 
@@ -216,8 +215,7 @@ TEST_F(PluginManagerTest, CallBenchmarkHooks) {
 TEST_F(PluginManagerTest, CallNotExistingBenchmarkHooks) {
   auto& pm = Hyrise::get().plugin_manager;
   const std::unique_ptr<AbstractBenchmarkItemRunner> benchmark_item_runner = std::make_unique<TPCHBenchmarkItemRunner>(
-      std::make_shared<BenchmarkConfig>(BenchmarkConfig::get_default_config()), false, 1,
-      ClusteringConfiguration::None);
+      std::make_shared<BenchmarkConfig>(), false, 1, ClusteringConfiguration::None);
   auto report = nlohmann::json{};
 
   // Call non-existing plugin (with non-existing hooks).


### PR DESCRIPTION
This PR adds a config option to use binary cached benchmark tables in hyriseConsole, which is turned on by default. Furthermore, I noticed that according to the documentation, the scheduler should be turned on per default, as well. This is also fixed.

Backgroung for this was that I demoed Hyrise using the console and noticed that data generation was always triggered and running on only one core.