### PR TITLE
Parallelize loading of benchmark data

### DIFF
--- a/scripts/test/hyriseBenchmarkTPCC_test.py
+++ b/scripts/test/hyriseBenchmarkTPCC_test.py
@@ -68,7 +68,7 @@ def main():
 
     benchmark = run_benchmark(build_dir, arguments, "hyriseBenchmarkTPCC", True)
     benchmark.expect_exact(f"Writing benchmark results to '{output_filename_2}'")
-    benchmark.expect_exact("Loading table 'NEW_ORDER' from cached binary")
+    benchmark.expect_exact("Loaded table 'NEW_ORDER' from cached binary")
 
     close_benchmark(benchmark)
     check_exit_status(benchmark)

--- a/scripts/test/hyriseBenchmarkTPCH_test.py
+++ b/scripts/test/hyriseBenchmarkTPCH_test.py
@@ -164,7 +164,7 @@ def main():
     benchmark.expect_exact("Visualizing the plans into SVG files. This will make the performance numbers invalid")
     benchmark.expect_exact("Chunk size is 10000")
     benchmark.expect_exact("Benchmarking Queries: [ 6 ]")
-    benchmark.expect_exact("Loading table 'orders' from cached binary \"tpch_cached_tables/sf-0.010000/orders.bin\"")
+    benchmark.expect_exact("Loaded table 'orders' from cached binary \"tpch_cached_tables/sf-0.010000/orders.bin\"")
     # Different encoding then previously loaded, writes binary tables again.
     benchmark.expect_exact("Writing 'lineitem' into binary file \"tpch_cached_tables/sf-0.010000/lineitem.bin\"")
 

--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -456,20 +456,30 @@ bool AbstractTableGenerator::_all_chunks_sorted_by(const std::shared_ptr<Table>&
 std::unordered_map<std::string, BenchmarkTableInfo> AbstractTableGenerator::_load_binary_tables_from_path(
     const std::string& cache_directory) {
   auto table_info_by_name = std::unordered_map<std::string, BenchmarkTableInfo>{};
+  const auto table_files = list_directory(cache_directory);
+  auto jobs = std::vector<std::shared_ptr<AbstractTask>>{};
+  jobs.reserve(table_files.size());
 
-  for (const auto& table_file : list_directory(cache_directory)) {
+  for (const auto& table_file : table_files) {
     const auto table_name = table_file.stem();
-    std::cout << "-  Loading table '" << table_name.string() << "' from cached binary " << table_file.relative_path();
+    table_info_by_name[table_name] = BenchmarkTableInfo{};
 
-    auto timer = Timer{};
-    auto table_info = BenchmarkTableInfo{};
-    table_info.table = BinaryParser::parse(table_file);
-    table_info.loaded_from_binary = true;
-    table_info.binary_file_path = table_file;
-    table_info_by_name[table_name] = table_info;
+    jobs.emplace_back(std::make_shared<JobTask>([table_name, table_file, &table_info_by_name]() {
+      auto message = std::stringstream{};
+      message << "-  Loaded table '" << table_name.string() << "' from cached binary " << table_file.relative_path();
 
-    std::cout << " (" << timer.lap_formatted() << ")\n";
+      auto timer = Timer{};
+      auto& table_info = table_info_by_name[table_name];
+      table_info.table = BinaryParser::parse(table_file);
+      table_info.loaded_from_binary = true;
+      table_info.binary_file_path = table_file;
+
+      message << " (" << timer.lap_formatted() << ")\n";
+      std::cout << message.str();
+    }));
   }
+
+  Hyrise::get().scheduler()->schedule_and_wait_for_tasks(jobs);
 
   return table_info_by_name;
 }

--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -470,14 +470,13 @@ std::unordered_map<std::string, BenchmarkTableInfo> AbstractTableGenerator::_loa
 
   for (auto& table_name_info_pair : table_info_by_name) {
     jobs.emplace_back(std::make_shared<JobTask>([&]() {
+      auto timer = Timer{};
       auto& table_info = table_name_info_pair.second;
+      table_info.table = BinaryParser::parse(*table_info.binary_file_path);
+
       auto message = std::stringstream{};
       message << "-  Loaded table '" << table_name_info_pair.first << "' from cached binary "
-              << *table_info.binary_file_path;
-
-      auto timer = Timer{};
-      table_info.table = BinaryParser::parse(*table_info.binary_file_path);
-      message << " (" << timer.lap_formatted() << ")\n";
+              << *table_info.binary_file_path << " (" << timer.lap_formatted() << ")\n";
       std::cout << message.str() << std::flush;
     }));
   }

--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -8,6 +8,7 @@
 #include <sstream>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "nlohmann/json.hpp"

--- a/src/benchmarklib/file_based_table_generator.cpp
+++ b/src/benchmarklib/file_based_table_generator.cpp
@@ -116,7 +116,7 @@ std::unordered_map<std::string, BenchmarkTableInfo> FileBasedTableGenerator::gen
       }
 
       message << " (" << table_info.table->row_count() << " rows; " << timer.lap_formatted() << ")\n";
-      std::cout << message.str();
+      std::cout << message.str() << std::flush;
     }));
   }
 

