### PR TITLE
Fix column type in TPC-DS schema

### DIFF
--- a/resources/benchmark/tpcds/schema.sql
+++ b/resources/benchmark/tpcds/schema.sql
@@ -248,7 +248,7 @@ create table customer
     c_birth_country           varchar(20)                   ,
     c_login                   char(13)                      ,
     c_email_address           char(50)                      ,
-    c_last_review_date        char(10)                      ,
+    c_last_review_date        integer                       ,
     primary key (c_customer_sk)
 );
 


### PR DESCRIPTION
While working on another project, I accidentally noticed that the TPC-DS schema we provide has the wrong data type for `customer`'s `c_last_review_date` column (`char(10)`instead of `integer`). There should not be any implications because it's correct in the table generator: https://github.com/hyrise/hyrise/blob/b31d65279c674f9af6b1e74e1302e97860861373/src/benchmarklib/tpcds/tpcds_table_generator.cpp#L225-L226

Source: https://www.tpc.org/TPC_Documents_Current_Versions/pdf/TPC-DS_v3.2.0.pdf (p. 32)