### PR TITLE
Fix io_service issue with libboost 1.87

### DIFF
--- a/src/lib/scheduler/node_queue_scheduler.cpp
+++ b/src/lib/scheduler/node_queue_scheduler.cpp
@@ -28,9 +28,9 @@ NodeQueueScheduler::NodeQueueScheduler() {
 }
 
 NodeQueueScheduler::~NodeQueueScheduler() {
-  if (HYRISE_DEBUG && _active) {
+  if (_active) {
     // We cannot throw an exception because destructors are noexcept by default.
-    std::cerr << "NodeQueueScheduler::finish() wasn't called prior to destroying it.\n";
+    std::cerr << "NodeQueueScheduler::finish() must be called before destroying the scheduler.\n";
     std::exit(EXIT_FAILURE);  // NOLINT(concurrency-mt-unsafe)
   }
 }

--- a/src/lib/server/server.cpp
+++ b/src/lib/server/server.cpp
@@ -22,7 +22,7 @@ namespace hyrise {
 // Specified port (default: 5432) will be opened after initializing the _acceptor
 Server::Server(const boost::asio::ip::address& address, const uint16_t port,
                const SendExecutionInfo send_execution_info)
-    : _acceptor(_io_service, boost::asio::ip::tcp::endpoint(address, port)), _send_execution_info(send_execution_info) {
+    : _acceptor(_io_context, boost::asio::ip::tcp::endpoint(address, port)), _send_execution_info(send_execution_info) {
   std::cout << "Server started at " << server_address() << " and port " << server_port() << ".\nRun 'psql -h localhost "
             << server_address() << "' to connect to the server\n." << std::flush;
 }
@@ -39,14 +39,14 @@ void Server::run() {
 
   _is_initialized = true;
   _accept_new_session();
-  _io_service.run();
+  _io_context.run();
 }
 
 void Server::_accept_new_session() {
   // Create a new session. This will also open a new data socket in order to communicate with the client
   // For more information on TCP ports + Asio see:
   // https://www.gamedev.net/forums/topic/586557-boostasio-allowing-multiple-connections-to-a-single-server-socket/
-  auto new_session = std::make_shared<Session>(_io_service, _send_execution_info);
+  auto new_session = std::make_shared<Session>(_io_context, _send_execution_info);
   _acceptor.async_accept(*(new_session->socket()),
                          boost::bind(&Server::_start_session, this, new_session, boost::asio::placeholders::error));
 }
@@ -94,7 +94,7 @@ void Server::shutdown() {
     // This busy wait might be inefficient, but as this is only to guarantee a clean shutdown, it's good enough.
     std::this_thread::yield();
   }
-  _io_service.stop();
+  _io_context.stop();
 }
 
 bool Server::is_initialized() const {

--- a/src/lib/server/server.hpp
+++ b/src/lib/server/server.hpp
@@ -2,7 +2,7 @@
 
 #include <memory>
 
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/tcp.hpp>
 
 #include "server_types.hpp"
@@ -54,7 +54,7 @@ class Server {
   void _start_session(const std::shared_ptr<Session>& new_session, const boost::system::error_code& error);
 
   std::atomic_uint64_t _num_running_sessions{0};
-  boost::asio::io_service _io_service;
+  boost::asio::io_context _io_context;
   boost::asio::ip::tcp::acceptor _acceptor;
   const SendExecutionInfo _send_execution_info;
   std::atomic_bool _is_initialized{false};

--- a/src/lib/server/session.cpp
+++ b/src/lib/server/session.cpp
@@ -19,8 +19,8 @@
 
 namespace hyrise {
 
-Session::Session(boost::asio::io_service& io_service, const SendExecutionInfo send_execution_info)
-    : _socket(std::make_shared<Socket>(io_service)),
+Session::Session(boost::asio::io_context& io_context, const SendExecutionInfo send_execution_info)
+    : _socket(std::make_shared<Socket>(io_context)),
       _postgres_protocol_handler(std::make_shared<PostgresProtocolHandler<Socket>>(_socket)),
       _send_execution_info(send_execution_info) {}
 

--- a/src/lib/server/session.hpp
+++ b/src/lib/server/session.hpp
@@ -18,7 +18,7 @@ namespace hyrise {
 // Example usage can be found here: https://stackoverflow.com/questions/52479293/postgresql-refcursor-and-portal-name
 class Session {
  public:
-  explicit Session(boost::asio::io_service& io_service, const SendExecutionInfo send_execution_info);
+  explicit Session(boost::asio::io_context& io_context, const SendExecutionInfo send_execution_info);
 
   // Start new session.
   void run();

--- a/src/test/lib/server/mock_socket.hpp
+++ b/src/test/lib/server/mock_socket.hpp
@@ -19,8 +19,8 @@ class MockSocket {
 
   MockSocket() : _path(test_data_path + filename) {
     _file_descriptor = open(_path.c_str(), O_RDWR | O_CREAT | O_APPEND, 0755);
-    _stream = std::make_shared<AsioStreamDescriptor>(_io_service, _file_descriptor);
-    _io_service.run();
+    _stream = std::make_shared<AsioStreamDescriptor>(_io_context, _file_descriptor);
+    _io_context.run();
   }
 
   ~MockSocket() {
@@ -48,7 +48,7 @@ class MockSocket {
  private:
   const std::string _path;
   int _file_descriptor;
-  boost::asio::io_service _io_service;
+  boost::asio::io_context _io_context;
   std::shared_ptr<AsioStreamDescriptor> _stream;
 };
 


### PR DESCRIPTION
Since boost 1.87, `io_service` is now `io_context` (more or less, there is more to it, see here: https://github.com/boostorg/asio/issues/110).

Since `brew` on macOS now ships boost 1.87, this PR addresses the deprecation.