### PR TITLE
Correctly parse named columns for joins

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Contact: firstname.lastname@hpi.de
 -   Hendrik   Tjabben
 -   Justin    Trautmann
 -   Carsten   Walther
+-   Robert    Weeke 
 -   Leo       Wendt
 -   Lukas     Wenzel
 -   Fabian    Wiebe

--- a/resources/test_data/sqlite_testrunner_queries.sql
+++ b/resources/test_data/sqlite_testrunner_queries.sql
@@ -175,6 +175,7 @@ SELECT * FROM id_int_int_int_100 AS t1 LEFT JOIN id_int_int_int_100 AS t2 ON t1.
 SELECT * FROM id_int_int_int_100 AS t1 LEFT JOIN id_int_int_int_100 AS t2 ON t1.a <= t2.a;
 SELECT * FROM id_int_int_int_100 AS t1 LEFT JOIN id_int_int_int_100 AS t2 ON t1.a >= t2.a;
 SELECT * FROM mixed AS t1 LEFT JOIN mixed AS t2 ON t1.id >= t2.b WHERE t1.id > 90;
+SELECT * FROM id_int_int_int_100 AS t1 INNER JOIN (SELECT a AS id FROM id_int_int_int_100) t2 USING (id) 
 
 -- Join multiple predicates
 SELECT * FROM mixed AS t1 JOIN mixed_null AS t2 ON t1.a = t2.a AND t1.b = t2.b;

--- a/src/lib/sql/sql_translator.cpp
+++ b/src/lib/sql/sql_translator.cpp
@@ -741,7 +741,7 @@ SQLTranslator::TableSourceState SQLTranslator::_translate_table_ref(const hsql::
         return _translate_natural_join(*hsql_table_ref.join);
       } else {
         if (hsql_table_ref.join->namedColumns && !hsql_table_ref.join->namedColumns->empty()) {
-          return _translate_namedColumns_join(*hsql_table_ref.join);
+          return _translate_named_columns_join(*hsql_table_ref.join);
         }
         return _translate_predicated_join(*hsql_table_ref.join);
       }
@@ -1054,7 +1054,7 @@ SQLTranslator::TableSourceState SQLTranslator::_translate_predicated_join(const 
   return result_state;
 }
 
