### PR TITLE
Mini-PR: flush server start message

### DIFF
--- a/src/lib/server/server.cpp
+++ b/src/lib/server/server.cpp
@@ -24,7 +24,7 @@ Server::Server(const boost::asio::ip::address& address, const uint16_t port,
                const SendExecutionInfo send_execution_info)
     : _acceptor(_io_service, boost::asio::ip::tcp::endpoint(address, port)), _send_execution_info(send_execution_info) {
   std::cout << "Server started at " << server_address() << " and port " << server_port() << ".\nRun 'psql -h localhost "
-            << server_address() << "' to connect to the server\n.";
+            << server_address() << "' to connect to the server\n." << std::flush;
 }
 
 void Server::run() {


### PR DESCRIPTION
This is a minimal PR that ensures that the server flushes the message "Server started at ..." when the server is starting.

We use this message in a couple of benchmarking scripts. The scripts wait for this message to be sure that the server has started. Without flushing, scripts sometimes wait forever.