--- a/src/benchmarklib/file_based_table_generator.cpp
+++ b/src/benchmarklib/file_based_table_generator.cpp
@@ -4,14 +4,19 @@
 #include <functional>
 #include <iostream>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 #include "abstract_table_generator.hpp"
 #include "benchmark_config.hpp"
+#include "hyrise.hpp"
 #include "import_export/binary/binary_parser.hpp"
 #include "import_export/csv/csv_parser.hpp"
+#include "scheduler/abstract_task.hpp"
+#include "scheduler/job_task.hpp"
 #include "utils/assert.hpp"
 #include "utils/list_directory.hpp"
 #include "utils/load_table.hpp"
@@ -82,33 +87,40 @@ std::unordered_map<std::string, BenchmarkTableInfo> FileBasedTableGenerator::gen
   }
 
   /**
-   * 3. Actually load the tables. Load from binary file if a up-to-date binary file exists for a Table.
+   * 3. Actually load the tables. Load from binary file if a up-to-date binary file exists for a table.
    */
-  for (auto& [table_name, table_info] : table_info_by_name) {
-    auto timer = Timer{};
+  auto jobs = std::vector<std::shared_ptr<AbstractTask>>{};
+  jobs.reserve(table_info_by_name.size());
+  for (auto& table_name_info_pair : table_info_by_name) {
+    jobs.emplace_back(std::make_shared<JobTask>([&]() {
+      auto timer = Timer{};
+      auto message = std::stringstream{};
+      message << "-  Loaded table '" << table_name_info_pair.first << "' ";
+      auto& table_info = table_name_info_pair.second;
 
-    std::cout << "-  Loading table '" << table_name << "' ";
-
-    // Pick a source file to load a table from, prefer the binary version
-    if (table_info.binary_file_path && !table_info.binary_file_out_of_date) {
-      std::cout << "from " << *table_info.binary_file_path << std::flush;
-      table_info.table = BinaryParser::parse(*table_info.binary_file_path);
-      table_info.loaded_from_binary = true;
-    } else {
-      std::cout << "from " << *table_info.text_file_path << std::flush;
-      const auto extension = table_info.text_file_path->extension();
-      if (extension == ".tbl") {
-        table_info.table = load_table(*table_info.text_file_path, _benchmark_config->chunk_size);
-      } else if (extension == ".csv") {
-        table_info.table = CsvParser::parse(*table_info.text_file_path, _benchmark_config->chunk_size);
+      // Pick a source file to load a table from, prefer the binary version.
+      if (table_info.binary_file_path && !table_info.binary_file_out_of_date) {
+        message << "from " << *table_info.binary_file_path;
+        table_info.table = BinaryParser::parse(*table_info.binary_file_path);
+        table_info.loaded_from_binary = true;
       } else {
-        Fail("Unknown textual file format. This should have been caught earlier.");
+        message << "from " << *table_info.text_file_path;
+        const auto extension = table_info.text_file_path->extension();
+        if (extension == ".tbl") {
+          table_info.table = load_table(*table_info.text_file_path, _benchmark_config->chunk_size);
+        } else if (extension == ".csv") {
+          table_info.table = CsvParser::parse(*table_info.text_file_path, _benchmark_config->chunk_size);
+        } else {
+          Fail("Unknown textual file format. This should have been caught earlier.");
+        }
       }
-    }
 
-    std::cout << " (" << table_info.table->row_count() << " rows; " << timer.lap_formatted() << ")\n";
+      message << " (" << table_info.table->row_count() << " rows; " << timer.lap_formatted() << ")\n";
+      std::cout << message.str();
+    }));
   }
 
+  Hyrise::get().scheduler()->schedule_and_wait_for_tasks(jobs);
   return table_info_by_name;
 }
 


### PR DESCRIPTION
Small PR that adds a job for each benchmark table that is loaded from a file (either cached binary or CSV file for file-based benchmarks). There should not be differences for the latter case (heavy parts of CSV parsing are already parallel).

However, parsing the binaries in single-threaded, so doing this in parallel for multiple tables is advantageous for benchmarks where not only a single table dominates the loading time. Thus, the loading times decrease significantly for TPC-DS, JOB, and TPC-C.

Though loading from binaries is by far not the slowest part of benchmark preparation, it might still be noticeable for larger SFs.