-SQLTranslator::TableSourceState SQLTranslator::_translate_namedColumns_join(const hsql::JoinDefinition& join) {
+SQLTranslator::TableSourceState SQLTranslator::_translate_named_columns_join(const hsql::JoinDefinition& join) {
   const auto join_mode = translate_join_mode(join.type);
 
   auto left_state = _translate_table_ref(*join.left);

--- a/src/lib/sql/sql_translator.cpp
+++ b/src/lib/sql/sql_translator.cpp
@@ -1069,8 +1069,8 @@ SQLTranslator::TableSourceState SQLTranslator::_translate_named_columns_join(con
   const auto& left_sql_identifier_resolver = left_state.sql_identifier_resolver;
   const auto& right_sql_identifier_resolver = right_state.sql_identifier_resolver;
 
-  Assert(left_sql_identifier_resolver, "Could not find valid sql_identifier resolver for left input.");
-  Assert(right_sql_identifier_resolver, "Could not find valid sql_identifier resolver for right input.");
+  Assert(left_sql_identifier_resolver, "Expected SQLIdentifierResolver for left input.");
+  Assert(right_sql_identifier_resolver, "Expected SQLIdentifierResolver for right input.");
 
   auto join_predicates = std::vector<std::shared_ptr<AbstractExpression>>{};
   join_predicates.reserve(join.namedColumns->size());

--- a/src/lib/sql/sql_translator.cpp
+++ b/src/lib/sql/sql_translator.cpp
@@ -1063,8 +1063,8 @@ SQLTranslator::TableSourceState SQLTranslator::_translate_named_columns_join(con
   auto left_input_lqp = left_state.lqp;
   auto right_input_lqp = right_state.lqp;
 
-  Assert(!join.condition, "Specify either a condition or namedColums for JOIN not both.");
-  Assert(!join.namedColumns->empty(), "No named column to use for JOIN.");
+  Assert(!join.namedColumns->empty(), "Expected at least one named column.");
+  Assert(!join.condition, "Did not expect join condition for join using named columns.");
 
   const auto& left_sql_identifier_resolver = left_state.sql_identifier_resolver;
   const auto& right_sql_identifier_resolver = right_state.sql_identifier_resolver;

--- a/src/lib/sql/sql_translator.cpp
+++ b/src/lib/sql/sql_translator.cpp
@@ -1057,6 +1057,7 @@ SQLTranslator::TableSourceState SQLTranslator::_translate_predicated_join(const 
 SQLTranslator::TableSourceState SQLTranslator::_translate_named_columns_join(const hsql::JoinDefinition& join) {
   const auto join_mode = translate_join_mode(join.type);
 
+  // We reuse `left_state` for the construction of the updated `TableSourceState`.
   auto left_state = _translate_table_ref(*join.left);
   const auto right_state = _translate_table_ref(*join.right);
 

--- a/src/lib/sql/sql_translator.cpp
+++ b/src/lib/sql/sql_translator.cpp
@@ -1061,7 +1061,7 @@ SQLTranslator::TableSourceState SQLTranslator::_translate_named_columns_join(con
   const auto right_state = _translate_table_ref(*join.right);
 
   const auto left_input_lqp = left_state.lqp;
-  const auto& right_input_lqp = right_state.lqp;
+  const auto right_input_lqp = right_state.lqp;
 
   Assert(!join.namedColumns->empty(), "Expected at least one named column.");
   Assert(!join.condition, "Did not expect join condition for join using named columns.");

--- a/src/lib/sql/sql_translator.cpp
+++ b/src/lib/sql/sql_translator.cpp
@@ -1088,7 +1088,7 @@ SQLTranslator::TableSourceState SQLTranslator::_translate_named_columns_join(con
 
       if (left_expression && std::find(join.namedColumns->begin(), join.namedColumns->end(),
                                        right_identifier.column_name) != join.namedColumns->end()) {
-        // Two columns match and are named. Create a join predicate.
+        // Two columns match and are named. Therefore create a join predicate.
         join_predicates.emplace_back(equals_(left_expression, right_expression));
         continue;
       }

--- a/src/lib/sql/sql_translator.cpp
+++ b/src/lib/sql/sql_translator.cpp
@@ -1058,7 +1058,7 @@ SQLTranslator::TableSourceState SQLTranslator::_translate_named_columns_join(con
   const auto join_mode = translate_join_mode(join.type);
 
   auto left_state = _translate_table_ref(*join.left);
-  const auto& right_state = _translate_table_ref(*join.right);
+  const auto right_state = _translate_table_ref(*join.right);
 
   const auto left_input_lqp = left_state.lqp;
   const auto& right_input_lqp = right_state.lqp;
@@ -1072,7 +1072,7 @@ SQLTranslator::TableSourceState SQLTranslator::_translate_named_columns_join(con
   Assert(left_sql_identifier_resolver, "Expected SQLIdentifierResolver for left input.");
   Assert(right_sql_identifier_resolver, "Expected SQLIdentifierResolver for right input.");
 
-  auto join_predicates = std::vector<std::shared_ptr<AbstractExpression>>{join.namedColumns->size()};
+  auto join_predicates = std::vector<std::shared_ptr<AbstractExpression>>(join.namedColumns->size());
 
   const auto resolve_table_name = [](const auto& input_ref) {
     Assert(input_ref.alias || input_ref.name, "Every table or nested SELECT must have either a name or an alias.");

--- a/src/lib/sql/sql_translator.cpp
+++ b/src/lib/sql/sql_translator.cpp
@@ -1063,13 +1063,13 @@ SQLTranslator::TableSourceState SQLTranslator::_translate_namedColumns_join(cons
   auto left_input_lqp = left_state.lqp;
   auto right_input_lqp = right_state.lqp;
 
-  AssertInput(!join.condition, "Specify either a condition or namedColums for JOIN not both!");
+  AssertInput(!join.condition, "Specify either a condition or namedColums for JOIN not both");
 
   const auto left_sql_identifier_resolver = left_state.sql_identifier_resolver;
 
   Assert(left_sql_identifier_resolver, "Could not find valid sql_identifier resolver");
 
-  // left_state becomes the result state
+  // left_state becomes the result state.
   auto result_state = std::move(left_state);
 
   auto join_predicates = std::vector<std::shared_ptr<AbstractExpression>>{};
@@ -1080,7 +1080,7 @@ SQLTranslator::TableSourceState SQLTranslator::_translate_namedColumns_join(cons
     const auto& right_identifiers = right_element.identifiers;
 
     if (!right_identifiers.empty()) {
-      // Ignore previous names if there is an alias
+      // Ignore previous names if there is an alias.
       const auto right_identifier = right_identifiers.back();
 
       const auto left_expression =
@@ -1088,13 +1088,13 @@ SQLTranslator::TableSourceState SQLTranslator::_translate_namedColumns_join(cons
 
       if (left_expression && std::find(join.namedColumns->begin(), join.namedColumns->end(),
                                        right_identifier.column_name) != join.namedColumns->end()) {
-        // Two columns match and are named, create a join predicate
+        // Two columns match and are named. Create a join predicate.
         join_predicates.emplace_back(equals_(left_expression, right_expression));
         continue;
       }
 
-      // No matching column in the left input found or the column was not one of the named_columns:
-      //   Add the column from the right input to the output.
+      // No matching column in the left input found or the column was not one of the named_columns.
+      // Add the column from the right input to the output.
       result_state.elements_in_order.emplace_back(right_element);
       result_state.sql_identifier_resolver->add_column_name(right_expression, right_identifier.column_name);
       if (right_identifier.table_name) {
@@ -1104,7 +1104,7 @@ SQLTranslator::TableSourceState SQLTranslator::_translate_namedColumns_join(cons
     }
   }
 
-  AssertInput(join_predicates.size() == join.namedColumns->size(), "Could not find all named columns in input tables!");
+  AssertInput(join_predicates.size() == join.namedColumns->size(), "Could not find all named columns in input tables");
 
   auto lqp = JoinNode::make(join_mode, join_predicates, left_input_lqp, right_input_lqp);
   result_state.lqp = lqp;

--- a/src/lib/sql/sql_translator.hpp
+++ b/src/lib/sql/sql_translator.hpp
@@ -149,6 +149,7 @@ class SQLTranslator final {
       const std::string& name, const std::shared_ptr<SQLIdentifierResolver>& sql_identifier_resolver);
   TableSourceState _translate_predicated_join(const hsql::JoinDefinition& join);
   TableSourceState _translate_natural_join(const hsql::JoinDefinition& join);
+  TableSourceState _translate_namedColumns_join(const hsql::JoinDefinition& join);
   TableSourceState _translate_cross_product(const std::vector<hsql::TableRef*>& tables);
 
   std::vector<SelectListElement> _translate_select_list(const std::vector<hsql::Expr*>& select_list);

--- a/src/lib/sql/sql_translator.hpp
+++ b/src/lib/sql/sql_translator.hpp
@@ -149,7 +149,7 @@ class SQLTranslator final {
       const std::string& name, const std::shared_ptr<SQLIdentifierResolver>& sql_identifier_resolver);
   TableSourceState _translate_predicated_join(const hsql::JoinDefinition& join);
   TableSourceState _translate_natural_join(const hsql::JoinDefinition& join);
-  TableSourceState _translate_namedColumns_join(const hsql::JoinDefinition& join);
+  TableSourceState _translate_named_columns_join(const hsql::JoinDefinition& join);
   TableSourceState _translate_cross_product(const std::vector<hsql::TableRef*>& tables);
 
   std::vector<SelectListElement> _translate_select_list(const std::vector<hsql::Expr*>& select_list);
@@ -194,7 +194,6 @@ class SQLTranslator final {
   std::shared_ptr<AbstractExpression> _translate_hsql_case(
       const hsql::Expr& expr, const std::shared_ptr<SQLIdentifierResolver>& sql_identifier_resolver);
 
- private:
   const UseMvcc _use_mvcc;
 
   std::shared_ptr<AbstractLQPNode> _current_lqp;

--- a/src/test/lib/sql/sql_translator_test.cpp
+++ b/src/test/lib/sql/sql_translator_test.cpp
@@ -1620,22 +1620,22 @@ TEST_F(SQLTranslatorTest, JoinInnerUsingNamedColumnsColumnAlias) {
 }
 
 TEST_F(SQLTranslatorTest, JoinInnerUsingNamedColumnsBadNamedColumn) {
-  // int_float2 alias (c,b) does not contain a column named d
+  // `int_float2` alias `(c,b)` does not contain a column named `d`.
   EXPECT_THROW(
       sql_to_lqp_helper("SELECT * FROM int_float AS int_float(c,d) INNER JOIN int_float2 AS intfloat2(c,b) USING (d)"),
       InvalidInputException);
 
-  // int_float2 alias (c,c) is ambiguous
+  // `int_float2` alias `(c,c)` is ambiguous.
   EXPECT_THROW(
       sql_to_lqp_helper("SELECT * FROM int_float AS int_float(c,d) INNER JOIN int_float2 AS intfloat2(c,c) USING (c)"),
       InvalidInputException);
 
-  // int_float alias (c,c) is ambiguous
+  // `int_float` alias `(c,c)` is ambiguous.
   EXPECT_THROW(
       sql_to_lqp_helper("SELECT * FROM int_float AS int_float(c,c) INNER JOIN int_float2 AS intfloat2(c,b) USING (c)"),
       InvalidInputException);
 
-  // int_float alias (c,b) does not contain a column named d
+  // `int_float` alias `(c,b)` does not contain a column named `d`.
   EXPECT_THROW(
       sql_to_lqp_helper("SELECT * FROM int_float AS int_float(c,b) INNER JOIN int_float2 AS intfloat2(c,d) USING (d)"),
       InvalidInputException);

--- a/src/test/lib/sql/sql_translator_test.cpp
+++ b/src/test/lib/sql/sql_translator_test.cpp
@@ -1,3 +1,6 @@
+#include <memory>
+#include <vector>
+
 #include "base_test.hpp"
 #include "expression/abstract_expression.hpp"
 #include "expression/binary_predicate_expression.hpp"
@@ -1569,6 +1572,21 @@ TEST_F(SQLTranslatorTest, JoinNaturalColumnAlias) {
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
 
+TEST_F(SQLTranslatorTest, JoinInnerUsingSimple) {
+  const auto [actual_lqp, translation_info] = sql_to_lqp_helper(
+      "SELECT "
+      " * "
+      "FROM "
+      "  int_float INNER JOIN int_float2 USING (a)");
+
+  const auto expected_lqp =
+      ProjectionNode::make(expression_vector(int_float_a, int_float_b, int_float2_b),
+                           JoinNode::make(JoinMode::Inner, equals_(int_float_a, int_float2_a),
+                                          stored_table_node_int_float, stored_table_node_int_float2));
+
+  EXPECT_LQP_EQ(actual_lqp, expected_lqp);
+}
+
 TEST_F(SQLTranslatorTest, JoinInnerComplexPredicateA) {
   const auto [actual_lqp, translation_info] = sql_to_lqp_helper(
       "SELECT * FROM int_float JOIN int_float2 ON int_float.a + int_float2.a = int_float2.b * int_float.a;");
@@ -1582,6 +1600,100 @@ TEST_F(SQLTranslatorTest, JoinInnerComplexPredicateA) {
       stored_table_node_int_float,
       stored_table_node_int_float2));
   // clang-format on
+
+  EXPECT_LQP_EQ(actual_lqp, expected_lqp);
+}
+
+TEST_F(SQLTranslatorTest, JoinInnerUsingColumnAlias) {
+  // Test that the USING statement works with a column alias and multiple columns
+
+  const auto [actual_lqp, translation_info] = sql_to_lqp_helper(
+      "SELECT "
+      " * "
+      "FROM "
+      "  int_float AS int_float(c,d) INNER JOIN int_float2 AS intfloat2(c,b) USING (c)");
+
+  const auto expected_lqp = AliasNode::make(
+      expression_vector(int_float_a, int_float_b, int_float2_b), std::vector<std::string>({"c", "d", "b"}),
+      ProjectionNode::make(expression_vector(int_float_a, int_float_b, int_float2_b),
+                           JoinNode::make(JoinMode::Inner, equals_(int_float_a, int_float2_a),
+                                          stored_table_node_int_float, stored_table_node_int_float2)));
+
+  EXPECT_LQP_EQ(actual_lqp, expected_lqp);
+}
+
+TEST_F(SQLTranslatorTest, JoinInnerUsingBadNamedColumn) {
+  // Test that the USING statement also fails if column names are not existing or ambiguous
+
+  // int_float2 alias (c,b) does contain a column named d
+  EXPECT_THROW(sql_to_lqp_helper("SELECT "
+                                 " * "
+                                 "FROM "
+                                 "  int_float AS int_float(c,d) INNER JOIN int_float2 AS intfloat2(c,b) USING (d)"),
+               InvalidInputException);
+
+  // int_float2 alias (c,c) is ambiguous
+  EXPECT_THROW(sql_to_lqp_helper("SELECT "
+                                 " * "
+                                 "FROM "
+                                 "  int_float AS int_float(c,d) INNER JOIN int_float2 AS intfloat2(c,c) USING (c)"),
+               InvalidInputException);
+
+  // int_float alias (c,c) is ambiguous
+  EXPECT_THROW(sql_to_lqp_helper("SELECT "
+                                 " * "
+                                 "FROM "
+                                 "  int_float AS int_float(c,c) INNER JOIN int_float2 AS intfloat2(c,b) USING (c)"),
+               InvalidInputException);
+
+  // int_float alias (c,b) does not contain a column named d
+  EXPECT_THROW(sql_to_lqp_helper("SELECT "
+                                 " * "
+                                 "FROM "
+                                 "  int_float AS int_float(c,b) INNER JOIN int_float2 AS intfloat2(c,d) USING (d)"),
+               InvalidInputException);
+}
+
+TEST_F(SQLTranslatorTest, JoinInnerUsingMultipleColumns) {
+  // Test that the USING statement works with multiple columns
+
+  const auto [actual_lqp, translation_info] = sql_to_lqp_helper(
+      "SELECT "
+      " * "
+      "FROM "
+      "  int_float AS int_float(c,d) INNER JOIN int_float2 AS intfloat2(c,d) USING (c,d)");
+
+  const auto expected_lqp = AliasNode::make(
+      expression_vector(int_float_a, int_float_b), std::vector<std::string>({"c", "d"}),
+      ProjectionNode::make(expression_vector(int_float_a, int_float_b),
+                           JoinNode::make(JoinMode::Inner,
+                                          std::vector<std::shared_ptr<AbstractExpression>>{
+                                              equals_(int_float_a, int_float2_a), equals_(int_float_b, int_float2_b)},
+                                          stored_table_node_int_float, stored_table_node_int_float2)));
+
+  EXPECT_LQP_EQ(actual_lqp, expected_lqp);
+}
+
+TEST_F(SQLTranslatorTest, JoinInnerUsingNested) {
+  // Test that the USING statement works with nested SELECT statements
+
+  const auto [actual_lqp, translation_info] = sql_to_lqp_helper(
+      "SELECT "
+      " * "
+      "FROM "
+      " int_float JOIN (SELECT a, int_float2.b, int_float5.d FROM int_float2 JOIN int_float5 USING (a)) AS "
+      "int_float_comb(a, c, d) USING (a)");
+
+  const auto expected_lqp = AliasNode::make(
+      expression_vector(int_float_a, int_float_b, int_float2_b, int_float5_d),
+      std::vector<std::string>({"a", "b", "c", "d"}),
+      ProjectionNode::make(
+          expression_vector(int_float_a, int_float_b, int_float2_b, int_float5_d),
+          JoinNode::make(
+              JoinMode::Inner, equals_(int_float_a, int_float2_a), stored_table_node_int_float,
+              ProjectionNode::make(expression_vector(int_float2_a, int_float2_b, int_float5_d),
+                                   JoinNode::make(JoinMode::Inner, equals_(int_float2_a, int_float5_a),
+                                                  stored_table_node_int_float2, stored_table_node_int_float5)))));
 
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }

--- a/src/test/lib/sql/sql_translator_test.cpp
+++ b/src/test/lib/sql/sql_translator_test.cpp
@@ -1,6 +1,3 @@
-#include <memory>
-#include <vector>
-
 #include "base_test.hpp"
 #include "expression/abstract_expression.hpp"
 #include "expression/binary_predicate_expression.hpp"
@@ -1572,21 +1569,6 @@ TEST_F(SQLTranslatorTest, JoinNaturalColumnAlias) {
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
 
-TEST_F(SQLTranslatorTest, JoinInnerUsingSimple) {
-  const auto [actual_lqp, translation_info] = sql_to_lqp_helper(
-      "SELECT "
-      " * "
-      "FROM "
-      "  int_float INNER JOIN int_float2 USING (a)");
-
-  const auto expected_lqp =
-      ProjectionNode::make(expression_vector(int_float_a, int_float_b, int_float2_b),
-                           JoinNode::make(JoinMode::Inner, equals_(int_float_a, int_float2_a),
-                                          stored_table_node_int_float, stored_table_node_int_float2));
-
-  EXPECT_LQP_EQ(actual_lqp, expected_lqp);
-}
-
 TEST_F(SQLTranslatorTest, JoinInnerComplexPredicateA) {
   const auto [actual_lqp, translation_info] = sql_to_lqp_helper(
       "SELECT * FROM int_float JOIN int_float2 ON int_float.a + int_float2.a = int_float2.b * int_float.a;");
@@ -1604,9 +1586,22 @@ TEST_F(SQLTranslatorTest, JoinInnerComplexPredicateA) {
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
 
-TEST_F(SQLTranslatorTest, JoinInnerUsingColumnAlias) {
-  // Test that the USING statement works with a column alias and multiple columns
+TEST_F(SQLTranslatorTest, JoinInnerUsingNamedColumnsSimple) {
+  const auto [actual_lqp, translation_info] = sql_to_lqp_helper(
+      "SELECT "
+      " * "
+      "FROM "
+      "  int_float INNER JOIN int_float2 USING (a)");
 
+  const auto expected_lqp =
+      ProjectionNode::make(expression_vector(int_float_a, int_float_b, int_float2_b),
+                           JoinNode::make(JoinMode::Inner, equals_(int_float_a, int_float2_a),
+                                          stored_table_node_int_float, stored_table_node_int_float2));
+
+  EXPECT_LQP_EQ(actual_lqp, expected_lqp);
+}
+
+TEST_F(SQLTranslatorTest, JoinInnerUsingNamedColumnsColumnAlias) {
   const auto [actual_lqp, translation_info] = sql_to_lqp_helper(
       "SELECT "
       " * "
@@ -1622,10 +1617,8 @@ TEST_F(SQLTranslatorTest, JoinInnerUsingColumnAlias) {
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
 
-TEST_F(SQLTranslatorTest, JoinInnerUsingBadNamedColumn) {
-  // Test that the USING statement also fails if column names are not existing or ambiguous
-
-  // int_float2 alias (c,b) does contain a column named d
+TEST_F(SQLTranslatorTest, JoinInnerUsingNamedColumnsBadNamedColumn) {
+  // int_float2 alias (c,b) does not contain a column named d
   EXPECT_THROW(sql_to_lqp_helper("SELECT "
                                  " * "
                                  "FROM "
@@ -1654,9 +1647,7 @@ TEST_F(SQLTranslatorTest, JoinInnerUsingBadNamedColumn) {
                InvalidInputException);
 }
 
-TEST_F(SQLTranslatorTest, JoinInnerUsingMultipleColumns) {
-  // Test that the USING statement works with multiple columns
-
+TEST_F(SQLTranslatorTest, JoinInnerUsingNamedColumnsMultipleColumns) {
   const auto [actual_lqp, translation_info] = sql_to_lqp_helper(
       "SELECT "
       " * "
@@ -1674,9 +1665,7 @@ TEST_F(SQLTranslatorTest, JoinInnerUsingMultipleColumns) {
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
 
-TEST_F(SQLTranslatorTest, JoinInnerUsingNested) {
-  // Test that the USING statement works with nested SELECT statements
-
+TEST_F(SQLTranslatorTest, JoinInnerUsingNamedColumnsNested) {
   const auto [actual_lqp, translation_info] = sql_to_lqp_helper(
       "SELECT "
       " * "

--- a/src/test/lib/sql/sql_translator_test.cpp
+++ b/src/test/lib/sql/sql_translator_test.cpp
@@ -1551,16 +1551,18 @@ TEST_F(SQLTranslatorTest, JoinNaturalColumnAlias) {
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
 
-TEST_F(SQLTranslatorTest, JoinNaturalDerivedTable) {
-  // Test that the Natural join can work with derived tables.
+TEST_F(SQLTranslatorTest, JoinNaturalSelectedConstant) {
+  // Test that the natural join can work with selected constants.
 
   const auto [actual_lqp, translation_info] =
       sql_to_lqp_helper("SELECT * FROM int_float NATURAL JOIN (SELECT 123 as a) bar;");
 
-  const auto derived_table_node = AliasNode::make(expression_vector(123), std::vector<std::string>({"a"}),
-                                                  ProjectionNode::make(expression_vector(123), DummyTableNode::make()));
-
   // clang-format off
+  const auto derived_table_node =
+  AliasNode::make(expression_vector(123), std::vector<std::string>({"a"}),
+    ProjectionNode::make(expression_vector(123),
+      DummyTableNode::make()));
+
   const auto expected_lqp =
   ProjectionNode::make(expression_vector(int_float_a, int_float_b),
     JoinNode::make(JoinMode::Inner, equals_(int_float_a, 123),

--- a/src/test/lib/sql/sql_translator_test.cpp
+++ b/src/test/lib/sql/sql_translator_test.cpp
@@ -1587,8 +1587,8 @@ TEST_F(SQLTranslatorTest, JoinInnerComplexPredicateA) {
 }
 
 TEST_F(SQLTranslatorTest, JoinInnerUsingNamedColumnsSimple) {
-  const auto [actual_lqp, translation_info] = sql_to_lqp_helper(
-    "SELECT * FROM int_float INNER JOIN int_float2 USING (a)");
+  const auto [actual_lqp, translation_info] =
+      sql_to_lqp_helper("SELECT * FROM int_float INNER JOIN int_float2 USING (a)");
 
   // clang-format off
   const auto expected_lqp =
@@ -1602,8 +1602,8 @@ TEST_F(SQLTranslatorTest, JoinInnerUsingNamedColumnsSimple) {
 }
 
 TEST_F(SQLTranslatorTest, JoinInnerUsingNamedColumnsColumnAlias) {
-  const auto [actual_lqp, translation_info] = sql_to_lqp_helper(
-  "SELECT * FROM int_float AS int_float(c,d) INNER JOIN int_float2 AS intfloat2(c,b) USING (c)");
+  const auto [actual_lqp, translation_info] =
+      sql_to_lqp_helper("SELECT * FROM int_float AS int_float(c,d) INNER JOIN int_float2 AS intfloat2(c,b) USING (c)");
 
   // clang-format off
   const auto expected_lqp =
@@ -1619,29 +1619,29 @@ TEST_F(SQLTranslatorTest, JoinInnerUsingNamedColumnsColumnAlias) {
 
 TEST_F(SQLTranslatorTest, JoinInnerUsingNamedColumnsBadNamedColumn) {
   // int_float2 alias (c,b) does not contain a column named d
-  EXPECT_THROW(sql_to_lqp_helper(
-      "SELECT * FROM int_float AS int_float(c,d) INNER JOIN int_float2 AS intfloat2(c,b) USING (d)"),
-    InvalidInputException);
+  EXPECT_THROW(
+      sql_to_lqp_helper("SELECT * FROM int_float AS int_float(c,d) INNER JOIN int_float2 AS intfloat2(c,b) USING (d)"),
+      InvalidInputException);
 
   // int_float2 alias (c,c) is ambiguous
-  EXPECT_THROW(sql_to_lqp_helper(
-      "SELECT * FROM int_float AS int_float(c,d) INNER JOIN int_float2 AS intfloat2(c,c) USING (c)"),
-    InvalidInputException);
+  EXPECT_THROW(
+      sql_to_lqp_helper("SELECT * FROM int_float AS int_float(c,d) INNER JOIN int_float2 AS intfloat2(c,c) USING (c)"),
+      InvalidInputException);
 
   // int_float alias (c,c) is ambiguous
-  EXPECT_THROW(sql_to_lqp_helper(
-      "SELECT * FROM int_float AS int_float(c,c) INNER JOIN int_float2 AS intfloat2(c,b) USING (c)"),
-    InvalidInputException);
+  EXPECT_THROW(
+      sql_to_lqp_helper("SELECT * FROM int_float AS int_float(c,c) INNER JOIN int_float2 AS intfloat2(c,b) USING (c)"),
+      InvalidInputException);
 
   // int_float alias (c,b) does not contain a column named d
-  EXPECT_THROW(sql_to_lqp_helper(
-      "SELECT * FROM int_float AS int_float(c,b) INNER JOIN int_float2 AS intfloat2(c,d) USING (d)"),
-    InvalidInputException);
+  EXPECT_THROW(
+      sql_to_lqp_helper("SELECT * FROM int_float AS int_float(c,b) INNER JOIN int_float2 AS intfloat2(c,d) USING (d)"),
+      InvalidInputException);
 }
 
 TEST_F(SQLTranslatorTest, JoinInnerUsingNamedColumnsMultipleColumns) {
   const auto [actual_lqp, translation_info] = sql_to_lqp_helper(
-    "SELECT * FROM int_float AS int_float(c,d) INNER JOIN int_float2 AS intfloat2(c,d) USING (c,d)");
+      "SELECT * FROM int_float AS int_float(c,d) INNER JOIN int_float2 AS intfloat2(c,d) USING (c,d)");
 
   // clang-format off
   const auto expected_lqp =
@@ -1661,9 +1661,9 @@ TEST_F(SQLTranslatorTest, JoinInnerUsingNamedColumnsMultipleColumns) {
 
 TEST_F(SQLTranslatorTest, JoinInnerUsingNamedColumnsNested) {
   const auto [actual_lqp, translation_info] = sql_to_lqp_helper(
-    "SELECT * FROM int_float JOIN "
+      "SELECT * FROM int_float JOIN "
       "(SELECT a, int_float2.b, int_float5.d FROM int_float2 JOIN int_float5 USING (a))"
-    "AS int_float_comb(a, c, d) USING (a)");
+      "AS int_float_comb(a, c, d) USING (a)");
 
   // clang-format off
   const auto expected_lqp =

--- a/src/test/lib/sql/sql_translator_test.cpp
+++ b/src/test/lib/sql/sql_translator_test.cpp
@@ -1588,101 +1588,96 @@ TEST_F(SQLTranslatorTest, JoinInnerComplexPredicateA) {
 
 TEST_F(SQLTranslatorTest, JoinInnerUsingNamedColumnsSimple) {
   const auto [actual_lqp, translation_info] = sql_to_lqp_helper(
-      "SELECT "
-      " * "
-      "FROM "
-      "  int_float INNER JOIN int_float2 USING (a)");
+    "SELECT * FROM int_float INNER JOIN int_float2 USING (a)");
 
+  // clang-format off
   const auto expected_lqp =
-      ProjectionNode::make(expression_vector(int_float_a, int_float_b, int_float2_b),
-                           JoinNode::make(JoinMode::Inner, equals_(int_float_a, int_float2_a),
-                                          stored_table_node_int_float, stored_table_node_int_float2));
+  ProjectionNode::make(expression_vector(int_float_a, int_float_b, int_float2_b),
+    JoinNode::make(JoinMode::Inner, equals_(int_float_a, int_float2_a),
+      stored_table_node_int_float,
+      stored_table_node_int_float2));
+  // clang-format on
 
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
 
 TEST_F(SQLTranslatorTest, JoinInnerUsingNamedColumnsColumnAlias) {
   const auto [actual_lqp, translation_info] = sql_to_lqp_helper(
-      "SELECT "
-      " * "
-      "FROM "
-      "  int_float AS int_float(c,d) INNER JOIN int_float2 AS intfloat2(c,b) USING (c)");
+  "SELECT * FROM int_float AS int_float(c,d) INNER JOIN int_float2 AS intfloat2(c,b) USING (c)");
 
-  const auto expected_lqp = AliasNode::make(
-      expression_vector(int_float_a, int_float_b, int_float2_b), std::vector<std::string>({"c", "d", "b"}),
-      ProjectionNode::make(expression_vector(int_float_a, int_float_b, int_float2_b),
-                           JoinNode::make(JoinMode::Inner, equals_(int_float_a, int_float2_a),
-                                          stored_table_node_int_float, stored_table_node_int_float2)));
-
+  // clang-format off
+  const auto expected_lqp =
+  AliasNode::make(expression_vector(int_float_a, int_float_b, int_float2_b),
+    std::vector<std::string>({"c", "d", "b"}),
+    ProjectionNode::make(expression_vector(int_float_a, int_float_b, int_float2_b),
+      JoinNode::make(JoinMode::Inner, equals_(int_float_a, int_float2_a),
+        stored_table_node_int_float,
+        stored_table_node_int_float2)));
+  // clang-format on
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
 
 TEST_F(SQLTranslatorTest, JoinInnerUsingNamedColumnsBadNamedColumn) {
   // int_float2 alias (c,b) does not contain a column named d
-  EXPECT_THROW(sql_to_lqp_helper("SELECT "
-                                 " * "
-                                 "FROM "
-                                 "  int_float AS int_float(c,d) INNER JOIN int_float2 AS intfloat2(c,b) USING (d)"),
-               InvalidInputException);
+  EXPECT_THROW(sql_to_lqp_helper(
+      "SELECT * FROM int_float AS int_float(c,d) INNER JOIN int_float2 AS intfloat2(c,b) USING (d)"),
+    InvalidInputException);
 
   // int_float2 alias (c,c) is ambiguous
-  EXPECT_THROW(sql_to_lqp_helper("SELECT "
-                                 " * "
-                                 "FROM "
-                                 "  int_float AS int_float(c,d) INNER JOIN int_float2 AS intfloat2(c,c) USING (c)"),
-               InvalidInputException);
+  EXPECT_THROW(sql_to_lqp_helper(
+      "SELECT * FROM int_float AS int_float(c,d) INNER JOIN int_float2 AS intfloat2(c,c) USING (c)"),
+    InvalidInputException);
 
   // int_float alias (c,c) is ambiguous
-  EXPECT_THROW(sql_to_lqp_helper("SELECT "
-                                 " * "
-                                 "FROM "
-                                 "  int_float AS int_float(c,c) INNER JOIN int_float2 AS intfloat2(c,b) USING (c)"),
-               InvalidInputException);
+  EXPECT_THROW(sql_to_lqp_helper(
+      "SELECT * FROM int_float AS int_float(c,c) INNER JOIN int_float2 AS intfloat2(c,b) USING (c)"),
+    InvalidInputException);
 
   // int_float alias (c,b) does not contain a column named d
-  EXPECT_THROW(sql_to_lqp_helper("SELECT "
-                                 " * "
-                                 "FROM "
-                                 "  int_float AS int_float(c,b) INNER JOIN int_float2 AS intfloat2(c,d) USING (d)"),
-               InvalidInputException);
+  EXPECT_THROW(sql_to_lqp_helper(
+      "SELECT * FROM int_float AS int_float(c,b) INNER JOIN int_float2 AS intfloat2(c,d) USING (d)"),
+    InvalidInputException);
 }
 
 TEST_F(SQLTranslatorTest, JoinInnerUsingNamedColumnsMultipleColumns) {
   const auto [actual_lqp, translation_info] = sql_to_lqp_helper(
-      "SELECT "
-      " * "
-      "FROM "
-      "  int_float AS int_float(c,d) INNER JOIN int_float2 AS intfloat2(c,d) USING (c,d)");
+    "SELECT * FROM int_float AS int_float(c,d) INNER JOIN int_float2 AS intfloat2(c,d) USING (c,d)");
 
-  const auto expected_lqp = AliasNode::make(
-      expression_vector(int_float_a, int_float_b), std::vector<std::string>({"c", "d"}),
-      ProjectionNode::make(expression_vector(int_float_a, int_float_b),
-                           JoinNode::make(JoinMode::Inner,
-                                          std::vector<std::shared_ptr<AbstractExpression>>{
-                                              equals_(int_float_a, int_float2_a), equals_(int_float_b, int_float2_b)},
-                                          stored_table_node_int_float, stored_table_node_int_float2)));
+  // clang-format off
+  const auto expected_lqp =
+  AliasNode::make(expression_vector(int_float_a, int_float_b), std::vector<std::string>({"c", "d"}),
+    ProjectionNode::make(expression_vector(int_float_a, int_float_b),
+      JoinNode::make(JoinMode::Inner,
+        std::vector<std::shared_ptr<AbstractExpression>>{
+          equals_(int_float_a, int_float2_a),
+          equals_(int_float_b, int_float2_b)
+        },
+        stored_table_node_int_float,
+        stored_table_node_int_float2)));
+  // clang-format on
 
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
 
 TEST_F(SQLTranslatorTest, JoinInnerUsingNamedColumnsNested) {
   const auto [actual_lqp, translation_info] = sql_to_lqp_helper(
-      "SELECT "
-      " * "
-      "FROM "
-      " int_float JOIN (SELECT a, int_float2.b, int_float5.d FROM int_float2 JOIN int_float5 USING (a)) AS "
-      "int_float_comb(a, c, d) USING (a)");
+    "SELECT * FROM int_float JOIN "
+      "(SELECT a, int_float2.b, int_float5.d FROM int_float2 JOIN int_float5 USING (a))"
+    "AS int_float_comb(a, c, d) USING (a)");
 
-  const auto expected_lqp = AliasNode::make(
-      expression_vector(int_float_a, int_float_b, int_float2_b, int_float5_d),
-      std::vector<std::string>({"a", "b", "c", "d"}),
-      ProjectionNode::make(
-          expression_vector(int_float_a, int_float_b, int_float2_b, int_float5_d),
-          JoinNode::make(
-              JoinMode::Inner, equals_(int_float_a, int_float2_a), stored_table_node_int_float,
-              ProjectionNode::make(expression_vector(int_float2_a, int_float2_b, int_float5_d),
-                                   JoinNode::make(JoinMode::Inner, equals_(int_float2_a, int_float5_a),
-                                                  stored_table_node_int_float2, stored_table_node_int_float5)))));
+  // clang-format off
+  const auto expected_lqp =
+  AliasNode::make(expression_vector(int_float_a, int_float_b, int_float2_b, int_float5_d),
+    std::vector<std::string>({"a", "b", "c", "d"}),
+    ProjectionNode::make(expression_vector(int_float_a, int_float_b, int_float2_b, int_float5_d),
+      JoinNode::make(
+        JoinMode::Inner,
+        equals_(int_float_a, int_float2_a), stored_table_node_int_float,
+        ProjectionNode::make(expression_vector(int_float2_a, int_float2_b, int_float5_d),
+          JoinNode::make(JoinMode::Inner, equals_(int_float2_a, int_float5_a),
+            stored_table_node_int_float2,
+            stored_table_node_int_float5)))));
+  // clang-format on
 
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }

--- a/src/test/lib/sql/sql_translator_test.cpp
+++ b/src/test/lib/sql/sql_translator_test.cpp
@@ -1561,10 +1561,10 @@ TEST_F(SQLTranslatorTest, JoinNaturalDerivedTable) {
                                                   ProjectionNode::make(expression_vector(123), DummyTableNode::make()));
 
   // clang-format off
-  const auto expected_lqp = 
-  ProjectionNode::make(expression_vector(int_float_a, int_float_b), 
-    JoinNode::make(JoinMode::Inner, equals_(int_float_a, 123), 
-      stored_table_node_int_float, 
+  const auto expected_lqp =
+  ProjectionNode::make(expression_vector(int_float_a, int_float_b),
+    JoinNode::make(JoinMode::Inner, equals_(int_float_a, 123),
+      stored_table_node_int_float,
       derived_table_node));
   // clang-format on
 


### PR DESCRIPTION
The PR integrates the changes to the sql-parser (see [hyrise/sql-parser #240](https://github.com/hyrise/sql-parser/pull/240)) into the Hyrise join behavior.
In short, this allows a list of identifiers (a.k.a column names) when joins name columns with USING (...). The result should only contain the columns that were used for the join once.
This behavior is in line with the SQL standard and PostgreSQL. 

Specifically, the sql-parser parses a join into the updated struct:
```C++
struct JoinDefinition {
  JoinDefinition();
  virtual ~JoinDefinition();

  TableRef* left;
  TableRef* right;
  Expr* condition;

  JoinType type;
  std::vector<char*>* namedColumns;
};
```
We execute a `_join_using_named_columns` when only namedColumns is set and condition is not. We fail if both are set (due to ambiguity).