### PR TITLE
Console: Restore default settings during `reset`

### DIFF
--- a/scripts/test/hyriseConsole_test.py
+++ b/scripts/test/hyriseConsole_test.py
@@ -129,10 +129,14 @@ def main():
     console.sendline("print nation")
     console.expect("=== Chunk 3 ===")
 
-    # Clear generated tables.
+    # Clear all generated tables and restore default configuration.
     console.sendline("reset")
     console.sendline("select * from meta_tables")
     console.expect("0 rows total")
+
+    # Make sure to turn off binary table caching again.
+    console.sendline("setting binary_caching off")
+    console.expect("Binary caching turned off")
 
     # Test TPC-C generation. We also tried different benchmarks here. SSB and JCC-H are not thread-safe due to the
     # external data generator, leading to problems since this test is executed multiple times. We consider TPC-DS data

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -140,17 +140,15 @@ Console::Console()
       _out(std::cout.rdbuf()),
       _log("console.log", std::ios_base::app | std::ios_base::out),
       _verbose(false),
-      _pagination_active(false),
-      _pqp_cache(std::make_shared<SQLPhysicalPlanCache>()),
-      _lqp_cache(std::make_shared<SQLLogicalPlanCache>()) {
+      _pagination_active(false) {
   // Init readline basics, tells readline to use our custom command completion function.
   rl_attempted_completion_function = &Console::_command_completion;
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
   rl_completer_word_break_characters = const_cast<char*>(" \t\n\"\\'`@$><=;|&{(");
 
   // Set Hyrise caches.
-  Hyrise::get().default_pqp_cache = _pqp_cache;
-  Hyrise::get().default_lqp_cache = _lqp_cache;
+  Hyrise::get().default_pqp_cache = std::make_shared<SQLPhysicalPlanCache>();
+  Hyrise::get().default_lqp_cache = std::make_shared<SQLLogicalPlanCache>();
 
   // Use scheduler.
   Hyrise::get().set_scheduler(std::make_shared<NodeQueueScheduler>());
@@ -179,6 +177,7 @@ Console::Console()
 
 Console::~Console() {
   _rollback();
+  Hyrise::get().scheduler()->finish();
 
   out("Bye.\n");
 
@@ -488,7 +487,7 @@ int Console::_help(const std::string& /*args*/) {
   out("  setting [property] [value]                - Change a runtime setting\n");
   out("           scheduler (on|off)               - Turn the scheduler on (default) or off\n");
   out("           binary_caching (on|off)          - Use cached binary tables for benchmarks (default) or not\n");
-  out("  reset                                     - Clear all stored tables and cached query plans\n\n");
+  out("  reset                                     - Clear all stored tables and cached query plans and restore the default settings\n\n");  // NOLINT(whitespace/line_length)
   // clang-format on
 
   return ReturnCode::Ok;
@@ -1027,8 +1026,8 @@ int Console::_unload_plugin(const std::string& input) {
   // The presence of some plugins might cause certain query plans to be generated which will not work if the plugin
   // is stopped. Therefore, we clear the cache. For example, a plugin might create indexes which lead to query plans
   // using IndexScans, these query plans might become unusable after the plugin is unloaded.
-  _lqp_cache->clear();
-  _pqp_cache->clear();
+  Hyrise::get().default_lqp_cache->clear();
+  Hyrise::get().default_pqp_cache->clear();
 
   out("Plugin (" + plugin_name + ") stopped.\n");
 
@@ -1037,12 +1036,14 @@ int Console::_unload_plugin(const std::string& input) {
 
 int Console::_reset() {
   _rollback();
-  _lqp_cache->clear();
-  _pqp_cache->clear();
 
   Hyrise::reset();
-  Hyrise::get().default_pqp_cache = _pqp_cache;
-  Hyrise::get().default_lqp_cache = _lqp_cache;
+  Hyrise::get().default_pqp_cache = std::make_shared<SQLPhysicalPlanCache>();
+  Hyrise::get().default_lqp_cache = std::make_shared<SQLLogicalPlanCache>();
+
+  // Restore default settings.
+  _binary_caching = true;
+  Hyrise::get().set_scheduler(std::make_shared<NodeQueueScheduler>());
 
   return ReturnCode::Ok;
 }

--- a/src/bin/console/console.hpp
+++ b/src/bin/console/console.hpp
@@ -158,8 +158,6 @@ class Console : public Singleton<Console> {
 
   std::unique_ptr<SQLPipeline> _sql_pipeline;
   std::shared_ptr<TransactionContext> _explicitly_created_transaction_context;
-  std::shared_ptr<SQLPhysicalPlanCache> _pqp_cache;
-  std::shared_ptr<SQLLogicalPlanCache> _lqp_cache;
 };
 
 }  // namespace hyrise


### PR DESCRIPTION
Just a small PR to restore the settings (scheduler, binary caching) and to fix the segfault when exiting the Console with scheduler.