### PR TITLE
Parallelize chunk pruning statistics generation for full table

### DIFF
--- a/src/benchmarklib/benchmark_table_encoder.cpp
+++ b/src/benchmarklib/benchmark_table_encoder.cpp
@@ -136,10 +136,12 @@ bool BenchmarkTableEncoder::encode(const std::string& table_name, const std::sha
   }
   Hyrise::get().scheduler()->schedule_and_wait_for_tasks(jobs);
 
-  // Note: Pruning statistics might have already been generated during chunk encoding, in which case this call
+  // Note: Pruning statistics might have already been generated during chunk encoding above, in which case this call
   // is (almost) a NoOp.
-  // However, this does not apply when loading benchmark data that we have cached, because that data is encoded already.
-  // We still need to generate the statistics in that case, though, because we don't cache them.
+  // However, encoding might not happen when loading benchmark data that we have stored in binary, because that data is
+  // encoded already. Re-encoding will only be necessary in case the benchmark encoding config has changed, and might
+  // only affect certain chunks then.
+  // If encoding did not happen for loaded data, we still need to generate the statistics, because we do not cache those.
   generate_chunk_pruning_statistics(table);
 
   return encoding_performed;

--- a/src/benchmarklib/benchmark_table_encoder.cpp
+++ b/src/benchmarklib/benchmark_table_encoder.cpp
@@ -136,6 +136,10 @@ bool BenchmarkTableEncoder::encode(const std::string& table_name, const std::sha
   }
   Hyrise::get().scheduler()->schedule_and_wait_for_tasks(jobs);
 
+  // Note: Pruning statistics might have already been generated during chunk encoding, in which case this call
+  // is (almost) a NoOp.
+  // However, this does not apply when loading benchmark data that we have cached, because that data is encoded already.
+  // We still need to generate the statistics in that case, though, because we don't cache them.
   generate_chunk_pruning_statistics(table);
 
   return encoding_performed;

--- a/src/benchmarklib/benchmark_table_encoder.cpp
+++ b/src/benchmarklib/benchmark_table_encoder.cpp
@@ -136,12 +136,11 @@ bool BenchmarkTableEncoder::encode(const std::string& table_name, const std::sha
   }
   Hyrise::get().scheduler()->schedule_and_wait_for_tasks(jobs);
 
-  // Note: Pruning statistics might have already been generated during chunk encoding above, in which case this call
-  // is (almost) a NoOp.
-  // However, encoding might not happen when loading benchmark data that we have stored in binary, because that data is
-  // encoded already. Re-encoding will only be necessary in case the benchmark encoding config has changed, and might
-  // only affect certain chunks then.
-  // If encoding did not happen for loaded data, we still need to generate the statistics, because we do not cache those.
+  // Note: Chunk pruning statistics might have already been generated during chunk encoding above, in which case this
+  // call is (almost) a NoOp. However, encoding might not happen when loading binary table data, because that data is
+  // written after encoding, thus skipping statistic generation. Re-encoding will only be necessary in case different
+  // encoding schemes are requested by the user and might only affect certain chunks then. If no re-encoding happened,
+  // we still need to generate chunk pruning statistics, because those are not cached as part of the binary table data.
   generate_chunk_pruning_statistics(table);
 
   return encoding_performed;

--- a/src/lib/statistics/generate_pruning_statistics.cpp
+++ b/src/lib/statistics/generate_pruning_statistics.cpp
@@ -1,6 +1,5 @@
 #include "generate_pruning_statistics.hpp"
 
-#include <algorithm>
 #include <memory>
 #include <type_traits>
 #include <unordered_set>

