### PR TITLE
Remove llvm-symbolizer from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,6 @@ RUN apt-get update \
         valgrind \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-    && ln -sf /usr/bin/llvm-symbolizer-14 /usr/bin/llvm-symbolizer \
     && pip3 install --break-system-packages scipy pandas matplotlib  # preload large Python packages (installs numpy
                                                                      # and others).
 


### PR DESCRIPTION
Removing setting a soft link for the llvm symbolizer (added with #953) in the Dockerfile.