### PR TITLE
[CI] Run Nix only for full CI and master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -399,10 +399,14 @@ try {
             }
           }, nixSetup: {
 	    stage('nixSetup') {
-              sh "curl -L https://nixos.org/nix/install > nix-install.sh && chmod +x nix-install.sh && ./nix-install.sh --daemon --yes"
-              sh "/nix/var/nix/profiles/default/bin/nix-shell resources/nix --pure --run \"mkdir nix-debug && cd nix-debug && cmake ${debug} ${clang} ${unity} ${ninja} .. && ninja all -j \$(( \$(nproc) / 7)) && ./hyriseTest\""
-              // We allocate a third of all cores for the release build as several parallel stages should have already finished at this point.
-              sh "/nix/var/nix/profiles/default/bin/nix-shell resources/nix --pure --run \"mkdir nix-release && cd nix-release && cmake ${release} ${clang} ${unity} ${ninja} .. && ninja all -j \$(( \$(nproc) / 3)) && ./hyriseTest\""
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "curl -L https://nixos.org/nix/install > nix-install.sh && chmod +x nix-install.sh && ./nix-install.sh --daemon --yes"
+                sh "/nix/var/nix/profiles/default/bin/nix-shell resources/nix --pure --run \"mkdir nix-debug && cd nix-debug && cmake ${debug} ${clang} ${unity} ${ninja} .. && ninja all -j \$(( \$(nproc) / 7)) && ./hyriseTest\""
+                // We allocate a third of all cores for the release build as several parallel stages should have already finished at this point.
+                sh "/nix/var/nix/profiles/default/bin/nix-shell resources/nix --pure --run \"mkdir nix-release && cd nix-release && cmake ${release} ${clang} ${unity} ${ninja} .. && ninja all -j \$(( \$(nproc) / 3)) && ./hyriseTest\""
+              } else {
+                Utils.markStageSkippedForConditional("nixSetup")
+              }
 	    }
           }
         } finally {


### PR DESCRIPTION
The CI step for nix missed the check for a full CI or master run. This PR adds this check.

https://hyrise-ci.epic-hpi.de/blue/organizations/jenkins/hyrise%2Fhyrise/detail/PR-2656/6/pipeline shows what happens. The CI hangs in a non-finishing state that does not make any progress.