--- a/src/lib/statistics/generate_pruning_statistics.cpp
+++ b/src/lib/statistics/generate_pruning_statistics.cpp
@@ -98,7 +98,7 @@ void generate_chunk_pruning_statistics(const std::shared_ptr<Table>& table) {
   for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
     const auto chunk = table->get_chunk(chunk_id);
 
-    if (!chunk || chunk->is_mutable()) {
+    if (!chunk || chunk->is_mutable() || chunk->pruning_statistics()) {
       continue;
     }
 

--- a/src/lib/statistics/generate_pruning_statistics.cpp
+++ b/src/lib/statistics/generate_pruning_statistics.cpp
@@ -20,10 +20,11 @@
 #include "storage/create_iterable_from_segment.hpp"
 #include "storage/table.hpp"
 #include "types.hpp"
+#include "utils/assert.hpp"
 
 namespace {
 
-using namespace hyrise;  // NOLINT
+using namespace hyrise;  // NOLINT (build/namespaces)
 
 template <typename T>
 void create_pruning_statistics_for_segment(AttributeStatistics<T>& segment_statistics,

--- a/src/lib/statistics/generate_pruning_statistics.hpp
+++ b/src/lib/statistics/generate_pruning_statistics.hpp
@@ -9,6 +9,11 @@ class Chunk;
 class Table;
 
 /**
+ * Check whether we need to generate pruning statistics for a chunk.
+ */
+bool pruning_statistics_should_be_generated_for_chunk(const std::shared_ptr<Chunk>& chunk);
+
+/**
  * Generate Pruning Filters for an immutable Chunk
  */
 void generate_chunk_pruning_statistics(const std::shared_ptr<Chunk>& chunk);

--- a/src/lib/statistics/generate_pruning_statistics.hpp
+++ b/src/lib/statistics/generate_pruning_statistics.hpp
@@ -9,9 +9,10 @@ class Chunk;
 class Table;
 
 /**
- * Check whether we need to generate pruning statistics for a chunk.
+ * Check whether a chunk is immutable and has no pruning statistics (we only want to generate statistics if both
+ * conditions are true).
  */
-bool pruning_statistics_should_be_generated_for_chunk(const std::shared_ptr<Chunk>& chunk);
+bool is_immutable_chunk_without_pruning_statistics(const std::shared_ptr<Chunk>& chunk);
 
 /**
  * Generate Pruning Filters for an immutable Chunk

--- a/src/lib/storage/chunk_encoder.cpp
+++ b/src/lib/storage/chunk_encoder.cpp
@@ -112,7 +112,7 @@ void ChunkEncoder::encode_chunk(const std::shared_ptr<Chunk>& chunk, const std::
     chunk->replace_segment(column_id, encoded_segment);
   }
 
-  if (pruning_statistics_should_be_generated_for_chunk(chunk)) {
+  if (is_immutable_chunk_without_pruning_statistics(chunk)) {
     generate_chunk_pruning_statistics(chunk);
   }
 }

--- a/src/lib/storage/chunk_encoder.cpp
+++ b/src/lib/storage/chunk_encoder.cpp
@@ -112,7 +112,9 @@ void ChunkEncoder::encode_chunk(const std::shared_ptr<Chunk>& chunk, const std::
     chunk->replace_segment(column_id, encoded_segment);
   }
 
-  generate_chunk_pruning_statistics(chunk);
+  if (pruning_statistics_should_be_generated_for_chunk(chunk)) {
+    generate_chunk_pruning_statistics(chunk);
+  }
 }
 
 void ChunkEncoder::encode_chunk(const std::shared_ptr<Chunk>& chunk, const std::vector<DataType>& column_data_types,


### PR DESCRIPTION
Parallelize generation of chunk pruning statistics when doing so for a full table.

Currently, statistics-generation is only fast when generating benchmark data from scratch (not when loading the cached binary files from disk).

This is because we immediately invoke the statistics generation when encoding a chunk (which is done in a parallel fashion). However, when chunks are already encoded, we fall back to the `generate_chunk_pruning_statistics(const std::shared_ptr<Table>& table)` for the whole table, which did not use any parallelization at all.

This step reduces the time required for the `encoding/statistics generation` step on loaded data from about 14.5s to 2.5s for SF 20.