### PR TITLE
Minor fixes in cardinality estimation

### DIFF
--- a/resources/test_data/sqlite_testrunner_queries.sql
+++ b/resources/test_data/sqlite_testrunner_queries.sql
@@ -233,6 +233,14 @@ SELECT * FROM id_int_int_int_100 WHERE NOT EXISTS (SELECT * FROM int_date WHERE 
 -- exists to semi join reformulation: query not rewriteable
 SELECT * FROM id_int_int_int_100 WHERE EXISTS (SELECT * FROM int_date WHERE id_int_int_int_100.id = int_date.a) OR id < 20
 
+-- Join on constant
+SELECT * FROM int_date NATURAL JOIN (SELECT 3 AS a) foo;
+SELECT * FROM int_date INNER JOIN (SELECT 3 AS c) foo ON (a = c);
+SELECT * FROM int_date INNER JOIN (SELECT 3 AS c) foo ON (a < c);
+SELECT a FROM int_date NATURAL JOIN (SELECT 3 AS a) foo;
+SELECT a FROM int_date INNER JOIN (SELECT 3 AS c) foo ON (a = c);
+SELECT a FROM int_date INNER JOIN (SELECT 3 AS c) foo ON (a < c);
+
 -- Aggregates
 SELECT SUM(b + b) AS sum_b_b FROM mixed;
 SELECT SUM(b) + AVG(c) AS x FROM mixed GROUP BY id + 5;

--- a/src/lib/statistics/cardinality_estimator.cpp
+++ b/src/lib/statistics/cardinality_estimator.cpp
@@ -1104,7 +1104,7 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_inner_equi_join(
       //               join.
       const auto left_cardinality = left_input_table_statistics.row_count;
       const auto right_cardinality = right_input_table_statistics.row_count;
-      cardinality = std::max(left_cardinality, std::max(right_cardinality, left_cardinality * right_cardinality));
+      cardinality = std::max({left_cardinality, right_cardinality, left_cardinality * right_cardinality});
     }
 
     const auto left_selectivity = Selectivity{
@@ -1202,10 +1202,6 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_semi_join(
     } else {
       // TODO(anyone): If we do not have histograms on both sides, use some other algorithm/statistics to estimate the
       //               join.
-      const auto left_cardinality = left_input_table_statistics.row_count;
-      const auto right_cardinality = right_input_table_statistics.row_count;
-      cardinality = std::max(left_cardinality, std::max(right_cardinality, left_cardinality * right_cardinality));
-
       cardinality = left_input_table_statistics.row_count;
     }
 
@@ -1267,8 +1263,7 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_cross_join(
   }
 
   const auto row_count =
-      std::max(Cardinality{left_selectivity},
-               std::max(Cardinality{right_selectivity}, Cardinality{left_selectivity * right_selectivity}));
+      Cardinality{std::max({left_selectivity, right_selectivity, left_selectivity * right_selectivity})};
 
   return std::make_shared<TableStatistics>(std::move(column_statistics), row_count);
 }

--- a/src/lib/statistics/cardinality_estimator.cpp
+++ b/src/lib/statistics/cardinality_estimator.cpp
@@ -1088,8 +1088,8 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_inner_equi_join(
     auto cardinality = Cardinality{0};
     auto join_column_histogram = std::shared_ptr<AbstractHistogram<ColumnDataType>>{};
 
-    auto left_histogram = left_input_column_statistics->histogram;
-    auto right_histogram = right_input_column_statistics->histogram;
+    auto left_histogram = left_input_column_statistics ? left_input_column_statistics->histogram : nullptr;
+    auto right_histogram = right_input_column_statistics ? right_input_column_statistics->histogram : nullptr;
 
     if (left_histogram && right_histogram) {
       // If we have histograms, we use the principle of inclusion to determine the number of matches between two bins.

--- a/src/test/lib/statistics/cardinality_estimator_test.cpp
+++ b/src/test/lib/statistics/cardinality_estimator_test.cpp
@@ -446,16 +446,16 @@ TEST_F(CardinalityEstimatorTest, JoinAnti) {
 }
 
 TEST_F(CardinalityEstimatorTest, JoinWithDummyStatistics) {
-  // Joins on projections, aggregates, etc. cannot use histograms. For now, we expect, ...
+  // Joins on projections, aggregates, etc. cannot use histograms. For now, we expect those joins to preserve all tuples
+  // in the worst case.
   for (const auto join_mode : magic_enum::enum_values<JoinMode>()) {
-    std::cout << join_mode << "\n";
     const auto right_input = ProjectionNode::make(expression_vector(value_(42)), DummyTableNode::make());
     const auto join_node =
         join_mode == JoinMode::Cross ? JoinNode::make(join_mode) : JoinNode::make(join_mode, equals_(a_a, value_(123)));
     join_node->set_left_input(node_a);
     join_node->set_right_input(right_input);
 
-    EXPECT_EQ(estimator.estimate_cardinality(join_node), 0);
+    EXPECT_EQ(estimator.estimate_cardinality(join_node), 100) << " for " << join_mode << " join";
   }
 }
 

--- a/src/test/lib/statistics/cardinality_estimator_test.cpp
+++ b/src/test/lib/statistics/cardinality_estimator_test.cpp
@@ -144,7 +144,7 @@ TEST_F(CardinalityEstimatorTest, Aggregate) {
   // clang-format off
   const auto input_lqp =
   AggregateNode::make(expression_vector(a_b, add_(a_b, a_a)), expression_vector(sum_(a_a)),
-                      node_a);
+    node_a);
   // clang-format on
 
   const auto input_table_statistics = node_a->table_statistics();
@@ -162,7 +162,6 @@ TEST_F(CardinalityEstimatorTest, Aggregate) {
 TEST_F(CardinalityEstimatorTest, AggregateWithoutGroupBy) {
   const auto input_lqp = AggregateNode::make(expression_vector(), expression_vector(sum_(a_a)), node_a);
 
-  const auto input_table_statistics = node_a->table_statistics();
   const auto result_table_statistics = estimator.estimate_statistics(input_lqp);
 
   EXPECT_EQ(result_table_statistics->row_count, 1);

--- a/src/test/lib/statistics/cardinality_estimator_test.cpp
+++ b/src/test/lib/statistics/cardinality_estimator_test.cpp
@@ -159,6 +159,18 @@ TEST_F(CardinalityEstimatorTest, Aggregate) {
       dynamic_cast<const CardinalityEstimator::DummyStatistics*>(&*result_table_statistics->column_statistics.at(2)));
 }
 
+TEST_F(CardinalityEstimatorTest, AggregateWithoutGroupBy) {
+  const auto input_lqp = AggregateNode::make(expression_vector(), expression_vector(sum_(a_a)), node_a);
+
+  const auto input_table_statistics = node_a->table_statistics();
+  const auto result_table_statistics = estimator.estimate_statistics(input_lqp);
+
+  EXPECT_EQ(result_table_statistics->row_count, 1);
+  ASSERT_EQ(result_table_statistics->column_statistics.size(), 1);
+  EXPECT_TRUE(
+      dynamic_cast<const CardinalityEstimator::DummyStatistics*>(&*result_table_statistics->column_statistics.at(0)));
+}
+
 TEST_F(CardinalityEstimatorTest, Alias) {
   // clang-format off
   const auto input_lqp =


### PR DESCRIPTION
While reviewing #2675, I [noticed](https://github.com/hyrise/hyrise/pull/2675#pullrequestreview-2552850261) that segfaults occur when joining with columns that have only `DummyStatistics` (e.g., constants or aggregates). That's something I missed in #2659 🙄.

This PR fixes these segfaults. Furthermore, we did not cover certain edge cases before:
1.  When we did not have an input row count (e.g., `SELECT foo JOIN (SELECT 1 AS bar) ...`), we returned a cardinality of 0. Now, we return at least the cardinality of `foo`.
2. For aggregates without `GROUP BY` columns, we still forwarded the input row count (which is the upper bound whenever we group by something). However, aggregates without `GROUP BY` yield one row per definition.

I don't know if that changes anything in the benchmarks, but I have 'em running.

**System**
<details>
<summary>nemea - click to expand</summary>

| property | value |
| -- | -- |
| Hostname | nemea |
| CPU | Intel(R) Xeon(R) Platinum 8180 CPU @ 2.50GHz |
| Memory | 1.3TB |
| numactl | nodebind: 2  |
| numactl | membind: 2  |
</details>

**Commit Info and Build Time**
| commit | date | message | build time |
| -- | -- | -- | -- |
| 2a56cc3c6 | 30.01.2025 16:02 | Parallelize chunk pruning statistics generation for full table (#2664) | real 564.66 user 4126.94 sys 144.61|
| addc64949 | 02.02.2025 00:40 | aggregate without group by only one row | real 568.20 user 4102.12 sys 146.14|


**hyriseBenchmarkTPCH - single-threaded, SF 10.0**
<details>
<summary>
Sum of avg. item runtimes: +1%
 ||
Geometric mean of throughput changes: -1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Daniel.Lindner/hyrise/clang17-release/benchmark_all_results/hyriseBenchmarkTPCH_2a56cc3c6d5b0997af199aa5383216af8f526cd1_st.json | /home/Daniel.Lindner/hyrise/clang17-release/benchmark_all_results/hyriseBenchmarkTPCH_addc64949a58ea471405384b366401d7497a4870_st.json |
 +--------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 2a56cc3c6d5b0997af199aa5383216af8f526cd1-dirty                                                                                         | addc64949a58ea471405384b366401d7497a4870-dirty                                                                                         |
 |  benchmark_mode          | Ordered                                                                                                                                | Ordered                                                                                                                                |
 |  build_type              | release                                                                                                                                | release                                                                                                                                |
 |  chunk_indexes           | False                                                                                                                                  | False                                                                                                                                  |
 |  chunk_size              | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                 | 1                                                                                                                                      | 1                                                                                                                                      |
 |  clustering              | None                                                                                                                                   | None                                                                                                                                   |
 |  compiler                | clang 17.0.6                                                                                                                           | clang 17.0.6                                                                                                                           |
 |  cores                   | 0                                                                                                                                      | 0                                                                                                                                      |
 |  data_preparation_cores  | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                    | 2025-02-02 00:51:30                                                                                                                    | 2025-02-02 04:28:32                                                                                                                    |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  max_duration            | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                | 50                                                                                                                                     | 50                                                                                                                                     |
 |  scale_factor            | 10.0                                                                                                                                   | 10.0                                                                                                                                   |
 |  time_unit               | ns                                                                                                                                     | ns                                                                                                                                     |
 |  use_prepared_statements | False                                                                                                                                  | False                                                                                                                                  |
 |  using_scheduler         | False                                                                                                                                  | False                                                                                                                                  |
 |  verify                  | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration         | 1000000000                                                                                                                             | 1000000000                                                                                                                             |
 +--------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+----------+--------++----------+----------+--------+----------------------+
 | Item     || Latency (ms/iter)   | Change || Throughput (iter/s) | Change |              p-value |
 |          ||      old |      new |        ||      old |      new |        |                      |
 +----------++----------+----------+--------++----------+----------+--------+----------------------+
 | TPC-H 01 ||  6007.50 |  6037.76 |   +1%  ||     0.17 |     0.17 |   -1%  |               0.8568 |
-| TPC-H 02 ||    37.30 |    38.99 |   +5%˄ ||    26.81 |    25.64 |   -4%˄ | (run time too short) |
 | TPC-H 03 ||  1215.94 |  1206.34 |   -1%˄ ||     0.82 |     0.83 |   +1%˄ |               0.5998 |
 | TPC-H 04 ||  1306.48 |  1333.95 |   +2%  ||     0.77 |     0.75 |   -2%  |               0.1857 |
 | TPC-H 05 ||  2006.46 |  2083.27 |   +4%  ||     0.50 |     0.48 |   -4%  |               0.0000 |
-| TPC-H 06 ||   156.68 |   179.31 |  +14%˄ ||     6.38 |     5.58 |  -13%˄ | (run time too short) |
 | TPC-H 07 ||   766.87 |   782.43 |   +2%˄ ||     1.30 |     1.28 |   -2%˄ | (run time too short) |
 | TPC-H 08 ||   500.23 |   496.90 |   -1%˄ ||     2.00 |     2.01 |   +1%˄ | (run time too short) |
 | TPC-H 09 ||  5018.33 |  5019.10 |   +0%  ||     0.20 |     0.20 |   -0%  |               0.9839 |
 | TPC-H 10 ||  1252.58 |  1238.75 |   -1%  ||     0.80 |     0.81 |   +1%  |               0.1508 |
 | TPC-H 11 ||    57.88 |    57.88 |   -0%˄ ||    17.28 |    17.28 |   +0%˄ | (run time too short) |
 | TPC-H 12 ||   900.33 |   910.55 |   +1%˄ ||     1.11 |     1.10 |   -1%˄ | (run time too short) |
 | TPC-H 13 ||  4797.00 |  4804.17 |   +0%  ||     0.21 |     0.21 |   -0%  |               0.8221 |
 | TPC-H 14 ||   398.51 |   404.19 |   +1%˄ ||     2.51 |     2.47 |   -1%˄ | (run time too short) |
 | TPC-H 15 ||   191.99 |   194.71 |   +1%˄ ||     5.21 |     5.14 |   -1%˄ | (run time too short) |
 | TPC-H 16 ||   513.32 |   516.77 |   +1%˄ ||     1.95 |     1.94 |   -1%˄ | (run time too short) |
 | TPC-H 17 ||   215.58 |   217.44 |   +1%˄ ||     4.64 |     4.60 |   -1%˄ | (run time too short) |
 | TPC-H 18 ||  1885.39 |  1933.43 |   +3%  ||     0.53 |     0.52 |   -2%  |               0.1607 |
 | TPC-H 19 ||   202.12 |   195.02 |   -4%˄ ||     4.95 |     5.13 |   +4%˄ | (run time too short) |
 | TPC-H 20 ||   477.64 |   474.79 |   -1%˄ ||     2.09 |     2.11 |   +1%˄ | (run time too short) |
 | TPC-H 21 ||  3700.41 |  3752.88 |   +1%  ||     0.27 |     0.27 |   -1%  |               0.3439 |
 | TPC-H 22 ||   424.48 |   419.64 |   -1%˄ ||     2.36 |     2.38 |   +1%˄ | (run time too short) |
 +----------++----------+----------+--------++----------+----------+--------+----------------------+
 | Sum      || 32033.02 | 32298.26 |   +1%  ||          |          |        |                      |
 | Geomean  ||          |          |        ||          |          |   -1%  |                      |
 +----------++----------+----------+--------++----------+----------+--------+----------------------+
 |    Notes || ˄ Execution stopped due to max runs reached                                         |
 +----------++----------+----------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkTPCH - single-threaded, SF 0.01**
<details>
<summary>
Sum of avg. item runtimes: -4%
 ||
Geometric mean of throughput changes: -0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Daniel.Lindner/hyrise/clang17-release/benchmark_all_results/hyriseBenchmarkTPCH_2a56cc3c6d5b0997af199aa5383216af8f526cd1_st_s01.json | /home/Daniel.Lindner/hyrise/clang17-release/benchmark_all_results/hyriseBenchmarkTPCH_addc64949a58ea471405384b366401d7497a4870_st_s01.json |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 2a56cc3c6d5b0997af199aa5383216af8f526cd1-dirty                                                                                             | addc64949a58ea471405384b366401d7497a4870-dirty                                                                                             |
 |  benchmark_mode          | Ordered                                                                                                                                    | Ordered                                                                                                                                    |
 |  build_type              | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_indexes           | False                                                                                                                                      | False                                                                                                                                      |
 |  chunk_size              | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients                 | 1                                                                                                                                          | 1                                                                                                                                          |
 |  clustering              | None                                                                                                                                       | None                                                                                                                                       |
 |  compiler                | clang 17.0.6                                                                                                                               | clang 17.0.6                                                                                                                               |
 |  cores                   | 0                                                                                                                                          | 0                                                                                                                                          |
 |  data_preparation_cores  | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date                    | 2025-02-02 01:06:45                                                                                                                        | 2025-02-02 04:43:57                                                                                                                        |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                    | {'default': {'encoding': 'Dictionary'}}                                                                                                    |
 |  max_duration            | 60000000000                                                                                                                                | 60000000000                                                                                                                                |
 |  max_runs                | 50                                                                                                                                         | 50                                                                                                                                         |
 |  scale_factor            | 0.009999999776482582                                                                                                                       | 0.009999999776482582                                                                                                                       |
 |  time_unit               | ns                                                                                                                                         | ns                                                                                                                                         |
 |  use_prepared_statements | False                                                                                                                                      | False                                                                                                                                      |
 |  using_scheduler         | False                                                                                                                                      | False                                                                                                                                      |
 |  verify                  | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration         | 1000000000                                                                                                                                 | 1000000000                                                                                                                                 |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |          ||      old |     new |        ||      old |      new |        |                      |
 +----------++----------+---------+--------++----------+----------+--------+----------------------+
 | TPC-H 01 ||     4.86 |    4.91 |   +1%˄ ||   205.62 |   203.60 |   -1%˄ | (run time too short) |
+| TPC-H 02 ||     3.66 |    3.20 |  -12%˄ ||   273.40 |   312.14 |  +14%˄ | (run time too short) |
 | TPC-H 03 ||     0.48 |    0.48 |   -1%˄ ||  2078.30 |  2092.71 |   +1%˄ | (run time too short) |
 | TPC-H 04 ||     0.35 |    0.35 |   +1%˄ ||  2865.80 |  2842.69 |   -1%˄ | (run time too short) |
 | TPC-H 05 ||     0.85 |    0.85 |   +0%˄ ||  1177.86 |  1174.21 |   -0%˄ | (run time too short) |
 | TPC-H 06 ||     0.17 |    0.17 |   +1%˄ ||  5999.10 |  5936.61 |   -1%˄ | (run time too short) |
+| TPC-H 07 ||     9.37 |    7.81 |  -17%˄ ||   106.66 |   127.96 |  +20%˄ | (run time too short) |
 | TPC-H 08 ||    14.21 |   13.85 |   -3%˄ ||    70.37 |    72.22 |   +3%˄ | (run time too short) |
-| TPC-H 09 ||     2.35 |    2.53 |   +8%˄ ||   425.74 |   395.80 |   -7%˄ | (run time too short) |
 | TPC-H 10 ||     0.58 |    0.59 |   +1%˄ ||  1712.96 |  1692.52 |   -1%˄ | (run time too short) |
 | TPC-H 11 ||     0.17 |    0.17 |   -0%˄ ||  5874.60 |  5874.77 |   +0%˄ | (run time too short) |
 | TPC-H 12 ||     0.54 |    0.54 |   -0%˄ ||  1858.90 |  1863.62 |   +0%˄ | (run time too short) |
 | TPC-H 13 ||     1.88 |    1.90 |   +1%˄ ||   530.54 |   524.89 |   -1%˄ | (run time too short) |
 | TPC-H 14 ||     0.29 |    0.30 |   +4%˄ ||  3419.23 |  3288.72 |   -4%˄ | (run time too short) |
 | TPC-H 15 ||     1.13 |    1.15 |   +1%˄ ||   879.68 |   869.12 |   -1%˄ | (run time too short) |
 | TPC-H 16 ||     1.83 |    1.83 |   -0%˄ ||   546.06 |   546.07 |   +0%˄ | (run time too short) |
-| TPC-H 17 ||     0.53 |    0.65 |  +21%˄ ||  1869.62 |  1543.76 |  -17%˄ | (run time too short) |
 | TPC-H 18 ||     1.20 |    1.19 |   -0%˄ ||   835.15 |   837.97 |   +0%˄ | (run time too short) |
 | TPC-H 19 ||     4.38 |    4.33 |   -1%˄ ||   228.43 |   230.62 |   +1%˄ | (run time too short) |
 | TPC-H 20 ||     2.32 |    2.41 |   +4%˄ ||   430.98 |   415.20 |   -4%˄ | (run time too short) |
 | TPC-H 21 ||     0.91 |    0.93 |   +2%˄ ||  1097.42 |  1068.34 |   -3%˄ | (run time too short) |
 | TPC-H 22 ||     1.01 |    1.02 |   +1%˄ ||   990.30 |   982.69 |   -1%˄ | (run time too short) |
 +----------++----------+---------+--------++----------+----------+--------+----------------------+
 | Sum      ||    53.06 |   51.15 |   -4%  ||          |          |        |                      |
 | Geomean  ||          |         |        ||          |          |   -0%  |                      |
 +----------++----------+---------+--------++----------+----------+--------+----------------------+
 |    Notes || ˄ Execution stopped due to max runs reached                                        |
 +----------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkTPCH - multi-threaded, ordered, 1 client, 28 cores, SF 10.0**
<details>
<summary>
Sum of avg. item runtimes: +0%
 ||
Geometric mean of throughput changes: +0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Daniel.Lindner/hyrise/clang17-release/benchmark_all_results/hyriseBenchmarkTPCH_2a56cc3c6d5b0997af199aa5383216af8f526cd1_mt_ordered.json | /home/Daniel.Lindner/hyrise/clang17-release/benchmark_all_results/hyriseBenchmarkTPCH_addc64949a58ea471405384b366401d7497a4870_mt_ordered.json |
 +-------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 2a56cc3c6d5b0997af199aa5383216af8f526cd1-dirty                                                                                                 | addc64949a58ea471405384b366401d7497a4870-dirty                                                                                                 |
 |  benchmark_mode               | Ordered                                                                                                                                        | Ordered                                                                                                                                        |
 |  build_type                   | release                                                                                                                                        | release                                                                                                                                        |
 |  chunk_indexes                | False                                                                                                                                          | False                                                                                                                                          |
 |  chunk_size                   | 65535                                                                                                                                          | 65535                                                                                                                                          |
 |  clients                      | 1                                                                                                                                              | 1                                                                                                                                              |
 |  clustering                   | None                                                                                                                                           | None                                                                                                                                           |
 |  compiler                     | clang 17.0.6                                                                                                                                   | clang 17.0.6                                                                                                                                   |
 |  cores                        | 28                                                                                                                                             | 28                                                                                                                                             |
 |  data_preparation_cores       | 0                                                                                                                                              | 0                                                                                                                                              |
 |  date                         | 2025-02-02 01:07:10                                                                                                                            | 2025-02-02 04:44:21                                                                                                                            |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                        | {'default': {'encoding': 'Dictionary'}}                                                                                                        |
 |  max_duration                 | 60000000000                                                                                                                                    | 60000000000                                                                                                                                    |
 |  max_runs                     | 50                                                                                                                                             | 50                                                                                                                                             |
 |  scale_factor                 | 10.0                                                                                                                                           | 10.0                                                                                                                                           |
 |  time_unit                    | ns                                                                                                                                             | ns                                                                                                                                             |
 |  use_prepared_statements      | False                                                                                                                                          | False                                                                                                                                          |
 |  using_scheduler              | True                                                                                                                                           | True                                                                                                                                           |
 |  utilized_cores_per_numa_node | [0, 0, 28]                                                                                                                                     | [0, 0, 28]                                                                                                                                     |
 |  verify                       | False                                                                                                                                          | False                                                                                                                                          |
 |  warmup_duration              | 1000000000                                                                                                                                     | 1000000000                                                                                                                                     |
 +-------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+----------+--------++----------+----------+--------+----------------------+
 | Item     || Latency (ms/iter)   | Change || Throughput (iter/s) | Change |              p-value |
 |          ||      old |      new |        ||      old |      new |        |                      |
 +----------++----------+----------+--------++----------+----------+--------+----------------------+
 | TPC-H 01 ||  4641.05 |  4673.05 |   +1%  ||     0.22 |     0.21 |   -1%  |               0.2232 |
 | TPC-H 02 ||    56.36 |    54.41 |   -3%˄ ||    17.68 |    18.31 |   +4%˄ | (run time too short) |
 | TPC-H 03 ||   568.52 |   569.70 |   +0%˄ ||     1.76 |     1.75 |   -0%˄ | (run time too short) |
 | TPC-H 04 ||   495.89 |   507.37 |   +2%˄ ||     2.02 |     1.97 |   -2%˄ | (run time too short) |
 | TPC-H 05 ||   513.86 |   507.15 |   -1%˄ ||     1.95 |     1.97 |   +1%˄ | (run time too short) |
 | TPC-H 06 ||    62.26 |    60.60 |   -3%˄ ||    16.01 |    16.45 |   +3%˄ | (run time too short) |
 | TPC-H 07 ||   255.64 |   255.77 |   +0%˄ ||     3.91 |     3.91 |   -0%˄ | (run time too short) |
 | TPC-H 08 ||   239.11 |   239.90 |   +0%˄ ||     4.18 |     4.17 |   -0%˄ | (run time too short) |
 | TPC-H 09 ||  1653.33 |  1661.73 |   +1%  ||     0.60 |     0.60 |   -1%  |               0.4966 |
 | TPC-H 10 ||   534.10 |   530.96 |   -1%˄ ||     1.87 |     1.88 |   +1%˄ | (run time too short) |
 | TPC-H 11 ||    63.38 |    65.16 |   +3%˄ ||    15.74 |    15.31 |   -3%˄ | (run time too short) |
 | TPC-H 12 ||   447.47 |   448.89 |   +0%˄ ||     2.23 |     2.23 |   -0%˄ | (run time too short) |
 | TPC-H 13 ||  2213.61 |  2207.84 |   -0%  ||     0.45 |     0.45 |   +0%  |               0.4350 |
 | TPC-H 14 ||   144.99 |   143.18 |   -1%˄ ||     6.89 |     6.97 |   +1%˄ | (run time too short) |
 | TPC-H 15 ||   144.84 |   146.56 |   +1%˄ ||     6.90 |     6.82 |   -1%˄ | (run time too short) |
 | TPC-H 16 ||   597.13 |   597.90 |   +0%˄ ||     1.67 |     1.67 |   -0%˄ | (run time too short) |
 | TPC-H 17 ||    73.48 |    73.66 |   +0%˄ ||    13.58 |    13.54 |   -0%˄ | (run time too short) |
 | TPC-H 18 ||  2403.37 |  2424.58 |   +1%  ||     0.42 |     0.41 |   -1%  |               0.5515 |
 | TPC-H 19 ||   111.58 |   110.90 |   -1%˄ ||     8.95 |     9.00 |   +1%˄ | (run time too short) |
 | TPC-H 20 ||   208.90 |   203.37 |   -3%˄ ||     4.78 |     4.91 |   +3%˄ | (run time too short) |
 | TPC-H 21 ||   862.35 |   868.44 |   +1%˄ ||     1.16 |     1.15 |   -1%˄ | (run time too short) |
 | TPC-H 22 ||   140.25 |   140.19 |   -0%˄ ||     7.12 |     7.12 |   +0%˄ | (run time too short) |
 +----------++----------+----------+--------++----------+----------+--------+----------------------+
 | Sum      || 16431.49 | 16491.33 |   +0%  ||          |          |        |                      |
 | Geomean  ||          |          |        ||          |          |   +0%  |                      |
 +----------++----------+----------+--------++----------+----------+--------+----------------------+
 |    Notes || ˄ Execution stopped due to max runs reached                                         |
 +----------++----------+----------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkTPCH - multi-threaded, shuffled, 28 clients, 28 cores, SF 10.0**
<details>
<summary>
Sum of avg. item runtimes: +0%
 ||
Geometric mean of throughput changes: -0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Daniel.Lindner/hyrise/clang17-release/benchmark_all_results/hyriseBenchmarkTPCH_2a56cc3c6d5b0997af199aa5383216af8f526cd1_mt.json | /home/Daniel.Lindner/hyrise/clang17-release/benchmark_all_results/hyriseBenchmarkTPCH_addc64949a58ea471405384b366401d7497a4870_mt.json |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 2a56cc3c6d5b0997af199aa5383216af8f526cd1-dirty                                                                                         | addc64949a58ea471405384b366401d7497a4870-dirty                                                                                         |
 |  benchmark_mode               | Shuffled                                                                                                                               | Shuffled                                                                                                                               |
 |  build_type                   | release                                                                                                                                | release                                                                                                                                |
 |  chunk_indexes                | False                                                                                                                                  | False                                                                                                                                  |
 |  chunk_size                   | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                      | 28                                                                                                                                     | 28                                                                                                                                     |
 |  clustering                   | None                                                                                                                                   | None                                                                                                                                   |
 |  compiler                     | clang 17.0.6                                                                                                                           | clang 17.0.6                                                                                                                           |
 |  cores                        | 28                                                                                                                                     | 28                                                                                                                                     |
 |  data_preparation_cores       | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                         | 2025-02-02 01:18:13                                                                                                                    | 2025-02-02 04:55:31                                                                                                                    |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  max_duration                 | 1200000000000                                                                                                                          | 1200000000000                                                                                                                          |
 |  max_runs                     | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor                 | 10.0                                                                                                                                   | 10.0                                                                                                                                   |
 |  time_unit                    | ns                                                                                                                                     | ns                                                                                                                                     |
 |  use_prepared_statements      | False                                                                                                                                  | False                                                                                                                                  |
 |  using_scheduler              | True                                                                                                                                   | True                                                                                                                                   |
 |  utilized_cores_per_numa_node | [0, 0, 28]                                                                                                                             | [0, 0, 28]                                                                                                                             |
 |  verify                       | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration              | 0                                                                                                                                      | 0                                                                                                                                      |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+----------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)   | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |      new |        ||      old |      new |        |         |
 +----------++----------+----------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||  6150.63 |  6329.74 |   +3%  ||     0.57 |     0.57 |   -0%  |  0.0261 |
 | TPC-H 02 ||   325.35 |   311.72 |   -4%  ||     0.57 |     0.57 |   -0%  |  0.8058 |
 | TPC-H 03 ||  2137.63 |  2132.55 |   -0%  ||     0.57 |     0.57 |   -0%  |  0.9751 |
+| TPC-H 04 ||  2036.61 |  1887.09 |   -7%  ||     0.57 |     0.57 |   +0%  |  0.2963 |
-| TPC-H 05 ||  3018.48 |  3217.60 |   +7%  ||     0.57 |     0.57 |   -0%  |  0.2992 |
+| TPC-H 06 ||   732.95 |   629.12 |  -14%  ||     0.57 |     0.57 |   +0%  |  0.2717 |
+| TPC-H 07 ||  2623.44 |  2472.51 |   -6%  ||     0.57 |     0.57 |   -0%  |  0.4036 |
+| TPC-H 08 ||  1851.96 |  1762.80 |   -5%  ||     0.57 |     0.57 |   -0%  |  0.5705 |
 | TPC-H 09 ||  4681.48 |  4689.48 |   +0%  ||     0.57 |     0.57 |   -0%  |  0.9668 |
-| TPC-H 10 ||  2585.33 |  2753.53 |   +7%  ||     0.57 |     0.57 |   +0%  |  0.3291 |
-| TPC-H 11 ||   350.01 |   453.95 |  +30%  ||     0.57 |     0.57 |   -0%  |  0.0979 |
+| TPC-H 12 ||  2142.26 |  1946.68 |   -9%  ||     0.57 |     0.57 |   +0%  |  0.1753 |
 | TPC-H 13 ||  4760.22 |  4861.72 |   +2%  ||     0.57 |     0.57 |   +0%  |  0.4199 |
-| TPC-H 14 ||   869.88 |  1010.36 |  +16%  ||     0.57 |     0.57 |   +0%  |  0.2160 |
+| TPC-H 15 ||   701.70 |   657.42 |   -6%  ||     0.57 |     0.57 |   -0%  |  0.6259 |
-| TPC-H 16 ||  1571.92 |  1729.07 |  +10%  ||     0.57 |     0.57 |   +0%  |  0.1641 |
+| TPC-H 17 ||   707.79 |   615.43 |  -13%  ||     0.57 |     0.57 |   -0%  |  0.2704 |
 | TPC-H 18 ||  3718.36 |  3685.80 |   -1%  ||     0.57 |     0.57 |   -0%  |  0.7524 |
-| TPC-H 19 ||   910.82 |   972.07 |   +7%  ||     0.57 |     0.57 |   -0%  |  0.5900 |
 | TPC-H 20 ||  1539.59 |  1483.71 |   -4%  ||     0.57 |     0.57 |   -0%  |  0.6989 |
 | TPC-H 21 ||  4101.79 |  3988.50 |   -3%  ||     0.57 |     0.57 |   -0%  |  0.5947 |
+| TPC-H 22 ||   951.18 |   907.47 |   -5%  ||     0.57 |     0.57 |   -0%  |  0.6874 |
 +----------++----------+----------+--------++----------+----------+--------+---------+
 | Sum      || 48469.40 | 48498.31 |   +0%  ||          |          |        |         |
 | Geomean  ||          |          |        ||          |          |   -0%  |         |
 +----------++----------+----------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCDS - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: +2%
 ||
Geometric mean of throughput changes: -1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter               | /home/Daniel.Lindner/hyrise/clang17-release/benchmark_all_results/hyriseBenchmarkTPCDS_2a56cc3c6d5b0997af199aa5383216af8f526cd1_st.json | /home/Daniel.Lindner/hyrise/clang17-release/benchmark_all_results/hyriseBenchmarkTPCDS_addc64949a58ea471405384b366401d7497a4870_st.json |
 +-------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH               | 2a56cc3c6d5b0997af199aa5383216af8f526cd1-dirty                                                                                          | addc64949a58ea471405384b366401d7497a4870-dirty                                                                                          |
 |  benchmark_mode         | Ordered                                                                                                                                 | Ordered                                                                                                                                 |
 |  build_type             | release                                                                                                                                 | release                                                                                                                                 |
 |  chunk_indexes          | False                                                                                                                                   | False                                                                                                                                   |
 |  chunk_size             | 65535                                                                                                                                   | 65535                                                                                                                                   |
 |  clients                | 1                                                                                                                                       | 1                                                                                                                                       |
 |  compiler               | clang 17.0.6                                                                                                                            | clang 17.0.6                                                                                                                            |
 |  cores                  | 0                                                                                                                                       | 0                                                                                                                                       |
 |  data_preparation_cores | 0                                                                                                                                       | 0                                                                                                                                       |
 |  date                   | 2025-02-02 01:39:43                                                                                                                     | 2025-02-02 05:17:05                                                                                                                     |
 |  encoding               | {'default': {'encoding': 'Dictionary'}}                                                                                                 | {'default': {'encoding': 'Dictionary'}}                                                                                                 |
 |  max_duration           | 60000000000                                                                                                                             | 60000000000                                                                                                                             |
 |  max_runs               | 50                                                                                                                                      | 50                                                                                                                                      |
 |  time_unit              | ns                                                                                                                                      | ns                                                                                                                                      |
 |  using_scheduler        | False                                                                                                                                   | False                                                                                                                                   |
 |  verify                 | False                                                                                                                                   | False                                                                                                                                   |
 |  warmup_duration        | 1000000000                                                                                                                              | 1000000000                                                                                                                              |
 +-------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change |              p-value |
 |         ||      old |      new |        ||      old |      new |        |                      |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 | 01      ||   229.58 |   231.34 |   +1%˄ ||     4.36 |     4.32 |   -1%˄ | (run time too short) |
 | 03      ||    69.06 |    69.59 |   +1%˄ ||    14.48 |    14.37 |   -1%˄ | (run time too short) |
 | 06      ||   169.92 |   173.37 |   +2%˄ ||     5.89 |     5.77 |   -2%˄ | (run time too short) |
 | 07      ||   267.42 |   270.05 |   +1%˄ ||     3.74 |     3.70 |   -1%˄ | (run time too short) |
 | 09      ||   696.04 |   704.98 |   +1%˄ ||     1.44 |     1.42 |   -1%˄ | (run time too short) |
-| 10      ||   123.14 |   131.76 |   +7%˄ ||     8.12 |     7.59 |   -7%˄ | (run time too short) |
 | 13      ||   482.53 |   490.50 |   +2%˄ ||     2.07 |     2.04 |   -2%˄ | (run time too short) |
 | 15      ||   100.58 |   102.10 |   +2%˄ ||     9.94 |     9.79 |   -1%˄ | (run time too short) |
-| 16      ||    57.15 |    61.87 |   +8%˄ ||    17.50 |    16.16 |   -8%˄ | (run time too short) |
-| 17      ||   300.41 |   315.79 |   +5%˄ ||     3.33 |     3.17 |   -5%˄ | (run time too short) |
 | 19      ||    92.89 |    92.54 |   -0%˄ ||    10.77 |    10.81 |   +0%˄ | (run time too short) |
+| 25      ||   168.27 |   160.37 |   -5%˄ ||     5.94 |     6.24 |   +5%˄ | (run time too short) |
+| 26      ||   128.76 |   114.30 |  -11%˄ ||     7.77 |     8.75 |  +13%˄ | (run time too short) |
 | 28      ||   619.39 |   621.51 |   +0%˄ ||     1.61 |     1.61 |   -0%˄ | (run time too short) |
 | 29      ||   473.49 |   476.89 |   +1%˄ ||     2.11 |     2.10 |   -1%˄ | (run time too short) |
 | 31      ||  1245.19 |  1253.15 |   +1%  ||     0.80 |     0.80 |   -1%  |               0.0277 |
 | 32      ||    33.00 |    33.98 |   +3%˄ ||    30.30 |    29.42 |   -3%˄ | (run time too short) |
 | 34      ||   149.73 |   150.57 |   +1%˄ ||     6.68 |     6.64 |   -1%˄ | (run time too short) |
 | 35      ||   571.31 |   572.94 |   +0%˄ ||     1.75 |     1.75 |   -0%˄ | (run time too short) |
 | 37      ||   526.91 |   523.44 |   -1%˄ ||     1.90 |     1.91 |   +1%˄ | (run time too short) |
 | 39a     ||  1534.21 |  1556.63 |   +1%  ||     0.65 |     0.64 |   -1%  |               0.0089 |
 | 39b     ||  1508.34 |  1537.49 |   +2%  ||     0.66 |     0.65 |   -2%  |               0.0000 |
 | 41      ||   270.59 |   269.14 |   -1%˄ ||     3.70 |     3.72 |   +1%˄ | (run time too short) |
 | 42      ||    77.52 |    75.45 |   -3%˄ ||    12.90 |    13.25 |   +3%˄ | (run time too short) |
 | 43      ||   849.98 |   861.29 |   +1%˄ ||     1.18 |     1.16 |   -1%˄ | (run time too short) |
 | 45      ||   106.58 |   108.16 |   +1%˄ ||     9.38 |     9.24 |   -1%˄ | (run time too short) |
 | 48      ||  1028.42 |  1043.97 |   +2%˄ ||     0.97 |     0.96 |   -1%˄ | (run time too short) |
 | 50      ||   111.31 |   112.42 |   +1%˄ ||     8.98 |     8.90 |   -1%˄ | (run time too short) |
 | 52      ||    72.83 |    72.82 |   -0%˄ ||    13.73 |    13.73 |   +0%˄ | (run time too short) |
 | 55      ||    69.50 |    69.75 |   +0%˄ ||    14.39 |    14.34 |   -0%˄ | (run time too short) |
 | 62      ||   502.82 |   506.44 |   +1%˄ ||     1.99 |     1.97 |   -1%˄ | (run time too short) |
 | 65      ||  1714.76 |  1738.93 |   +1%  ||     0.58 |     0.58 |   -1%  |               0.0303 |
 | 69      ||   132.07 |   132.76 |   +1%˄ ||     7.57 |     7.53 |   -1%˄ | (run time too short) |
 | 73      ||    71.30 |    71.64 |   +0%˄ ||    14.03 |    13.96 |   -0%˄ | (run time too short) |
 | 79      ||   444.66 |   445.80 |   +0%˄ ||     2.25 |     2.24 |   -0%˄ | (run time too short) |
 | 81      ||   143.28 |   145.78 |   +2%˄ ||     6.98 |     6.86 |   -2%˄ | (run time too short) |
 | 82      ||   561.08 |   574.62 |   +2%˄ ||     1.78 |     1.74 |   -2%˄ | (run time too short) |
-| 83      ||    30.60 |    32.99 |   +8%˄ ||    32.68 |    30.31 |   -7%˄ | (run time too short) |
 | 84      ||    11.16 |    11.07 |   -1%˄ ||    89.57 |    90.34 |   +1%˄ | (run time too short) |
 | 85      ||   149.31 |   143.16 |   -4%˄ ||     6.70 |     6.99 |   +4%˄ | (run time too short) |
 | 88      ||   588.09 |   594.31 |   +1%˄ ||     1.70 |     1.68 |   -1%˄ | (run time too short) |
 | 91      ||    13.74 |    13.92 |   +1%˄ ||    72.75 |    71.83 |   -1%˄ | (run time too short) |
 | 92      ||    25.01 |    25.11 |   +0%˄ ||    39.98 |    39.81 |   -0%˄ | (run time too short) |
 | 93      ||  3764.72 |  3768.43 |   +0%  ||     0.27 |     0.27 |   -0%  |               0.7310 |
 | 94      ||    32.02 |    32.05 |   +0%˄ ||    31.23 |    31.20 |   -0%˄ | (run time too short) |
-| 95      ||  4663.12 |  5069.74 |   +9%  ||     0.21 |     0.20 |   -8%  |               0.0060 |
+| 96      ||    59.17 |    56.35 |   -5%˄ ||    16.90 |    17.75 |   +5%˄ | (run time too short) |
 | 97      ||  4046.43 |  4175.39 |   +3%  ||     0.25 |     0.24 |   -3%  |               0.0018 |
 | 99      ||   969.80 |   978.36 |   +1%˄ ||     1.03 |     1.02 |   -1%˄ | (run time too short) |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 | Sum     || 30057.16 | 30775.05 |   +2%  ||          |          |        |                      |
 | Geomean ||          |          |        ||          |          |   -1%  |                      |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 |   Notes || ˄ Execution stopped due to max runs reached                                         |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkTPCDS - multi-threaded, ordered, 1 client, 28 cores**
<details>
<summary>
Sum of avg. item runtimes: -0%
 ||
Geometric mean of throughput changes: +0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+-------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Daniel.Lindner/hyrise/clang17-release/benchmark_all_results/hyriseBenchmarkTPCDS_2a56cc3c6d5b0997af199aa5383216af8f526cd1_mt_ordered.json | /home/Daniel.Lindner/hyrise/clang17-release/benchmark_all_results/hyriseBenchmarkTPCDS_addc64949a58ea471405384b366401d7497a4870_mt_ordered.json |
 +-------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 2a56cc3c6d5b0997af199aa5383216af8f526cd1-dirty                                                                                                  | addc64949a58ea471405384b366401d7497a4870-dirty                                                                                                  |
 |  benchmark_mode               | Ordered                                                                                                                                         | Ordered                                                                                                                                         |
 |  build_type                   | release                                                                                                                                         | release                                                                                                                                         |
 |  chunk_indexes                | False                                                                                                                                           | False                                                                                                                                           |
 |  chunk_size                   | 65535                                                                                                                                           | 65535                                                                                                                                           |
 |  clients                      | 1                                                                                                                                               | 1                                                                                                                                               |
 |  compiler                     | clang 17.0.6                                                                                                                                    | clang 17.0.6                                                                                                                                    |
 |  cores                        | 28                                                                                                                                              | 28                                                                                                                                              |
 |  data_preparation_cores       | 0                                                                                                                                               | 0                                                                                                                                               |
 |  date                         | 2025-02-02 01:58:03                                                                                                                             | 2025-02-02 05:35:25                                                                                                                             |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                         | {'default': {'encoding': 'Dictionary'}}                                                                                                         |
 |  max_duration                 | 60000000000                                                                                                                                     | 60000000000                                                                                                                                     |
 |  max_runs                     | 50                                                                                                                                              | 50                                                                                                                                              |
 |  time_unit                    | ns                                                                                                                                              | ns                                                                                                                                              |
 |  using_scheduler              | True                                                                                                                                            | True                                                                                                                                            |
 |  utilized_cores_per_numa_node | [0, 0, 28]                                                                                                                                      | [0, 0, 28]                                                                                                                                      |
 |  verify                       | False                                                                                                                                           | False                                                                                                                                           |
 |  warmup_duration              | 1000000000                                                                                                                                      | 1000000000                                                                                                                                      |
 +-------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change |              p-value |
 |         ||      old |      new |        ||      old |      new |        |                      |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 | 01      ||   217.91 |   217.37 |   -0%˄ ||     4.59 |     4.60 |   +0%˄ | (run time too short) |
 | 03      ||    39.34 |    38.16 |   -3%˄ ||    25.29 |    26.09 |   +3%˄ | (run time too short) |
 | 06      ||   187.66 |   189.72 |   +1%˄ ||     5.32 |     5.27 |   -1%˄ | (run time too short) |
 | 07      ||   171.78 |   171.50 |   -0%˄ ||     5.81 |     5.82 |   +0%˄ | (run time too short) |
 | 09      ||   102.00 |   100.94 |   -1%˄ ||     9.79 |     9.89 |   +1%˄ | (run time too short) |
 | 10      ||    45.87 |    45.76 |   -0%˄ ||    21.74 |    21.80 |   +0%˄ | (run time too short) |
 | 13      ||   256.68 |   258.31 |   +1%˄ ||     3.89 |     3.87 |   -1%˄ | (run time too short) |
 | 15      ||    66.09 |    65.30 |   -1%˄ ||    15.09 |    15.27 |   +1%˄ | (run time too short) |
 | 16      ||    43.16 |    42.53 |   -1%˄ ||    23.09 |    23.43 |   +1%˄ | (run time too short) |
 | 17      ||   145.67 |   145.55 |   -0%˄ ||     6.86 |     6.86 |   +0%˄ | (run time too short) |
 | 19      ||    71.02 |    71.40 |   +1%˄ ||    14.05 |    13.97 |   -1%˄ | (run time too short) |
 | 25      ||   109.45 |   109.37 |   -0%˄ ||     9.12 |     9.13 |   +0%˄ | (run time too short) |
 | 26      ||    85.21 |    84.73 |   -1%˄ ||    11.71 |    11.78 |   +1%˄ | (run time too short) |
 | 28      ||    97.56 |    98.66 |   +1%˄ ||    10.24 |    10.12 |   -1%˄ | (run time too short) |
 | 29      ||   405.22 |   414.72 |   +2%˄ ||     2.47 |     2.41 |   -2%˄ | (run time too short) |
 | 31      ||   455.39 |   453.05 |   -1%˄ ||     2.20 |     2.21 |   +1%˄ | (run time too short) |
 | 32      ||    39.24 |    38.77 |   -1%˄ ||    25.39 |    25.70 |   +1%˄ | (run time too short) |
 | 34      ||    92.88 |    92.64 |   -0%˄ ||    10.75 |    10.78 |   +0%˄ | (run time too short) |
 | 35      ||   360.19 |   362.52 |   +1%˄ ||     2.78 |     2.76 |   -1%˄ | (run time too short) |
 | 37      ||   182.00 |   184.71 |   +1%˄ ||     5.49 |     5.41 |   -1%˄ | (run time too short) |
 | 39a     ||   780.63 |   754.75 |   -3%˄ ||     1.28 |     1.32 |   +3%˄ | (run time too short) |
 | 39b     ||   773.11 |   757.84 |   -2%˄ ||     1.29 |     1.32 |   +2%˄ | (run time too short) |
 | 41      ||   323.21 |   321.50 |   -1%˄ ||     3.09 |     3.11 |   +1%˄ | (run time too short) |
 | 42      ||    59.27 |    59.20 |   -0%˄ ||    16.82 |    16.85 |   +0%˄ | (run time too short) |
 | 43      ||   391.32 |   389.13 |   -1%˄ ||     2.55 |     2.57 |   +1%˄ | (run time too short) |
 | 45      ||    54.51 |    54.69 |   +0%˄ ||    18.30 |    18.23 |   -0%˄ | (run time too short) |
 | 48      ||   445.73 |   446.71 |   +0%˄ ||     2.24 |     2.24 |   -0%˄ | (run time too short) |
 | 50      ||   112.62 |   115.21 |   +2%˄ ||     8.86 |     8.67 |   -2%˄ | (run time too short) |
 | 52      ||    62.76 |    61.28 |   -2%˄ ||    15.89 |    16.27 |   +2%˄ | (run time too short) |
-| 55      ||    53.69 |    57.05 |   +6%˄ ||    18.58 |    17.48 |   -6%˄ | (run time too short) |
 | 62      ||   299.61 |   293.14 |   -2%˄ ||     3.34 |     3.41 |   +2%˄ | (run time too short) |
 | 65      ||  1456.18 |  1457.79 |   +0%  ||     0.69 |     0.69 |   -0%  |               0.8601 |
 | 69      ||    74.61 |    74.42 |   -0%˄ ||    13.37 |    13.41 |   +0%˄ | (run time too short) |
 | 73      ||    58.12 |    58.90 |   +1%˄ ||    17.17 |    16.94 |   -1%˄ | (run time too short) |
 | 79      ||   423.19 |   423.82 |   +0%˄ ||     2.36 |     2.36 |   -0%˄ | (run time too short) |
 | 81      ||   183.78 |   181.65 |   -1%˄ ||     5.44 |     5.50 |   +1%˄ | (run time too short) |
 | 82      ||   217.46 |   215.99 |   -1%˄ ||     4.59 |     4.63 |   +1%˄ | (run time too short) |
 | 83      ||    45.05 |    45.18 |   +0%˄ ||    22.11 |    22.06 |   -0%˄ | (run time too short) |
+| 84      ||    17.36 |    16.22 |   -7%˄ ||    57.06 |    61.04 |   +7%˄ | (run time too short) |
 | 85      ||    63.37 |    64.23 |   +1%˄ ||    15.74 |    15.54 |   -1%˄ | (run time too short) |
 | 88      ||    79.59 |    82.04 |   +3%˄ ||    12.55 |    12.17 |   -3%˄ | (run time too short) |
 | 91      ||    21.69 |    22.36 |   +3%˄ ||    45.85 |    44.46 |   -3%˄ | (run time too short) |
+| 92      ||    38.85 |    36.31 |   -7%˄ ||    25.64 |    27.45 |   +7%˄ | (run time too short) |
 | 93      ||   624.10 |   614.98 |   -1%˄ ||     1.60 |     1.63 |   +1%˄ | (run time too short) |
 | 94      ||    42.96 |    42.44 |   -1%˄ ||    23.19 |    23.48 |   +1%˄ | (run time too short) |
 | 95      ||   671.01 |   675.92 |   +1%˄ ||     1.49 |     1.48 |   -1%˄ | (run time too short) |
 | 96      ||    59.36 |    60.61 |   +2%˄ ||    16.81 |    16.46 |   -2%˄ | (run time too short) |
 | 97      ||  1547.47 |  1529.90 |   -1%  ||     0.65 |     0.65 |   +1%  |               0.3158 |
 | 99      ||   585.28 |   585.82 |   +0%˄ ||     1.71 |     1.71 |   -0%˄ | (run time too short) |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 | Sum     || 12740.18 | 12684.78 |   -0%  ||          |          |        |                      |
 | Geomean ||          |          |        ||          |          |   +0%  |                      |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 |   Notes || ˄ Execution stopped due to max runs reached                                         |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkTPCDS - multi-threaded, shuffled, 28 clients, 28 cores**
<details>
<summary>
Sum of avg. item runtimes: +0%
 ||
Geometric mean of throughput changes: -0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Daniel.Lindner/hyrise/clang17-release/benchmark_all_results/hyriseBenchmarkTPCDS_2a56cc3c6d5b0997af199aa5383216af8f526cd1_mt.json | /home/Daniel.Lindner/hyrise/clang17-release/benchmark_all_results/hyriseBenchmarkTPCDS_addc64949a58ea471405384b366401d7497a4870_mt.json |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 2a56cc3c6d5b0997af199aa5383216af8f526cd1-dirty                                                                                          | addc64949a58ea471405384b366401d7497a4870-dirty                                                                                          |
 |  benchmark_mode               | Shuffled                                                                                                                                | Shuffled                                                                                                                                |
 |  build_type                   | release                                                                                                                                 | release                                                                                                                                 |
 |  chunk_indexes                | False                                                                                                                                   | False                                                                                                                                   |
 |  chunk_size                   | 65535                                                                                                                                   | 65535                                                                                                                                   |
 |  clients                      | 28                                                                                                                                      | 28                                                                                                                                      |
 |  compiler                     | clang 17.0.6                                                                                                                            | clang 17.0.6                                                                                                                            |
 |  cores                        | 28                                                                                                                                      | 28                                                                                                                                      |
 |  data_preparation_cores       | 0                                                                                                                                       | 0                                                                                                                                       |
 |  date                         | 2025-02-02 02:09:47                                                                                                                     | 2025-02-02 05:47:15                                                                                                                     |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                 | {'default': {'encoding': 'Dictionary'}}                                                                                                 |
 |  max_duration                 | 1200000000000                                                                                                                           | 1200000000000                                                                                                                           |
 |  max_runs                     | -1                                                                                                                                      | -1                                                                                                                                      |
 |  time_unit                    | ns                                                                                                                                      | ns                                                                                                                                      |
 |  using_scheduler              | True                                                                                                                                    | True                                                                                                                                    |
 |  utilized_cores_per_numa_node | [0, 0, 28]                                                                                                                              | [0, 0, 28]                                                                                                                              |
 |  verify                       | False                                                                                                                                   | False                                                                                                                                   |
 |  warmup_duration              | 0                                                                                                                                       | 0                                                                                                                                       |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |      new |        ||      old |      new |        |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | 01      ||   634.26 |   616.36 |   -3%  ||     0.57 |     0.57 |   -0%  |  0.7362 |
-| 03      ||   264.48 |   284.03 |   +7%  ||     0.57 |     0.57 |   -0%  |  0.6498 |
 | 06      ||   686.15 |   692.33 |   +1%  ||     0.57 |     0.57 |   -0%  |  0.9141 |
-| 07      ||   788.51 |   864.96 |  +10%  ||     0.57 |     0.57 |   -0%  |  0.2289 |
+| 09      ||   673.18 |   608.57 |  -10%  ||     0.57 |     0.57 |   -0%  |  0.2451 |
-| 10      ||   622.65 |   665.09 |   +7%  ||     0.57 |     0.57 |   -1%  |  0.5209 |
 | 13      ||  1419.96 |  1392.34 |   -2%  ||     0.57 |     0.57 |   -0%  |  0.7510 |
-| 15      ||   382.88 |   407.88 |   +7%  ||     0.57 |     0.57 |   -0%  |  0.5840 |
+| 16      ||   398.21 |   346.21 |  -13%  ||     0.57 |     0.57 |   -0%  |  0.2973 |
+| 17      ||  1111.13 |  1016.07 |   -9%  ||     0.57 |     0.57 |   -1%  |  0.2782 |
-| 19      ||   506.01 |   569.76 |  +13%  ||     0.57 |     0.57 |   -0%  |  0.2160 |
-| 25      ||   725.55 |   882.15 |  +22%  ||     0.57 |     0.57 |   -0%  |  0.0231 |
+| 26      ||   478.74 |   449.38 |   -6%  ||     0.57 |     0.57 |   -0%  |  0.5651 |
+| 28      ||  1171.30 |  1070.50 |   -9%  ||     0.57 |     0.57 |   -0%  |  0.2941 |
 | 29      ||  1309.77 |  1319.85 |   +1%  ||     0.57 |     0.57 |   -0%  |  0.8994 |
 | 31      ||  1982.18 |  2018.85 |   +2%  ||     0.57 |     0.57 |   -0%  |  0.7278 |
+| 32      ||   176.62 |   159.66 |  -10%  ||     0.57 |     0.57 |   -0%  |  0.6141 |
+| 34      ||   664.08 |   624.49 |   -6%  ||     0.57 |     0.57 |   -0%  |  0.5008 |
 | 35      ||  1557.78 |  1560.76 |   +0%  ||     0.57 |     0.57 |   -0%  |  0.9723 |
-| 37      ||   701.83 |   832.03 |  +19%  ||     0.57 |     0.57 |   -1%  |  0.0318 |
 | 39a     ||  2141.87 |  2153.91 |   +1%  ||     0.57 |     0.57 |   -1%  |  0.8926 |
 | 39b     ||  2209.68 |  2195.30 |   -1%  ||     0.57 |     0.56 |   -1%  |  0.8839 |
 | 41      ||  1852.79 |  1833.77 |   -1%  ||     0.57 |     0.57 |   -0%  |  0.8423 |
+| 42      ||   456.05 |   416.05 |   -9%  ||     0.57 |     0.57 |   -0%  |  0.4446 |
 | 43      ||  1299.17 |  1295.48 |   -0%  ||     0.57 |     0.57 |   -0%  |  0.9577 |
 | 45      ||   637.17 |   664.86 |   +4%  ||     0.57 |     0.56 |   -1%  |  0.6718 |
-| 48      ||  1890.77 |  2039.74 |   +8%  ||     0.57 |     0.57 |   -0%  |  0.1150 |
-| 50      ||   794.65 |   835.79 |   +5%  ||     0.57 |     0.57 |   -0%  |  0.5240 |
-| 52      ||   436.05 |   484.27 |  +11%  ||     0.57 |     0.57 |   -0%  |  0.4009 |
-| 55      ||   331.01 |   381.69 |  +15%  ||     0.57 |     0.57 |   -0%  |  0.2457 |
+| 62      ||   969.03 |   865.83 |  -11%  ||     0.57 |     0.57 |   -0%  |  0.0855 |
 | 65      ||  3317.85 |  3266.09 |   -2%  ||     0.57 |     0.56 |   -0%  |  0.4883 |
 | 69      ||   845.45 |   818.49 |   -3%  ||     0.57 |     0.57 |   -0%  |  0.7289 |
+| 73      ||   471.21 |   394.60 |  -16%  ||     0.57 |     0.57 |   -0%  |  0.1570 |
 | 79      ||  1316.74 |  1285.47 |   -2%  ||     0.57 |     0.57 |   -0%  |  0.6761 |
+| 81      ||   517.68 |   493.53 |   -5%  ||     0.57 |     0.57 |   -0%  |  0.5260 |
 | 82      ||   849.29 |   836.82 |   -1%  ||     0.57 |     0.57 |   -0%  |  0.8361 |
+| 83      ||   360.91 |   288.81 |  -20%  ||     0.57 |     0.57 |   -0%  |  0.1897 |
 | 84      ||   159.64 |   165.64 |   +4%  ||     0.57 |     0.57 |   -0%  |  0.8778 |
+| 85      ||   655.18 |   591.74 |  -10%  ||     0.57 |     0.57 |   -0%  |  0.3065 |
-| 88      ||  1865.77 |  2035.90 |   +9%  ||     0.57 |     0.56 |   -0%  |  0.1657 |
-| 91      ||   146.58 |   178.68 |  +22%  ||     0.57 |     0.57 |   -0%  |  0.3474 |
+| 92      ||   270.74 |   239.75 |  -11%  ||     0.57 |     0.57 |   +0%  |  0.4068 |
 | 93      ||  1692.49 |  1703.62 |   +1%  ||     0.57 |     0.57 |   -0%  |  0.8738 |
-| 94      ||   263.40 |   322.01 |  +22%  ||     0.57 |     0.57 |   -1%  |  0.1380 |
-| 95      ||  1805.41 |  1945.56 |   +8%  ||     0.57 |     0.57 |   -1%  |  0.1168 |
 | 96      ||   371.40 |   370.43 |   -0%  ||     0.57 |     0.57 |   -0%  |  0.9825 |
 | 97      ||  3691.99 |  3621.67 |   -2%  ||     0.57 |     0.57 |   -0%  |  0.4777 |
+| 99      ||  1265.66 |  1196.68 |   -5%  ||     0.57 |     0.57 |   -0%  |  0.2883 |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Sum     || 49140.90 | 49303.45 |   +0%  ||          |          |        |         |
 | Geomean ||          |          |        ||          |          |   -0%  |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCC - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -1%
 ||
Geometric mean of throughput changes: +3%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter               | /home/Daniel.Lindner/hyrise/clang17-release/benchmark_all_results/hyriseBenchmarkTPCC_2a56cc3c6d5b0997af199aa5383216af8f526cd1_st.json | /home/Daniel.Lindner/hyrise/clang17-release/benchmark_all_results/hyriseBenchmarkTPCC_addc64949a58ea471405384b366401d7497a4870_st.json |
 +-------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH               | 2a56cc3c6d5b0997af199aa5383216af8f526cd1-dirty                                                                                         | addc64949a58ea471405384b366401d7497a4870-dirty                                                                                         |
 |  benchmark_mode         | Shuffled                                                                                                                               | Shuffled                                                                                                                               |
 |  build_type             | release                                                                                                                                | release                                                                                                                                |
 |  chunk_indexes          | False                                                                                                                                  | False                                                                                                                                  |
 |  chunk_size             | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                | 1                                                                                                                                      | 1                                                                                                                                      |
 |  compiler               | clang 17.0.6                                                                                                                           | clang 17.0.6                                                                                                                           |
 |  cores                  | 0                                                                                                                                      | 0                                                                                                                                      |
 |  data_preparation_cores | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                   | 2025-02-02 02:30:03                                                                                                                    | 2025-02-02 06:07:38                                                                                                                    |
 |  encoding               | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  max_duration           | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs               | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor           | 10                                                                                                                                     | 10                                                                                                                                     |
 |  time_unit              | ns                                                                                                                                     | ns                                                                                                                                     |
 |  using_scheduler        | False                                                                                                                                  | False                                                                                                                                  |
 |  verify                 | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration        | 0                                                                                                                                      | 0                                                                                                                                      |
 +-------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |              ||      old |     new |        ||      old |      new |        |         |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
+| Delivery     ||    25.23 |   24.97 |   -1%  ||     4.82 |     5.98 |  +24%  |  0.0000 |
 | New-Order    ||    12.16 |   11.99 |   -1%  ||    61.01 |    59.06 |   -3%  |  0.0454 |
-| Order-Status ||     1.12 |    1.12 |   -1%  ||     5.72 |     5.23 |   -8%  |  0.3196 |
+| Payment      ||     2.13 |    2.12 |   -0%  ||    55.30 |    58.58 |   +6%  |  0.0571 |
 | Stock-Level  ||     1.90 |    1.93 |   +1%  ||     5.37 |     5.27 |   -2%  |  0.2591 |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Sum          ||    42.54 |   42.12 |   -1%  ||          |          |        |         |
 | Geomean      ||          |         |        ||          |          |   +3%  |         |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCC - multi-threaded, shuffled, 28 clients, 10 warehouses, 28 cores (high contention)**
<details>
<summary>
Sum of avg. item runtimes: -0%
 ||
Geometric mean of throughput changes: +0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+-------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Daniel.Lindner/hyrise/clang17-release/benchmark_all_results/hyriseBenchmarkTPCC_2a56cc3c6d5b0997af199aa5383216af8f526cd1_mt_highcont.json | /home/Daniel.Lindner/hyrise/clang17-release/benchmark_all_results/hyriseBenchmarkTPCC_addc64949a58ea471405384b366401d7497a4870_mt_highcont.json |
 +-------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 2a56cc3c6d5b0997af199aa5383216af8f526cd1-dirty                                                                                                  | addc64949a58ea471405384b366401d7497a4870-dirty                                                                                                  |
 |  benchmark_mode               | Shuffled                                                                                                                                        | Shuffled                                                                                                                                        |
 |  build_type                   | release                                                                                                                                         | release                                                                                                                                         |
 |  chunk_indexes                | False                                                                                                                                           | False                                                                                                                                           |
 |  chunk_size                   | 65535                                                                                                                                           | 65535                                                                                                                                           |
 |  clients                      | 28                                                                                                                                              | 28                                                                                                                                              |
 |  compiler                     | clang 17.0.6                                                                                                                                    | clang 17.0.6                                                                                                                                    |
 |  cores                        | 28                                                                                                                                              | 28                                                                                                                                              |
 |  data_preparation_cores       | 0                                                                                                                                               | 0                                                                                                                                               |
 |  date                         | 2025-02-02 02:31:09                                                                                                                             | 2025-02-02 06:08:44                                                                                                                             |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                         | {'default': {'encoding': 'Dictionary'}}                                                                                                         |
 |  max_duration                 | 600000000000                                                                                                                                    | 600000000000                                                                                                                                    |
 |  max_runs                     | -1                                                                                                                                              | -1                                                                                                                                              |
 |  scale_factor                 | 10                                                                                                                                              | 10                                                                                                                                              |
 |  time_unit                    | ns                                                                                                                                              | ns                                                                                                                                              |
 |  using_scheduler              | True                                                                                                                                            | True                                                                                                                                            |
 |  utilized_cores_per_numa_node | [0, 0, 28]                                                                                                                                      | [0, 0, 28]                                                                                                                                      |
 |  verify                       | False                                                                                                                                           | False                                                                                                                                           |
 |  warmup_duration              | 0                                                                                                                                               | 0                                                                                                                                               |
 +-------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |              ||      old |     new |        ||      old |      new |        |         |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Delivery     ||    93.86 |   93.58 |   -0%  ||    35.35 |    35.13 |   -1%  |  0.5689 |
 |    unsucc.:  ||     2.16 |    1.68 |  -22%  ||    16.37 |    16.34 |   -0%  |         |
 | New-Order    ||    43.93 |   43.97 |   +0%  ||   450.09 |   449.08 |   -0%  |  0.6650 |
 |    unsucc.:  ||     5.77 |    6.01 |   +4%  ||   135.57 |   136.46 |   +1%  |         |
 | Order-Status ||     5.05 |    5.12 |   +1%  ||    52.17 |    52.31 |   +0%  |  0.4398 |
 | Payment      ||     8.12 |    8.09 |   -0%  ||   318.00 |   319.29 |   +0%  |  0.4490 |
 |    unsucc.:  ||     3.13 |    3.19 |   +2%  ||   239.91 |   240.21 |   +0%  |         |
 | Stock-Level  ||     8.90 |    8.90 |   -0%  ||    51.93 |    52.46 |   +1%  |  0.9695 |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Sum          ||   159.87 |  159.65 |   -0%  ||          |          |        |         |
 | Geomean      ||          |         |        ||          |          |   +0%  |         |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCC - multi-threaded, shuffled, 10 clients, 10 warehouses, 28 cores (low contention)**
<details>
<summary>
Sum of avg. item runtimes: -0%
 ||
Geometric mean of throughput changes: +0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Daniel.Lindner/hyrise/clang17-release/benchmark_all_results/hyriseBenchmarkTPCC_2a56cc3c6d5b0997af199aa5383216af8f526cd1_mt_lowcont.json | /home/Daniel.Lindner/hyrise/clang17-release/benchmark_all_results/hyriseBenchmarkTPCC_addc64949a58ea471405384b366401d7497a4870_mt_lowcont.json |
 +-------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 2a56cc3c6d5b0997af199aa5383216af8f526cd1-dirty                                                                                                 | addc64949a58ea471405384b366401d7497a4870-dirty                                                                                                 |
 |  benchmark_mode               | Shuffled                                                                                                                                       | Shuffled                                                                                                                                       |
 |  build_type                   | release                                                                                                                                        | release                                                                                                                                        |
 |  chunk_indexes                | False                                                                                                                                          | False                                                                                                                                          |
 |  chunk_size                   | 65535                                                                                                                                          | 65535                                                                                                                                          |
 |  clients                      | 10                                                                                                                                             | 10                                                                                                                                             |
 |  compiler                     | clang 17.0.6                                                                                                                                   | clang 17.0.6                                                                                                                                   |
 |  cores                        | 28                                                                                                                                             | 28                                                                                                                                             |
 |  data_preparation_cores       | 0                                                                                                                                              | 0                                                                                                                                              |
 |  date                         | 2025-02-02 02:41:18                                                                                                                            | 2025-02-02 06:18:53                                                                                                                            |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                        | {'default': {'encoding': 'Dictionary'}}                                                                                                        |
 |  max_duration                 | 600000000000                                                                                                                                   | 600000000000                                                                                                                                   |
 |  max_runs                     | -1                                                                                                                                             | -1                                                                                                                                             |
 |  scale_factor                 | 10                                                                                                                                             | 10                                                                                                                                             |
 |  time_unit                    | ns                                                                                                                                             | ns                                                                                                                                             |
 |  using_scheduler              | True                                                                                                                                           | True                                                                                                                                           |
 |  utilized_cores_per_numa_node | [0, 0, 28]                                                                                                                                     | [0, 0, 28]                                                                                                                                     |
 |  verify                       | False                                                                                                                                          | False                                                                                                                                          |
 |  warmup_duration              | 0                                                                                                                                              | 0                                                                                                                                              |
 +-------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |              ||      old |     new |        ||      old |      new |        |         |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Delivery     ||    53.05 |   52.81 |   -0%  ||    20.68 |    20.90 |   +1%  |  0.0122 |
 |    unsucc.:  ||     0.81 |    0.85 |   +4%  ||     2.24 |     2.22 |   -1%  |         |
 | New-Order    ||    29.22 |   29.14 |   -0%  ||   237.38 |   238.22 |   +0%  |  0.0175 |
 |    unsucc.:  ||     3.15 |    2.63 |  -17%  ||    21.67 |    20.87 |   -4%  |         |
 | Order-Status ||     4.17 |    4.15 |   -0%  ||    22.96 |    23.09 |   +1%  |  0.3462 |
 | Payment      ||     7.86 |    7.86 |   +0%  ||   197.09 |   197.13 |   +0%  |  0.9223 |
 |    unsucc.:  ||     1.94 |    1.94 |   +0%  ||    50.04 |    50.29 |   +0%  |         |
 | Stock-Level  ||     6.03 |    6.00 |   -0%  ||    23.04 |    23.10 |   +0%  |  0.3454 |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Sum          ||   100.32 |   99.96 |   -0%  ||          |          |        |         |
 | Geomean      ||          |         |        ||          |          |   +0%  |         |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkJoinOrder - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -0%
 ||
Geometric mean of throughput changes: +1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter               | /home/Daniel.Lindner/hyrise/clang17-release/benchmark_all_results/hyriseBenchmarkJoinOrder_2a56cc3c6d5b0997af199aa5383216af8f526cd1_st.json | /home/Daniel.Lindner/hyrise/clang17-release/benchmark_all_results/hyriseBenchmarkJoinOrder_addc64949a58ea471405384b366401d7497a4870_st.json |
 +-------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH               | 2a56cc3c6d5b0997af199aa5383216af8f526cd1-dirty                                                                                              | addc64949a58ea471405384b366401d7497a4870-dirty                                                                                              |
 |  benchmark_mode         | Ordered                                                                                                                                     | Ordered                                                                                                                                     |
 |  build_type             | release                                                                                                                                     | release                                                                                                                                     |
 |  chunk_indexes          | False                                                                                                                                       | False                                                                                                                                       |
 |  chunk_size             | 65535                                                                                                                                       | 65535                                                                                                                                       |
 |  clients                | 1                                                                                                                                           | 1                                                                                                                                           |
 |  compiler               | clang 17.0.6                                                                                                                                | clang 17.0.6                                                                                                                                |
 |  cores                  | 0                                                                                                                                           | 0                                                                                                                                           |
 |  data_preparation_cores | 0                                                                                                                                           | 0                                                                                                                                           |
 |  date                   | 2025-02-02 02:51:27                                                                                                                         | 2025-02-02 06:29:01                                                                                                                         |
 |  encoding               | {'default': {'encoding': 'Dictionary'}}                                                                                                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     |
 |  max_duration           | 60000000000                                                                                                                                 | 60000000000                                                                                                                                 |
 |  max_runs               | 50                                                                                                                                          | 50                                                                                                                                          |
 |  time_unit              | ns                                                                                                                                          | ns                                                                                                                                          |
 |  using_scheduler        | False                                                                                                                                       | False                                                                                                                                       |
 |  verify                 | False                                                                                                                                       | False                                                                                                                                       |
 |  warmup_duration        | 1000000000                                                                                                                                  | 1000000000                                                                                                                                  |
 +-------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change |              p-value |
 |         ||      old |      new |        ||      old |      new |        |                      |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 | 10a     ||   105.29 |   105.63 |   +0%˄ ||     9.50 |     9.47 |   -0%˄ | (run time too short) |
 | 10b     ||    59.67 |    59.47 |   -0%˄ ||    16.76 |    16.81 |   +0%˄ | (run time too short) |
 | 10c     ||   311.70 |   306.61 |   -2%˄ ||     3.21 |     3.26 |   +2%˄ | (run time too short) |
 | 11a     ||    77.97 |    78.84 |   +1%˄ ||    12.83 |    12.68 |   -1%˄ | (run time too short) |
 | 11b     ||    74.89 |    73.76 |   -2%˄ ||    13.35 |    13.56 |   +2%˄ | (run time too short) |
 | 11c     ||    23.34 |    23.17 |   -1%˄ ||    42.84 |    43.15 |   +1%˄ | (run time too short) |
 | 11d     ||    21.01 |    20.93 |   -0%˄ ||    47.59 |    47.78 |   +0%˄ | (run time too short) |
 | 12a     ||    25.46 |    25.30 |   -1%˄ ||    39.27 |    39.53 |   +1%˄ | (run time too short) |
 | 12b     ||    28.58 |    28.86 |   +1%˄ ||    34.98 |    34.65 |   -1%˄ | (run time too short) |
 | 12c     ||    56.85 |    56.07 |   -1%˄ ||    17.59 |    17.83 |   +1%˄ | (run time too short) |
 | 13a     ||   166.23 |   165.14 |   -1%˄ ||     6.02 |     6.06 |   +1%˄ | (run time too short) |
 | 13b     ||   210.75 |   209.25 |   -1%˄ ||     4.74 |     4.78 |   +1%˄ | (run time too short) |
 | 13c     ||    32.08 |    31.63 |   -1%˄ ||    31.17 |    31.61 |   +1%˄ | (run time too short) |
 | 13d     ||   467.79 |   463.43 |   -1%˄ ||     2.14 |     2.16 |   +1%˄ | (run time too short) |
 | 14a     ||    87.63 |    86.93 |   -1%˄ ||    11.41 |    11.50 |   +1%˄ | (run time too short) |
 | 14b     ||    98.15 |    97.47 |   -1%˄ ||    10.19 |    10.26 |   +1%˄ | (run time too short) |
 | 14c     ||   192.99 |   190.86 |   -1%˄ ||     5.18 |     5.24 |   +1%˄ | (run time too short) |
 | 15a     ||    50.28 |    50.01 |   -1%˄ ||    19.89 |    20.00 |   +1%˄ | (run time too short) |
 | 15b     ||    50.70 |    50.24 |   -1%˄ ||    19.72 |    19.90 |   +1%˄ | (run time too short) |
 | 15c     ||    40.15 |    39.93 |   -1%˄ ||    24.91 |    25.04 |   +1%˄ | (run time too short) |
 | 15d     ||    37.68 |    37.39 |   -1%˄ ||    26.54 |    26.74 |   +1%˄ | (run time too short) |
 | 16a     ||  1316.99 |  1300.66 |   -1%  ||     0.76 |     0.77 |   +1%  |               0.0373 |
 | 16b     ||  2345.54 |  2307.98 |   -2%  ||     0.43 |     0.43 |   +2%  |               0.0009 |
 | 16c     ||  1457.13 |  1450.98 |   -0%  ||     0.69 |     0.69 |   +0%  |               0.3082 |
 | 16d     ||  1409.72 |  1407.87 |   -0%  ||     0.71 |     0.71 |   +0%  |               0.7219 |
 | 17a     ||   427.34 |   424.65 |   -1%˄ ||     2.34 |     2.35 |   +1%˄ | (run time too short) |
 | 17b     ||   346.06 |   350.35 |   +1%˄ ||     2.89 |     2.85 |   -1%˄ | (run time too short) |
 | 17c     ||   330.01 |   331.10 |   +0%˄ ||     3.03 |     3.02 |   -0%˄ | (run time too short) |
 | 17d     ||   399.53 |   398.02 |   -0%˄ ||     2.50 |     2.51 |   +0%˄ | (run time too short) |
 | 17e     ||  1483.25 |  1473.50 |   -1%  ||     0.67 |     0.68 |   +1%  |               0.0420 |
 | 17f     ||   843.09 |   848.65 |   +1%˄ ||     1.19 |     1.18 |   -1%˄ | (run time too short) |
 | 18a     ||   130.05 |   129.60 |   -0%˄ ||     7.69 |     7.72 |   +0%˄ | (run time too short) |
 | 18b     ||    96.98 |    96.05 |   -1%˄ ||    10.31 |    10.41 |   +1%˄ | (run time too short) |
 | 18c     ||   208.37 |   205.03 |   -2%˄ ||     4.80 |     4.88 |   +2%˄ | (run time too short) |
 | 19a     ||   213.12 |   212.17 |   -0%˄ ||     4.69 |     4.71 |   +0%˄ | (run time too short) |
 | 19b     ||   171.00 |   169.71 |   -1%˄ ||     5.85 |     5.89 |   +1%˄ | (run time too short) |
 | 19c     ||   255.95 |   255.48 |   -0%˄ ||     3.91 |     3.91 |   +0%˄ | (run time too short) |
 | 19d     ||   612.07 |   613.11 |   +0%˄ ||     1.63 |     1.63 |   -0%˄ | (run time too short) |
 | 1a      ||     8.94 |     9.02 |   +1%˄ ||   111.83 |   110.89 |   -1%˄ | (run time too short) |
 | 1b      ||    10.75 |    10.75 |   -0%˄ ||    92.98 |    92.98 |   +0%˄ | (run time too short) |
 | 1c      ||    12.58 |    12.61 |   +0%˄ ||    79.46 |    79.31 |   -0%˄ | (run time too short) |
 | 1d      ||     8.52 |     8.35 |   -2%˄ ||   117.35 |   119.79 |   +2%˄ | (run time too short) |
 | 20a     ||   552.15 |   551.07 |   -0%˄ ||     1.81 |     1.81 |   +0%˄ | (run time too short) |
 | 20b     ||   592.27 |   592.15 |   -0%˄ ||     1.69 |     1.69 |   +0%˄ | (run time too short) |
 | 20c     ||   360.57 |   361.83 |   +0%˄ ||     2.77 |     2.76 |   -0%˄ | (run time too short) |
 | 21a     ||    91.92 |    91.13 |   -1%˄ ||    10.88 |    10.97 |   +1%˄ | (run time too short) |
 | 21b     ||    83.82 |    82.83 |   -1%˄ ||    11.93 |    12.07 |   +1%˄ | (run time too short) |
 | 21c     ||    94.91 |    94.64 |   -0%˄ ||    10.54 |    10.57 |   +0%˄ | (run time too short) |
 | 22a     ||   154.96 |   152.55 |   -2%˄ ||     6.45 |     6.56 |   +2%˄ | (run time too short) |
 | 22b     ||   140.72 |   138.79 |   -1%˄ ||     7.11 |     7.20 |   +1%˄ | (run time too short) |
 | 22c     ||   209.34 |   206.87 |   -1%˄ ||     4.78 |     4.83 |   +1%˄ | (run time too short) |
 | 22d     ||   324.99 |   321.52 |   -1%˄ ||     3.08 |     3.11 |   +1%˄ | (run time too short) |
 | 23a     ||    42.72 |    42.21 |   -1%˄ ||    23.41 |    23.69 |   +1%˄ | (run time too short) |
 | 23b     ||    46.09 |    45.35 |   -2%˄ ||    21.69 |    22.05 |   +2%˄ | (run time too short) |
 | 23c     ||    44.97 |    44.44 |   -1%˄ ||    22.24 |    22.50 |   +1%˄ | (run time too short) |
 | 24a     ||   209.14 |   209.47 |   +0%˄ ||     4.78 |     4.77 |   -0%˄ | (run time too short) |
 | 24b     ||   201.18 |   201.96 |   +0%˄ ||     4.97 |     4.95 |   -0%˄ | (run time too short) |
 | 25a     ||   100.56 |    99.70 |   -1%˄ ||     9.94 |    10.03 |   +1%˄ | (run time too short) |
 | 25b     ||    62.93 |    61.83 |   -2%˄ ||    15.89 |    16.17 |   +2%˄ | (run time too short) |
 | 25c     ||   234.34 |   233.63 |   -0%˄ ||     4.27 |     4.28 |   +0%˄ | (run time too short) |
 | 26a     ||   164.07 |   161.71 |   -1%˄ ||     6.09 |     6.18 |   +1%˄ | (run time too short) |
 | 26b     ||   133.98 |   132.23 |   -1%˄ ||     7.46 |     7.56 |   +1%˄ | (run time too short) |
 | 26c     ||   285.92 |   281.32 |   -2%˄ ||     3.50 |     3.55 |   +2%˄ | (run time too short) |
 | 27a     ||    88.07 |    87.28 |   -1%˄ ||    11.35 |    11.46 |   +1%˄ | (run time too short) |
 | 27b     ||    79.92 |    78.40 |   -2%˄ ||    12.51 |    12.76 |   +2%˄ | (run time too short) |
 | 27c     ||    94.63 |    94.92 |   +0%˄ ||    10.57 |    10.54 |   -0%˄ | (run time too short) |
 | 28a     ||   189.55 |   188.37 |   -1%˄ ||     5.28 |     5.31 |   +1%˄ | (run time too short) |
 | 28b     ||    56.77 |    55.97 |   -1%˄ ||    17.61 |    17.86 |   +1%˄ | (run time too short) |
 | 28c     ||   154.82 |   152.89 |   -1%˄ ||     6.46 |     6.54 |   +1%˄ | (run time too short) |
 | 29a     ||   173.28 |   173.65 |   +0%˄ ||     5.77 |     5.76 |   -0%˄ | (run time too short) |
 | 29b     ||   699.78 |   692.48 |   -1%˄ ||     1.43 |     1.44 |   +1%˄ | (run time too short) |
 | 29c     ||   209.43 |   210.37 |   +0%˄ ||     4.77 |     4.75 |   -0%˄ | (run time too short) |
 | 2a      ||    25.01 |    24.96 |   -0%˄ ||    39.98 |    40.06 |   +0%˄ | (run time too short) |
 | 2b      ||    23.31 |    23.06 |   -1%˄ ||    42.90 |    43.36 |   +1%˄ | (run time too short) |
 | 2c      ||    20.10 |    20.01 |   -0%˄ ||    49.75 |    49.97 |   +0%˄ | (run time too short) |
 | 2d      ||    45.32 |    44.85 |   -1%˄ ||    22.06 |    22.30 |   +1%˄ | (run time too short) |
 | 30a     ||    92.59 |    91.21 |   -1%˄ ||    10.80 |    10.96 |   +2%˄ | (run time too short) |
 | 30b     ||    95.90 |    95.08 |   -1%˄ ||    10.43 |    10.52 |   +1%˄ | (run time too short) |
 | 30c     ||   156.66 |   153.49 |   -2%˄ ||     6.38 |     6.52 |   +2%˄ | (run time too short) |
 | 31a     ||    80.16 |    79.24 |   -1%˄ ||    12.47 |    12.62 |   +1%˄ | (run time too short) |
 | 31b     ||    79.09 |    78.58 |   -1%˄ ||    12.64 |    12.72 |   +1%˄ | (run time too short) |
 | 31c     ||    91.49 |    90.25 |   -1%˄ ||    10.93 |    11.08 |   +1%˄ | (run time too short) |
 | 32a     ||    12.80 |    12.60 |   -2%˄ ||    78.09 |    79.36 |   +2%˄ | (run time too short) |
 | 32b     ||    27.88 |    27.20 |   -2%˄ ||    35.86 |    36.76 |   +3%˄ | (run time too short) |
 | 33a     ||    30.66 |    30.19 |   -2%˄ ||    32.62 |    33.12 |   +2%˄ | (run time too short) |
 | 33b     ||    20.22 |    20.05 |   -1%˄ ||    49.46 |    49.86 |   +1%˄ | (run time too short) |
 | 33c     ||    36.17 |    35.87 |   -1%˄ ||    27.64 |    27.87 |   +1%˄ | (run time too short) |
 | 3a      ||    54.81 |    54.11 |   -1%˄ ||    18.24 |    18.48 |   +1%˄ | (run time too short) |
 | 3b      ||    14.34 |    14.37 |   +0%˄ ||    69.73 |    69.60 |   -0%˄ | (run time too short) |
 | 3c      ||   210.40 |   207.96 |   -1%˄ ||     4.75 |     4.81 |   +1%˄ | (run time too short) |
 | 4a      ||   126.72 |   125.00 |   -1%˄ ||     7.89 |     8.00 |   +1%˄ | (run time too short) |
 | 4b      ||    13.72 |    13.59 |   -1%˄ ||    72.90 |    73.56 |   +1%˄ | (run time too short) |
 | 4c      ||   178.17 |   177.67 |   -0%˄ ||     5.61 |     5.63 |   +0%˄ | (run time too short) |
 | 5a      ||    39.41 |    39.07 |   -1%˄ ||    25.38 |    25.59 |   +1%˄ | (run time too short) |
 | 5b      ||    42.24 |    42.46 |   +1%˄ ||    23.67 |    23.55 |   -1%˄ | (run time too short) |
 | 5c      ||    81.08 |    80.89 |   -0%˄ ||    12.33 |    12.36 |   +0%˄ | (run time too short) |
 | 6a      ||   158.44 |   159.62 |   +1%˄ ||     6.31 |     6.26 |   -1%˄ | (run time too short) |
 | 6b      ||   167.40 |   168.27 |   +1%˄ ||     5.97 |     5.94 |   -1%˄ | (run time too short) |
 | 6c      ||   151.05 |   151.95 |   +1%˄ ||     6.62 |     6.58 |   -1%˄ | (run time too short) |
 | 6d      ||   364.63 |   372.15 |   +2%˄ ||     2.74 |     2.69 |   -2%˄ | (run time too short) |
 | 6e      ||   158.18 |   159.90 |   +1%˄ ||     6.32 |     6.25 |   -1%˄ | (run time too short) |
 | 6f      ||   640.53 |   641.25 |   +0%˄ ||     1.56 |     1.56 |   -0%˄ | (run time too short) |
 | 7a      ||    85.27 |    85.66 |   +0%˄ ||    11.73 |    11.67 |   -0%˄ | (run time too short) |
 | 7b      ||    79.58 |    79.81 |   +0%˄ ||    12.57 |    12.53 |   -0%˄ | (run time too short) |
 | 7c      ||   532.50 |   556.09 |   +4%˄ ||     1.88 |     1.80 |   -4%˄ | (run time too short) |
 | 8a      ||   170.62 |   171.93 |   +1%˄ ||     5.86 |     5.82 |   -1%˄ | (run time too short) |
 | 8b      ||   160.57 |   162.10 |   +1%˄ ||     6.23 |     6.17 |   -1%˄ | (run time too short) |
 | 8c      ||  1731.00 |  1731.20 |   +0%  ||     0.58 |     0.58 |   -0%  |               0.9680 |
 | 8d      ||   281.99 |   277.15 |   -2%˄ ||     3.55 |     3.61 |   +2%˄ | (run time too short) |
 | 9a      ||   238.03 |   237.12 |   -0%˄ ||     4.20 |     4.22 |   +0%˄ | (run time too short) |
 | 9b      ||   147.82 |   147.07 |   -1%˄ ||     6.77 |     6.80 |   +1%˄ | (run time too short) |
 | 9c      ||   265.68 |   265.48 |   -0%˄ ||     3.76 |     3.77 |   +0%˄ | (run time too short) |
 | 9d      ||   389.38 |   389.17 |   -0%˄ ||     2.57 |     2.57 |   +0%˄ | (run time too short) |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 | Sum     || 27504.93 | 27395.84 |   -0%  ||          |          |        |                      |
 | Geomean ||          |          |        ||          |          |   +1%  |                      |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 |   Notes || ˄ Execution stopped due to max runs reached                                         |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkJoinOrder - multi-threaded, ordered, 1 client, 28 cores**
<details>
<summary>
Sum of avg. item runtimes: +0%
 ||
Geometric mean of throughput changes: -0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+-----------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Daniel.Lindner/hyrise/clang17-release/benchmark_all_results/hyriseBenchmarkJoinOrder_2a56cc3c6d5b0997af199aa5383216af8f526cd1_mt_ordered.json | /home/Daniel.Lindner/hyrise/clang17-release/benchmark_all_results/hyriseBenchmarkJoinOrder_addc64949a58ea471405384b366401d7497a4870_mt_ordered.json |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 2a56cc3c6d5b0997af199aa5383216af8f526cd1-dirty                                                                                                      | addc64949a58ea471405384b366401d7497a4870-dirty                                                                                                      |
 |  benchmark_mode               | Ordered                                                                                                                                             | Ordered                                                                                                                                             |
 |  build_type                   | release                                                                                                                                             | release                                                                                                                                             |
 |  chunk_indexes                | False                                                                                                                                               | False                                                                                                                                               |
 |  chunk_size                   | 65535                                                                                                                                               | 65535                                                                                                                                               |
 |  clients                      | 1                                                                                                                                                   | 1                                                                                                                                                   |
 |  compiler                     | clang 17.0.6                                                                                                                                        | clang 17.0.6                                                                                                                                        |
 |  cores                        | 28                                                                                                                                                  | 28                                                                                                                                                  |
 |  data_preparation_cores       | 0                                                                                                                                                   | 0                                                                                                                                                   |
 |  date                         | 2025-02-02 03:14:56                                                                                                                                 | 2025-02-02 06:52:23                                                                                                                                 |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                             | {'default': {'encoding': 'Dictionary'}}                                                                                                             |
 |  max_duration                 | 60000000000                                                                                                                                         | 60000000000                                                                                                                                         |
 |  max_runs                     | 50                                                                                                                                                  | 50                                                                                                                                                  |
 |  time_unit                    | ns                                                                                                                                                  | ns                                                                                                                                                  |
 |  using_scheduler              | True                                                                                                                                                | True                                                                                                                                                |
 |  utilized_cores_per_numa_node | [0, 0, 28]                                                                                                                                          | [0, 0, 28]                                                                                                                                          |
 |  verify                       | False                                                                                                                                               | False                                                                                                                                               |
 |  warmup_duration              | 1000000000                                                                                                                                          | 1000000000                                                                                                                                          |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change |              p-value |
 |         ||      old |      new |        ||      old |      new |        |                      |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 | 10a     ||    42.38 |    42.96 |   +1%˄ ||    23.50 |    23.18 |   -1%˄ | (run time too short) |
 | 10b     ||    24.95 |    25.04 |   +0%˄ ||    39.82 |    39.69 |   -0%˄ | (run time too short) |
 | 10c     ||   136.41 |   135.97 |   -0%˄ ||     7.32 |     7.35 |   +0%˄ | (run time too short) |
 | 11a     ||    25.02 |    25.23 |   +1%˄ ||    39.81 |    39.46 |   -1%˄ | (run time too short) |
 | 11b     ||    24.03 |    23.72 |   -1%˄ ||    41.39 |    41.93 |   +1%˄ | (run time too short) |
-| 11c     ||    29.86 |    31.53 |   +6%˄ ||    33.32 |    31.54 |   -5%˄ | (run time too short) |
 | 11d     ||    32.67 |    33.32 |   +2%˄ ||    30.45 |    29.86 |   -2%˄ | (run time too short) |
 | 12a     ||    30.02 |    29.34 |   -2%˄ ||    33.11 |    33.91 |   +2%˄ | (run time too short) |
 | 12b     ||    19.52 |    19.54 |   +0%˄ ||    50.81 |    50.79 |   -0%˄ | (run time too short) |
 | 12c     ||    60.23 |    60.75 |   +1%˄ ||    16.55 |    16.41 |   -1%˄ | (run time too short) |
 | 13a     ||   135.17 |   134.50 |   -0%˄ ||     7.39 |     7.42 |   +0%˄ | (run time too short) |
 | 13b     ||    92.17 |    93.07 |   +1%˄ ||    10.83 |    10.73 |   -1%˄ | (run time too short) |
 | 13c     ||    24.61 |    24.52 |   -0%˄ ||    40.39 |    40.56 |   +0%˄ | (run time too short) |
 | 13d     ||   343.81 |   353.53 |   +3%˄ ||     2.91 |     2.83 |   -3%˄ | (run time too short) |
 | 14a     ||    59.75 |    59.67 |   -0%˄ ||    16.69 |    16.72 |   +0%˄ | (run time too short) |
 | 14b     ||    68.37 |    69.48 |   +2%˄ ||    14.60 |    14.37 |   -2%˄ | (run time too short) |
 | 14c     ||   177.65 |   181.35 |   +2%˄ ||     5.62 |     5.51 |   -2%˄ | (run time too short) |
 | 15a     ||    31.55 |    32.57 |   +3%˄ ||    31.56 |    30.58 |   -3%˄ | (run time too short) |
 | 15b     ||    27.62 |    26.97 |   -2%˄ ||    36.04 |    36.90 |   +2%˄ | (run time too short) |
 | 15c     ||    30.48 |    30.59 |   +0%˄ ||    32.62 |    32.52 |   -0%˄ | (run time too short) |
 | 15d     ||    33.24 |    33.96 |   +2%˄ ||    29.95 |    29.31 |   -2%˄ | (run time too short) |
 | 16a     ||   750.61 |   761.72 |   +1%˄ ||     1.33 |     1.31 |   -1%˄ | (run time too short) |
 | 16b     ||  1726.63 |  1725.42 |   -0%  ||     0.58 |     0.58 |   +0%  |               0.8976 |
 | 16c     ||   896.17 |   913.16 |   +2%˄ ||     1.12 |     1.09 |   -2%˄ | (run time too short) |
 | 16d     ||   866.15 |   879.36 |   +2%˄ ||     1.15 |     1.14 |   -1%˄ | (run time too short) |
 | 17a     ||   207.68 |   207.38 |   -0%˄ ||     4.81 |     4.82 |   +0%˄ | (run time too short) |
 | 17b     ||   177.37 |   178.34 |   +1%˄ ||     5.63 |     5.60 |   -1%˄ | (run time too short) |
 | 17c     ||   153.62 |   150.00 |   -2%˄ ||     6.50 |     6.66 |   +2%˄ | (run time too short) |
 | 17d     ||   148.13 |   145.61 |   -2%˄ ||     6.74 |     6.86 |   +2%˄ | (run time too short) |
 | 17e     ||   720.69 |   722.25 |   +0%˄ ||     1.39 |     1.38 |   -0%˄ | (run time too short) |
 | 17f     ||   315.29 |   314.37 |   -0%˄ ||     3.17 |     3.18 |   +0%˄ | (run time too short) |
 | 18a     ||    61.05 |    60.81 |   -0%˄ ||    16.34 |    16.40 |   +0%˄ | (run time too short) |
 | 18b     ||    58.93 |    60.90 |   +3%˄ ||    16.93 |    16.37 |   -3%˄ | (run time too short) |
 | 18c     ||   131.73 |   131.57 |   -0%˄ ||     7.58 |     7.59 |   +0%˄ | (run time too short) |
 | 19a     ||   113.79 |   111.76 |   -2%˄ ||     8.78 |     8.94 |   +2%˄ | (run time too short) |
 | 19b     ||    75.60 |    74.88 |   -1%˄ ||    13.21 |    13.34 |   +1%˄ | (run time too short) |
 | 19c     ||   124.84 |   122.93 |   -2%˄ ||     8.00 |     8.12 |   +2%˄ | (run time too short) |
 | 19d     ||   473.53 |   475.35 |   +0%˄ ||     2.11 |     2.10 |   -0%˄ | (run time too short) |
 | 1a      ||    10.41 |    10.45 |   +0%˄ ||    94.46 |    94.21 |   -0%˄ | (run time too short) |
 | 1b      ||     6.24 |     6.12 |   -2%˄ ||   156.38 |   159.24 |   +2%˄ | (run time too short) |
 | 1c      ||     6.00 |     6.01 |   +0%˄ ||   162.36 |   162.08 |   -0%˄ | (run time too short) |
 | 1d      ||     8.48 |     8.68 |   +2%˄ ||   115.98 |   113.06 |   -3%˄ | (run time too short) |
 | 20a     ||    83.83 |    84.16 |   +0%˄ ||    11.91 |    11.87 |   -0%˄ | (run time too short) |
 | 20b     ||    66.58 |    64.42 |   -3%˄ ||    15.00 |    15.50 |   +3%˄ | (run time too short) |
 | 20c     ||    79.42 |    79.43 |   +0%˄ ||    12.56 |    12.56 |   -0%˄ | (run time too short) |
 | 21a     ||    30.46 |    31.09 |   +2%˄ ||    32.69 |    32.00 |   -2%˄ | (run time too short) |
 | 21b     ||    27.76 |    27.69 |   -0%˄ ||    35.82 |    35.94 |   +0%˄ | (run time too short) |
 | 21c     ||    32.93 |    32.17 |   -2%˄ ||    30.20 |    30.94 |   +2%˄ | (run time too short) |
 | 22a     ||    64.15 |    65.03 |   +1%˄ ||    15.54 |    15.33 |   -1%˄ | (run time too short) |
 | 22b     ||    54.01 |    54.83 |   +2%˄ ||    18.48 |    18.21 |   -1%˄ | (run time too short) |
 | 22c     ||   130.78 |   130.96 |   +0%˄ ||     7.64 |     7.62 |   -0%˄ | (run time too short) |
 | 22d     ||   234.22 |   237.58 |   +1%˄ ||     4.27 |     4.21 |   -1%˄ | (run time too short) |
 | 23a     ||    22.41 |    22.83 |   +2%˄ ||    44.35 |    43.54 |   -2%˄ | (run time too short) |
 | 23b     ||    30.23 |    30.25 |   +0%˄ ||    32.92 |    32.91 |   -0%˄ | (run time too short) |
 | 23c     ||    24.63 |    24.81 |   +1%˄ ||    40.37 |    40.09 |   -1%˄ | (run time too short) |
 | 24a     ||    69.78 |    70.11 |   +0%˄ ||    14.31 |    14.23 |   -1%˄ | (run time too short) |
 | 24b     ||    57.93 |    57.85 |   -0%˄ ||    17.22 |    17.25 |   +0%˄ | (run time too short) |
 | 25a     ||    59.26 |    58.51 |   -1%˄ ||    16.83 |    17.04 |   +1%˄ | (run time too short) |
 | 25b     ||    37.93 |    37.50 |   -1%˄ ||    26.25 |    26.56 |   +1%˄ | (run time too short) |
 | 25c     ||   157.42 |   158.73 |   +1%˄ ||     6.35 |     6.29 |   -1%˄ | (run time too short) |
 | 26a     ||    83.49 |    83.15 |   -0%˄ ||    11.95 |    12.00 |   +0%˄ | (run time too short) |
 | 26b     ||    63.18 |    63.41 |   +0%˄ ||    15.79 |    15.73 |   -0%˄ | (run time too short) |
 | 26c     ||   138.74 |   138.67 |   -0%˄ ||     7.20 |     7.20 |   +0%˄ | (run time too short) |
 | 27a     ||    27.82 |    26.88 |   -3%˄ ||    35.77 |    37.06 |   +4%˄ | (run time too short) |
-| 27b     ||    26.48 |    27.72 |   +5%˄ ||    37.62 |    35.90 |   -5%˄ | (run time too short) |
 | 27c     ||    31.59 |    31.82 |   +1%˄ ||    31.53 |    31.27 |   -1%˄ | (run time too short) |
 | 28a     ||   143.71 |   144.96 |   +1%˄ ||     6.95 |     6.89 |   -1%˄ | (run time too short) |
-| 28b     ||    32.75 |    34.35 |   +5%˄ ||    30.43 |    28.99 |   -5%˄ | (run time too short) |
 | 28c     ||   115.17 |   114.37 |   -1%˄ ||     8.67 |     8.73 |   +1%˄ | (run time too short) |
 | 29a     ||    60.60 |    60.06 |   -1%˄ ||    16.47 |    16.62 |   +1%˄ | (run time too short) |
 | 29b     ||    97.15 |    99.38 |   +2%˄ ||    10.28 |    10.05 |   -2%˄ | (run time too short) |
 | 29c     ||    66.38 |    66.01 |   -1%˄ ||    15.02 |    15.11 |   +1%˄ | (run time too short) |
-| 2a      ||    26.04 |    31.64 |  +21%˄ ||    38.27 |    31.43 |  -18%˄ | (run time too short) |
+| 2b      ||    29.12 |    27.61 |   -5%˄ ||    34.13 |    36.02 |   +6%˄ | (run time too short) |
 | 2c      ||    21.73 |    21.99 |   +1%˄ ||    45.70 |    45.12 |   -1%˄ | (run time too short) |
 | 2d      ||    52.14 |    53.88 |   +3%˄ ||    19.11 |    18.50 |   -3%˄ | (run time too short) |
 | 30a     ||    53.86 |    52.64 |   -2%˄ ||    18.51 |    18.93 |   +2%˄ | (run time too short) |
 | 30b     ||    46.20 |    44.26 |   -4%˄ ||    21.58 |    22.52 |   +4%˄ | (run time too short) |
 | 30c     ||   111.13 |   111.66 |   +0%˄ ||     8.98 |     8.94 |   -0%˄ | (run time too short) |
 | 31a     ||    42.12 |    41.74 |   -1%˄ ||    23.65 |    23.87 |   +1%˄ | (run time too short) |
 | 31b     ||    37.34 |    37.21 |   -0%˄ ||    26.68 |    26.77 |   +0%˄ | (run time too short) |
 | 31c     ||    45.70 |    46.01 |   +1%˄ ||    21.80 |    21.67 |   -1%˄ | (run time too short) |
 | 32a     ||    10.99 |    11.06 |   +1%˄ ||    89.79 |    89.05 |   -1%˄ | (run time too short) |
 | 32b     ||    38.57 |    38.62 |   +0%˄ ||    25.81 |    25.77 |   -0%˄ | (run time too short) |
 | 33a     ||    15.72 |    16.02 |   +2%˄ ||    63.00 |    61.80 |   -2%˄ | (run time too short) |
 | 33b     ||    13.44 |    13.54 |   +1%˄ ||    73.52 |    72.91 |   -1%˄ | (run time too short) |
 | 33c     ||    23.41 |    23.98 |   +2%˄ ||    42.45 |    41.42 |   -2%˄ | (run time too short) |
 | 3a      ||    41.77 |    42.76 |   +2%˄ ||    23.85 |    23.29 |   -2%˄ | (run time too short) |
 | 3b      ||    10.46 |    10.45 |   -0%˄ ||    94.20 |    94.34 |   +0%˄ | (run time too short) |
 | 3c      ||    84.30 |    81.75 |   -3%˄ ||    11.84 |    12.20 |   +3%˄ | (run time too short) |
 | 4a      ||    72.17 |    71.73 |   -1%˄ ||    13.82 |    13.91 |   +1%˄ | (run time too short) |
 | 4b      ||     8.64 |     8.76 |   +1%˄ ||   113.70 |   112.15 |   -1%˄ | (run time too short) |
 | 4c      ||    91.60 |    92.62 |   +1%˄ ||    10.90 |    10.79 |   -1%˄ | (run time too short) |
 | 5a      ||    33.49 |    32.85 |   -2%˄ ||    29.72 |    30.32 |   +2%˄ | (run time too short) |
 | 5b      ||    25.19 |    25.49 |   +1%˄ ||    39.43 |    38.96 |   -1%˄ | (run time too short) |
 | 5c      ||    51.41 |    52.34 |   +2%˄ ||    19.39 |    19.05 |   -2%˄ | (run time too short) |
 | 6a      ||    30.41 |    30.55 |   +0%˄ ||    32.77 |    32.64 |   -0%˄ | (run time too short) |
 | 6b      ||    49.92 |    50.79 |   +2%˄ ||    20.00 |    19.65 |   -2%˄ | (run time too short) |
 | 6c      ||    28.35 |    27.97 |   -1%˄ ||    35.14 |    35.63 |   +1%˄ | (run time too short) |
 | 6d      ||   156.83 |   158.63 |   +1%˄ ||     6.37 |     6.30 |   -1%˄ | (run time too short) |
 | 6e      ||    30.59 |    30.82 |   +1%˄ ||    32.57 |    32.33 |   -1%˄ | (run time too short) |
 | 6f      ||   454.95 |   454.96 |   +0%˄ ||     2.20 |     2.20 |   -0%˄ | (run time too short) |
 | 7a      ||    35.93 |    35.60 |   -1%˄ ||    27.71 |    27.97 |   +1%˄ | (run time too short) |
 | 7b      ||    38.50 |    37.67 |   -2%˄ ||    25.87 |    26.44 |   +2%˄ | (run time too short) |
 | 7c      ||   321.13 |   323.73 |   +1%˄ ||     3.11 |     3.09 |   -1%˄ | (run time too short) |
 | 8a      ||    40.38 |    40.43 |   +0%˄ ||    24.67 |    24.66 |   -0%˄ | (run time too short) |
 | 8b      ||    37.72 |    37.88 |   +0%˄ ||    26.41 |    26.31 |   -0%˄ | (run time too short) |
 | 8c      ||  1119.11 |  1123.93 |   +0%˄ ||     0.89 |     0.89 |   -0%˄ | (run time too short) |
 | 8d      ||   228.49 |   229.94 |   +1%˄ ||     4.37 |     4.35 |   -1%˄ | (run time too short) |
 | 9a      ||   144.53 |   143.76 |   -1%˄ ||     6.91 |     6.95 |   +1%˄ | (run time too short) |
 | 9b      ||    85.75 |    84.49 |   -1%˄ ||    11.64 |    11.82 |   +2%˄ | (run time too short) |
 | 9c      ||   140.41 |   139.14 |   -1%˄ ||     7.11 |     7.18 |   +1%˄ | (run time too short) |
 | 9d      ||   318.49 |   318.03 |   -0%˄ ||     3.14 |     3.14 |   +0%˄ | (run time too short) |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 | Sum     || 14881.27 | 14952.33 |   +0%  ||          |          |        |                      |
 | Geomean ||          |          |        ||          |          |   -0%  |                      |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 |   Notes || ˄ Execution stopped due to max runs reached                                         |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkJoinOrder - multi-threaded, shuffled, 28 clients, 28 cores**
<details>
<summary>
Sum of avg. item runtimes: +0%
 ||
Geometric mean of throughput changes: -0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Daniel.Lindner/hyrise/clang17-release/benchmark_all_results/hyriseBenchmarkJoinOrder_2a56cc3c6d5b0997af199aa5383216af8f526cd1_mt.json | /home/Daniel.Lindner/hyrise/clang17-release/benchmark_all_results/hyriseBenchmarkJoinOrder_addc64949a58ea471405384b366401d7497a4870_mt.json |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 2a56cc3c6d5b0997af199aa5383216af8f526cd1-dirty                                                                                              | addc64949a58ea471405384b366401d7497a4870-dirty                                                                                              |
 |  benchmark_mode               | Shuffled                                                                                                                                    | Shuffled                                                                                                                                    |
 |  build_type                   | release                                                                                                                                     | release                                                                                                                                     |
 |  chunk_indexes                | False                                                                                                                                       | False                                                                                                                                       |
 |  chunk_size                   | 65535                                                                                                                                       | 65535                                                                                                                                       |
 |  clients                      | 28                                                                                                                                          | 28                                                                                                                                          |
 |  compiler                     | clang 17.0.6                                                                                                                                | clang 17.0.6                                                                                                                                |
 |  cores                        | 28                                                                                                                                          | 28                                                                                                                                          |
 |  data_preparation_cores       | 0                                                                                                                                           | 0                                                                                                                                           |
 |  date                         | 2025-02-02 03:29:50                                                                                                                         | 2025-02-02 07:07:22                                                                                                                         |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     |
 |  max_duration                 | 1200000000000                                                                                                                               | 1200000000000                                                                                                                               |
 |  max_runs                     | -1                                                                                                                                          | -1                                                                                                                                          |
 |  time_unit                    | ns                                                                                                                                          | ns                                                                                                                                          |
 |  using_scheduler              | True                                                                                                                                        | True                                                                                                                                        |
 |  utilized_cores_per_numa_node | [0, 0, 28]                                                                                                                                  | [0, 0, 28]                                                                                                                                  |
 |  verify                       | False                                                                                                                                       | False                                                                                                                                       |
 |  warmup_duration              | 0                                                                                                                                           | 0                                                                                                                                           |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |      new |        ||      old |      new |        |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
-| 10a     ||   170.88 |   181.81 |   +6%  ||     0.64 |     0.64 |   -0%  |  0.5609 |
 | 10b     ||   148.92 |   150.06 |   +1%  ||     0.64 |     0.64 |   -0%  |  0.9606 |
 | 10c     ||   475.49 |   463.50 |   -3%  ||     0.64 |     0.64 |   -0%  |  0.7021 |
+| 11a     ||   100.54 |    89.79 |  -11%  ||     0.64 |     0.64 |   -0%  |  0.4198 |
-| 11b     ||   102.24 |   111.14 |   +9%  ||     0.64 |     0.64 |   -0%  |  0.5957 |
 | 11c     ||   135.27 |   132.07 |   -2%  ||     0.64 |     0.64 |   -0%  |  0.8828 |
-| 11d     ||    87.12 |    92.77 |   +6%  ||     0.64 |     0.64 |   -0%  |  0.6850 |
+| 12a     ||   145.57 |   136.16 |   -6%  ||     0.64 |     0.64 |   -0%  |  0.6151 |
-| 12b     ||    69.93 |    98.36 |  +41%  ||     0.64 |     0.64 |   -0%  |  0.0719 |
+| 12c     ||   352.72 |   298.87 |  -15%  ||     0.64 |     0.64 |   -0%  |  0.0872 |
-| 13a     ||   370.80 |   390.02 |   +5%  ||     0.64 |     0.64 |   -0%  |  0.5073 |
 | 13b     ||   276.24 |   269.15 |   -3%  ||     0.64 |     0.64 |   -0%  |  0.7384 |
+| 13c     ||   104.95 |    80.69 |  -23%  ||     0.64 |     0.64 |   -0%  |  0.1448 |
+| 13d     ||   793.45 |   744.13 |   -6%  ||     0.64 |     0.64 |   -0%  |  0.1874 |
-| 14a     ||   300.13 |   339.26 |  +13%  ||     0.64 |     0.64 |   -0%  |  0.1782 |
-| 14b     ||   327.54 |   364.70 |  +11%  ||     0.64 |     0.64 |   -0%  |  0.2172 |
+| 14c     ||   491.71 |   444.64 |  -10%  ||     0.64 |     0.64 |   -0%  |  0.1458 |
-| 15a     ||    82.95 |   106.22 |  +28%  ||     0.64 |     0.64 |   -0%  |  0.0522 |
-| 15b     ||   119.33 |   144.62 |  +21%  ||     0.64 |     0.64 |   -0%  |  0.2849 |
-| 15c     ||   117.44 |   124.85 |   +6%  ||     0.64 |     0.64 |   -0%  |  0.6741 |
-| 15d     ||   116.91 |   160.80 |  +38%  ||     0.64 |     0.64 |   -0%  |  0.0084 |
 | 16a     ||  1387.60 |  1420.52 |   +2%  ||     0.64 |     0.64 |   -0%  |  0.5179 |
 | 16b     ||  2647.00 |  2583.85 |   -2%  ||     0.64 |     0.64 |   -0%  |  0.1798 |
 | 16c     ||  1610.74 |  1593.63 |   -1%  ||     0.64 |     0.64 |   -0%  |  0.7358 |
 | 16d     ||  1529.00 |  1483.12 |   -3%  ||     0.64 |     0.64 |   -0%  |  0.3334 |
 | 17a     ||   746.20 |   729.73 |   -2%  ||     0.64 |     0.64 |   -0%  |  0.7036 |
+| 17b     ||   594.04 |   550.05 |   -7%  ||     0.64 |     0.64 |   -0%  |  0.2384 |
 | 17c     ||   507.88 |   514.08 |   +1%  ||     0.64 |     0.64 |   -0%  |  0.8636 |
 | 17d     ||   536.54 |   540.99 |   +1%  ||     0.64 |     0.64 |   -0%  |  0.8991 |
 | 17e     ||  1397.34 |  1420.08 |   +2%  ||     0.64 |     0.64 |   -0%  |  0.6341 |
 | 17f     ||   983.83 |  1002.30 |   +2%  ||     0.64 |     0.64 |   -0%  |  0.6918 |
-| 18a     ||   243.78 |   269.07 |  +10%  ||     0.64 |     0.64 |   -0%  |  0.3813 |
-| 18b     ||   311.52 |   342.54 |  +10%  ||     0.64 |     0.64 |   -0%  |  0.3301 |
+| 18c     ||   603.66 |   527.22 |  -13%  ||     0.64 |     0.64 |   -0%  |  0.0566 |
 | 19a     ||   501.06 |   519.44 |   +4%  ||     0.64 |     0.64 |   -0%  |  0.6283 |
-| 19b     ||   325.32 |   360.35 |  +11%  ||     0.64 |     0.64 |   -0%  |  0.2238 |
 | 19c     ||   526.57 |   542.03 |   +3%  ||     0.64 |     0.64 |   -0%  |  0.6652 |
 | 19d     ||  1182.21 |  1203.95 |   +2%  ||     0.64 |     0.64 |   -0%  |  0.6286 |
-| 1a      ||    35.00 |    56.86 |  +62%  ||     0.64 |     0.64 |   -0%  |  0.0441 |
+| 1b      ||    56.72 |    38.81 |  -32%  ||     0.64 |     0.64 |   -0%  |  0.0698 |
+| 1c      ||    52.83 |    41.34 |  -22%  ||     0.64 |     0.64 |   -0%  |  0.3596 |
-| 1d      ||    34.96 |    37.06 |   +6%  ||     0.64 |     0.64 |   -0%  |  0.7876 |
 | 20a     ||   406.84 |   408.31 |   +0%  ||     0.64 |     0.64 |   -0%  |  0.9637 |
-| 20b     ||   316.35 |   343.04 |   +8%  ||     0.64 |     0.64 |   -0%  |  0.3739 |
-| 20c     ||   262.98 |   339.85 |  +29%  ||     0.64 |     0.64 |   -0%  |  0.0015 |
 | 21a     ||   159.39 |   160.54 |   +1%  ||     0.64 |     0.64 |   -0%  |  0.9623 |
 | 21b     ||   150.00 |   152.39 |   +2%  ||     0.64 |     0.64 |   -0%  |  0.9281 |
-| 21c     ||   139.35 |   156.58 |  +12%  ||     0.64 |     0.64 |   -0%  |  0.3631 |
 | 22a     ||   380.88 |   385.78 |   +1%  ||     0.64 |     0.64 |   -0%  |  0.8730 |
 | 22b     ||   326.97 |   318.11 |   -3%  ||     0.64 |     0.64 |   -0%  |  0.7627 |
 | 22c     ||   514.06 |   535.20 |   +4%  ||     0.64 |     0.64 |   -0%  |  0.5685 |
-| 22d     ||   680.21 |   727.48 |   +7%  ||     0.64 |     0.64 |   -0%  |  0.2614 |
 | 23a     ||   164.84 |   158.21 |   -4%  ||     0.64 |     0.64 |   -0%  |  0.7555 |
-| 23b     ||   100.28 |   109.70 |   +9%  ||     0.64 |     0.64 |   -0%  |  0.4892 |
+| 23c     ||   183.64 |   158.60 |  -14%  ||     0.64 |     0.64 |   -0%  |  0.2732 |
 | 24a     ||   355.93 |   366.61 |   +3%  ||     0.64 |     0.64 |   -0%  |  0.7354 |
-| 24b     ||   251.81 |   326.30 |  +30%  ||     0.64 |     0.64 |   -0%  |  0.0228 |
 | 25a     ||   326.86 |   334.17 |   +2%  ||     0.64 |     0.64 |   -0%  |  0.7976 |
-| 25b     ||   190.89 |   216.29 |  +13%  ||     0.64 |     0.64 |   -0%  |  0.3474 |
 | 25c     ||   740.36 |   718.72 |   -3%  ||     0.64 |     0.64 |   -0%  |  0.6440 |
+| 26a     ||   363.73 |   327.22 |  -10%  ||     0.64 |     0.64 |   -0%  |  0.1921 |
-| 26b     ||   240.54 |   255.54 |   +6%  ||     0.64 |     0.64 |   -0%  |  0.5887 |
+| 26c     ||   506.52 |   469.25 |   -7%  ||     0.64 |     0.64 |   -0%  |  0.2166 |
+| 27a     ||   178.98 |   168.01 |   -6%  ||     0.64 |     0.64 |   -0%  |  0.6370 |
-| 27b     ||   128.98 |   145.37 |  +13%  ||     0.64 |     0.64 |   -0%  |  0.3953 |
 | 27c     ||   165.41 |   163.65 |   -1%  ||     0.64 |     0.64 |   -0%  |  0.9275 |
-| 28a     ||   488.48 |   533.90 |   +9%  ||     0.64 |     0.64 |   -0%  |  0.1555 |
+| 28b     ||   225.68 |   201.64 |  -11%  ||     0.64 |     0.64 |   -0%  |  0.3416 |
-| 28c     ||   505.11 |   543.93 |   +8%  ||     0.64 |     0.64 |   -0%  |  0.3485 |
+| 29a     ||   276.43 |   262.84 |   -5%  ||     0.64 |     0.64 |   -0%  |  0.6282 |
 | 29b     ||   343.05 |   348.65 |   +2%  ||     0.64 |     0.64 |   -0%  |  0.8610 |
+| 29c     ||   347.75 |   330.86 |   -5%  ||     0.64 |     0.64 |   -0%  |  0.5840 |
+| 2a      ||   125.94 |   119.91 |   -5%  ||     0.64 |     0.64 |   -0%  |  0.7247 |
 | 2b      ||   108.46 |   109.65 |   +1%  ||     0.64 |     0.64 |   -0%  |  0.9401 |
-| 2c      ||    75.84 |    79.66 |   +5%  ||     0.64 |     0.64 |   -0%  |  0.7424 |
+| 2d      ||   195.20 |   181.83 |   -7%  ||     0.64 |     0.64 |   -0%  |  0.5213 |
-| 30a     ||   312.63 |   361.47 |  +16%  ||     0.64 |     0.64 |   -0%  |  0.1790 |
+| 30b     ||   310.10 |   268.82 |  -13%  ||     0.64 |     0.64 |   -0%  |  0.1579 |
+| 30c     ||   586.43 |   539.45 |   -8%  ||     0.64 |     0.64 |   -0%  |  0.2220 |
 | 31a     ||   241.37 |   251.27 |   +4%  ||     0.64 |     0.64 |   -0%  |  0.7144 |
 | 31b     ||   226.88 |   222.41 |   -2%  ||     0.64 |     0.64 |   -0%  |  0.8761 |
 | 31c     ||   263.90 |   273.93 |   +4%  ||     0.64 |     0.64 |   -0%  |  0.7084 |
+| 32a     ||    56.87 |    42.00 |  -26%  ||     0.64 |     0.64 |   -0%  |  0.1985 |
+| 32b     ||   151.77 |   144.78 |   -5%  ||     0.64 |     0.64 |   -0%  |  0.7096 |
-| 33a     ||   113.31 |   123.89 |   +9%  ||     0.64 |     0.64 |   -0%  |  0.5622 |
+| 33b     ||   107.31 |    96.15 |  -10%  ||     0.64 |     0.64 |   -0%  |  0.5643 |
-| 33c     ||   152.95 |   172.46 |  +13%  ||     0.64 |     0.64 |   -0%  |  0.4261 |
 | 3a      ||   235.79 |   226.80 |   -4%  ||     0.64 |     0.64 |   -0%  |  0.7616 |
+| 3b      ||    68.09 |    61.17 |  -10%  ||     0.64 |     0.64 |   -0%  |  0.6066 |
 | 3c      ||   330.10 |   344.06 |   +4%  ||     0.64 |     0.64 |   -0%  |  0.6499 |
 | 4a      ||   225.84 |   226.76 |   +0%  ||     0.64 |     0.64 |   -0%  |  0.9679 |
+| 4b      ||    76.24 |    53.21 |  -30%  ||     0.64 |     0.64 |   -0%  |  0.1245 |
-| 4c      ||   267.03 |   289.99 |   +9%  ||     0.64 |     0.64 |   -0%  |  0.4103 |
-| 5a      ||   208.99 |   222.32 |   +6%  ||     0.64 |     0.64 |   -0%  |  0.6432 |
 | 5b      ||   133.93 |   135.88 |   +1%  ||     0.64 |     0.64 |   -0%  |  0.9206 |
 | 5c      ||   276.39 |   279.48 |   +1%  ||     0.64 |     0.64 |   -0%  |  0.9217 |
+| 6a      ||   150.05 |   112.48 |  -25%  ||     0.64 |     0.64 |   -0%  |  0.0255 |
-| 6b      ||   178.04 |   186.76 |   +5%  ||     0.64 |     0.64 |   -0%  |  0.7102 |
 | 6c      ||   123.61 |   124.13 |   +0%  ||     0.64 |     0.64 |   -0%  |  0.9752 |
+| 6d      ||   528.96 |   455.19 |  -14%  ||     0.64 |     0.64 |   -0%  |  0.0352 |
 | 6e      ||   116.08 |   111.29 |   -4%  ||     0.64 |     0.64 |   -0%  |  0.7685 |
 | 6f      ||   997.70 |  1036.11 |   +4%  ||     0.64 |     0.64 |   -0%  |  0.3587 |
 | 7a      ||   177.22 |   179.82 |   +1%  ||     0.64 |     0.64 |   -0%  |  0.9244 |
 | 7b      ||   133.34 |   138.73 |   +4%  ||     0.64 |     0.64 |   -0%  |  0.7461 |
 | 7c      ||   921.53 |   909.10 |   -1%  ||     0.64 |     0.64 |   -0%  |  0.7532 |
-| 8a      ||   184.99 |   219.04 |  +18%  ||     0.64 |     0.64 |   -0%  |  0.1592 |
+| 8b      ||   170.50 |   126.43 |  -26%  ||     0.64 |     0.64 |   -0%  |  0.0519 |
 | 8c      ||  1956.72 |  1917.34 |   -2%  ||     0.64 |     0.64 |   -0%  |  0.4350 |
 | 8d      ||   560.59 |   549.38 |   -2%  ||     0.64 |     0.64 |   -0%  |  0.7304 |
-| 9a      ||   551.15 |   602.25 |   +9%  ||     0.64 |     0.64 |   -0%  |  0.2021 |
-| 9b      ||   366.98 |   413.64 |  +13%  ||     0.64 |     0.64 |   -0%  |  0.1274 |
 | 9c      ||   608.39 |   593.84 |   -2%  ||     0.64 |     0.64 |   -0%  |  0.7417 |
 | 9d      ||   924.06 |   923.31 |   -0%  ||     0.64 |     0.64 |   -0%  |  0.9861 |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Sum     || 43627.51 | 43793.51 |   +0%  ||          |          |        |         |
 | Geomean ||          |          |        ||          |          |   -0%  |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkStarSchema - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -0%
 ||
Geometric mean of throughput changes: -1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---+----------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter               | /home/Daniel.Lindner/hyrise/clang17-release/benchmark_all_results/hyriseBenchmarkStarSchema_2a56cc3c6d5b0997af199aa5383216af8f526cd1_st.json | /home/Daniel.Lindner/hyrise/clang17-release/benchmark_all_results/hyriseBenchmarkStarSchema_addc64949a58ea471405384b366401d7497a4870_st.json |
 +-------------------------+----------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH               | 2a56cc3c6d5b0997af199aa5383216af8f526cd1-dirty                                                                                               | addc64949a58ea471405384b366401d7497a4870-dirty                                                                                               |
 |  benchmark_mode         | Ordered                                                                                                                                      | Ordered                                                                                                                                      |
 |  build_type             | release                                                                                                                                      | release                                                                                                                                      |
 |  chunk_indexes          | False                                                                                                                                        | False                                                                                                                                        |
 |  chunk_size             | 65535                                                                                                                                        | 65535                                                                                                                                        |
 |  clients                | 1                                                                                                                                            | 1                                                                                                                                            |
 |  compiler               | clang 17.0.6                                                                                                                                 | clang 17.0.6                                                                                                                                 |
 |  cores                  | 0                                                                                                                                            | 0                                                                                                                                            |
 |  data_preparation_cores | 0                                                                                                                                            | 0                                                                                                                                            |
 |  date                   | 2025-02-02 03:50:16                                                                                                                          | 2025-02-02 07:27:47                                                                                                                          |
 |  encoding               | {'default': {'encoding': 'Dictionary'}}                                                                                                      | {'default': {'encoding': 'Dictionary'}}                                                                                                      |
 |  max_duration           | 60000000000                                                                                                                                  | 60000000000                                                                                                                                  |
 |  max_runs               | 50                                                                                                                                           | 50                                                                                                                                           |
 |  scale_factor           | 10.0                                                                                                                                         | 10.0                                                                                                                                         |
 |  time_unit              | ns                                                                                                                                           | ns                                                                                                                                           |
 |  using_scheduler        | False                                                                                                                                        | False                                                                                                                                        |
 |  verify                 | False                                                                                                                                        | False                                                                                                                                        |
 |  warmup_duration        | 1000000000                                                                                                                                   | 1000000000                                                                                                                                   |
 +-------------------------+----------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |         ||      old |     new |        ||      old |      new |        |                      |
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
 | 1.1     ||   299.19 |  295.88 |   -1%˄ ||     3.34 |     3.38 |   +1%˄ | (run time too short) |
+| 1.2     ||   157.10 |  149.67 |   -5%˄ ||     6.37 |     6.68 |   +5%˄ | (run time too short) |
-| 1.3     ||   145.88 |  156.81 |   +7%˄ ||     6.85 |     6.38 |   -7%˄ | (run time too short) |
 | 2.1     ||   504.39 |  516.79 |   +2%˄ ||     1.98 |     1.94 |   -2%˄ | (run time too short) |
 | 2.2     ||   276.63 |  278.23 |   +1%˄ ||     3.61 |     3.59 |   -1%˄ | (run time too short) |
 | 2.3     ||   188.47 |  189.55 |   +1%˄ ||     5.31 |     5.28 |   -1%˄ | (run time too short) |
 | 3.1     ||  2685.96 | 2620.02 |   -2%  ||     0.37 |     0.38 |   +3%  |               0.0603 |
 | 3.2     ||   247.10 |  253.92 |   +3%˄ ||     4.05 |     3.94 |   -3%˄ | (run time too short) |
 | 3.3     ||   110.96 |  113.77 |   +3%˄ ||     9.01 |     8.79 |   -2%˄ | (run time too short) |
 | 3.4     ||   105.08 |  106.92 |   +2%˄ ||     9.52 |     9.35 |   -2%˄ | (run time too short) |
 | 4.1     ||  2542.95 | 2594.92 |   +2%  ||     0.39 |     0.39 |   -2%  |               0.0690 |
 | 4.2     ||   758.72 |  732.84 |   -3%˄ ||     1.32 |     1.36 |   +4%˄ | (run time too short) |
 | 4.3     ||   212.16 |  210.62 |   -1%˄ ||     4.71 |     4.75 |   +1%˄ | (run time too short) |
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
 | Sum     ||  8234.59 | 8219.94 |   -0%  ||          |          |        |                      |
 | Geomean ||          |         |        ||          |          |   -1%  |                      |
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
 |   Notes || ˄ Execution stopped due to max runs reached                                        |
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkStarSchema - multi-threaded, ordered, 1 client, 28 cores**
<details>
<summary>
Sum of avg. item runtimes: -0%
 ||
Geometric mean of throughput changes: +1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Daniel.Lindner/hyrise/clang17-release/benchmark_all_results/hyriseBenchmarkStarSchema_2a56cc3c6d5b0997af199aa5383216af8f526cd1_mt_ordered.json | /home/Daniel.Lindner/hyrise/clang17-release/benchmark_all_results/hyriseBenchmarkStarSchema_addc64949a58ea471405384b366401d7497a4870_mt_ordered.json |
 +-------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 2a56cc3c6d5b0997af199aa5383216af8f526cd1-dirty                                                                                                       | addc64949a58ea471405384b366401d7497a4870-dirty                                                                                                       |
 |  benchmark_mode               | Ordered                                                                                                                                              | Ordered                                                                                                                                              |
 |  build_type                   | release                                                                                                                                              | release                                                                                                                                              |
 |  chunk_indexes                | False                                                                                                                                                | False                                                                                                                                                |
 |  chunk_size                   | 65535                                                                                                                                                | 65535                                                                                                                                                |
 |  clients                      | 1                                                                                                                                                    | 1                                                                                                                                                    |
 |  compiler                     | clang 17.0.6                                                                                                                                         | clang 17.0.6                                                                                                                                         |
 |  cores                        | 28                                                                                                                                                   | 28                                                                                                                                                   |
 |  data_preparation_cores       | 0                                                                                                                                                    | 0                                                                                                                                                    |
 |  date                         | 2025-02-02 03:55:29                                                                                                                                  | 2025-02-02 07:32:59                                                                                                                                  |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                              | {'default': {'encoding': 'Dictionary'}}                                                                                                              |
 |  max_duration                 | 60000000000                                                                                                                                          | 60000000000                                                                                                                                          |
 |  max_runs                     | 50                                                                                                                                                   | 50                                                                                                                                                   |
 |  scale_factor                 | 10.0                                                                                                                                                 | 10.0                                                                                                                                                 |
 |  time_unit                    | ns                                                                                                                                                   | ns                                                                                                                                                   |
 |  using_scheduler              | True                                                                                                                                                 | True                                                                                                                                                 |
 |  utilized_cores_per_numa_node | [0, 0, 28]                                                                                                                                           | [0, 0, 28]                                                                                                                                           |
 |  verify                       | False                                                                                                                                                | False                                                                                                                                                |
 |  warmup_duration              | 1000000000                                                                                                                                           | 1000000000                                                                                                                                           |
 +-------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |         ||      old |     new |        ||      old |      new |        |                      |
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
 | 1.1     ||   110.17 |  111.43 |   +1%˄ ||     9.06 |     8.96 |   -1%˄ | (run time too short) |
 | 1.2     ||    82.97 |   83.03 |   +0%˄ ||    12.02 |    12.02 |   -0%˄ | (run time too short) |
 | 1.3     ||    81.24 |   80.53 |   -1%˄ ||    12.29 |    12.39 |   +1%˄ | (run time too short) |
 | 2.1     ||   336.95 |  335.88 |   -0%˄ ||     2.97 |     2.98 |   +0%˄ | (run time too short) |
 | 2.2     ||   165.57 |  164.14 |   -1%˄ ||     6.03 |     6.09 |   +1%˄ | (run time too short) |
 | 2.3     ||    57.66 |   56.34 |   -2%˄ ||    17.29 |    17.72 |   +2%˄ | (run time too short) |
 | 3.1     ||   814.51 |  811.84 |   -0%˄ ||     1.23 |     1.23 |   +0%˄ | (run time too short) |
 | 3.2     ||   157.22 |  156.04 |   -1%˄ ||     6.35 |     6.40 |   +1%˄ | (run time too short) |
 | 3.3     ||    82.35 |   83.33 |   +1%˄ ||    12.12 |    11.98 |   -1%˄ | (run time too short) |
+| 3.4     ||    89.82 |   85.49 |   -5%˄ ||    11.11 |    11.67 |   +5%˄ | (run time too short) |
 | 4.1     ||   669.36 |  671.58 |   +0%˄ ||     1.49 |     1.49 |   -0%˄ | (run time too short) |
 | 4.2     ||   387.61 |  386.95 |   -0%˄ ||     2.58 |     2.58 |   +0%˄ | (run time too short) |
 | 4.3     ||   116.50 |  116.11 |   -0%˄ ||     8.57 |     8.60 |   +0%˄ | (run time too short) |
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
 | Sum     ||  3151.93 | 3142.69 |   -0%  ||          |          |        |                      |
 | Geomean ||          |         |        ||          |          |   +1%  |                      |
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
 |   Notes || ˄ Execution stopped due to max runs reached                                        |
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkStarSchema - multi-threaded, shuffled, 28 clients, 28 cores**
<details>
<summary>
Sum of avg. item runtimes: +0%
 ||
Geometric mean of throughput changes: -0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+----------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Daniel.Lindner/hyrise/clang17-release/benchmark_all_results/hyriseBenchmarkStarSchema_2a56cc3c6d5b0997af199aa5383216af8f526cd1_mt.json | /home/Daniel.Lindner/hyrise/clang17-release/benchmark_all_results/hyriseBenchmarkStarSchema_addc64949a58ea471405384b366401d7497a4870_mt.json |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 2a56cc3c6d5b0997af199aa5383216af8f526cd1-dirty                                                                                               | addc64949a58ea471405384b366401d7497a4870-dirty                                                                                               |
 |  benchmark_mode               | Shuffled                                                                                                                                     | Shuffled                                                                                                                                     |
 |  build_type                   | release                                                                                                                                      | release                                                                                                                                      |
 |  chunk_indexes                | False                                                                                                                                        | False                                                                                                                                        |
 |  chunk_size                   | 65535                                                                                                                                        | 65535                                                                                                                                        |
 |  clients                      | 28                                                                                                                                           | 28                                                                                                                                           |
 |  compiler                     | clang 17.0.6                                                                                                                                 | clang 17.0.6                                                                                                                                 |
 |  cores                        | 28                                                                                                                                           | 28                                                                                                                                           |
 |  data_preparation_cores       | 0                                                                                                                                            | 0                                                                                                                                            |
 |  date                         | 2025-02-02 03:58:42                                                                                                                          | 2025-02-02 07:36:19                                                                                                                          |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                      | {'default': {'encoding': 'Dictionary'}}                                                                                                      |
 |  max_duration                 | 1200000000000                                                                                                                                | 1200000000000                                                                                                                                |
 |  max_runs                     | -1                                                                                                                                           | -1                                                                                                                                           |
 |  scale_factor                 | 10.0                                                                                                                                         | 10.0                                                                                                                                         |
 |  time_unit                    | ns                                                                                                                                           | ns                                                                                                                                           |
 |  using_scheduler              | True                                                                                                                                         | True                                                                                                                                         |
 |  utilized_cores_per_numa_node | [0, 0, 28]                                                                                                                                   | [0, 0, 28]                                                                                                                                   |
 |  verify                       | False                                                                                                                                        | False                                                                                                                                        |
 |  warmup_duration              | 0                                                                                                                                            | 0                                                                                                                                            |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |      new |        ||      old |      new |        |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | 1.1     ||   616.67 |   609.34 |   -1%  ||     2.28 |     2.28 |   -0%  |  0.7462 |
-| 1.2     ||   345.30 |   361.62 |   +5%  ||     2.28 |     2.28 |   -0%  |  0.3199 |
 | 1.3     ||   327.29 |   331.64 |   +1%  ||     2.28 |     2.28 |   -0%  |  0.7692 |
 | 2.1     ||  1509.28 |  1459.27 |   -3%  ||     2.28 |     2.28 |   -0%  |  0.1202 |
 | 2.2     ||   785.09 |   808.59 |   +3%  ||     2.28 |     2.28 |   +0%  |  0.3403 |
 | 2.3     ||   291.87 |   286.16 |   -2%  ||     2.28 |     2.28 |   -0%  |  0.6783 |
 | 3.1     ||  2354.05 |  2357.10 |   +0%  ||     2.28 |     2.28 |   +0%  |  0.9306 |
 | 3.2     ||   751.91 |   739.02 |   -2%  ||     2.28 |     2.28 |   +0%  |  0.5783 |
 | 3.3     ||   371.04 |   386.48 |   +4%  ||     2.28 |     2.28 |   +0%  |  0.4216 |
 | 3.4     ||   366.27 |   373.73 |   +2%  ||     2.28 |     2.28 |   -0%  |  0.6776 |
 | 4.1     ||  2156.39 |  2162.30 |   +0%  ||     2.28 |     2.28 |   -0%  |  0.8691 |
 | 4.2     ||  1804.00 |  1831.88 |   +2%  ||     2.28 |     2.28 |   -0%  |  0.4657 |
 | 4.3     ||   564.54 |   551.94 |   -2%  ||     2.28 |     2.28 |   +0%  |  0.5308 |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Sum     || 12243.70 | 12259.07 |   +0%  ||          |          |        |         |
 | Geomean ||          |          |        ||          |          |   -0%  |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
```
</details>