### PR TITLE
Docker build fails with parse error (#2660)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # scripted pipelines. With Python >= 3.11, we need to use --break-system-packages.
 
 FROM ubuntu:23.10
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get install -y \
         autoconf \

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
     && ln -sf /usr/bin/llvm-symbolizer-14 /usr/bin/llvm-symbolizer \
-    && pip3 install --break-system-packages \
-        scipy pandas matplotlib  # preload large Python packages (installs numpy and others).
+    && pip3 install --break-system-packages scipy pandas matplotlib  # preload large Python packages (installs numpy
+                                                                     # and others).
 
 ENV HYRISE_HEADLESS_SETUP=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
     && ln -sf /usr/bin/llvm-symbolizer-14 /usr/bin/llvm-symbolizer \
-    && pip3 install --break-system-packages scipy pandas matplotlib  # preload large Python packages (installs numpy and
-                                                                       others).
+    && pip3 install --break-system-packages \
+        scipy pandas matplotlib  # preload large Python packages (installs numpy and others).
 
 ENV HYRISE_HEADLESS_SETUP=true


### PR DESCRIPTION
The docker build fails because a comment is misaligned. 

```
 => [internal] load build definition from Dockerfile                                                                                                                    2.2s
 => => transferring dockerfile: 1.71kB                                                                                                                                  0.0s
 - ConsistentInstructionCasing: Command 'others).' should match the case of the command majority (uppercase) (line 52)
Dockerfile:52
--------------------
  50 |         && ln -sf /usr/bin/llvm-symbolizer-14 /usr/bin/llvm-symbolizer \
  51 |         && pip3 install --break-system-packages scipy pandas matplotlib  # preload large Python packages (installs numpy and
  52 | >>>                                                                        others).
  53 |     
  54 |     ENV HYRISE_HEADLESS_SETUP=true
--------------------
ERROR: failed to solve: dockerfile parse error on line 52: unknown instruction: others).


```