### PR TITLE
Fix `install_dependencies.sh`

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -49,8 +49,8 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
         if [ -f /etc/lsb-release ] && cat /etc/lsb-release | grep DISTRIB_ID | grep Ubuntu >/dev/null; then
             echo "Installing dependencies (this may take a while)..."
             if sudo apt-get update >/dev/null; then
+            
                 # Packages added here should also be added to the Dockerfile
-
                 if ! sudo apt-get install --no-install-recommends -y software-properties-common lsb-release git python3 python3-pip autoconf bash-completion bc clang-16 clang-17 clang-format-17 clang-tidy-17 cmake curl dos2unix g++-14 gcc-14 graphviz libboost-all-dev libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld-17 man parallel postgresql-server-dev-all valgrind; then
                     echo "Error during apt-get installations."
                     exit 1

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -56,7 +56,7 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
 
                 # Packages added here should also be added to the Dockerfile
                 sudo apt-get install --no-install-recommends -y python3 python3-pip
-                sudo apt-get install --no-install-recommends -y autoconf bash-completion bc clang-16 clang-17 clang-format-17 clang-tidy-17 cmake curl dos2unix g++-14 gcc-14 git graphviz libboost-all-dev libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld-17 man parallel postgresql-server-dev-all valgrind
+                sudo apt-get install --no-install-recommends -y autoconf bash-completion bc clang-16 clang-17 clang-format-17 clang-tidy-17 cmake curl dos2unix g++-14 gcc-14 git graphviz libboost-all-dev libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld-17 man parallel postgresql-server-dev-all valgrind &
 
                 if ! git submodule update --jobs 5 --init --recursive; then
                     echo "Error during git fetching submodules."

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -52,7 +52,7 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
                 sudo apt-get install --no-install-recommends -y software-properties-common lsb-release
 
                 # Packages added here should also be added to the Dockerfile
-                sudo apt-get install --no-install-recommends -y autoconf bash-completion bc clang-16 clang-17 clang-format-17 clang-tidy-17 cmake curl dos2unix g++-14 gcc-14 git graphviz libboost-all-dev libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld-17 man parallel postgresql-server-dev-all python3 python3-pip valgrind &
+                sudo apt-get install --no-install-recommends -y autoconf bash-completion bc clang-16 clang-17 clang-format-17 clang-tidy-17 cmake curl dos2unix g++-14 gcc-14 git graphviz libboost-all-dev libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld-17 man parallel postgresql-server-dev-all python3 python3-pip valgrind
 
                 if ! git submodule update --jobs 5 --init --recursive; then
                     echo "Error during git fetching submodules."

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -52,10 +52,9 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
         if [ -f /etc/lsb-release ] && cat /etc/lsb-release | grep DISTRIB_ID | grep Ubuntu >/dev/null; then
             echo "Installing dependencies (this may take a while)..."
             if sudo apt-get update >/dev/null; then
-                sudo apt-get install --no-install-recommends -y software-properties-common lsb-release
-
                 # Packages added here should also be added to the Dockerfile
-                sudo apt-get install --no-install-recommends -y git python3 python3-pip
+                # Some packages are not installed in the background since they are required for this script to complete
+                sudo apt-get install --no-install-recommends -y software-properties-common lsb-release git python3 python3-pip
                 sudo apt-get install --no-install-recommends -y autoconf bash-completion bc clang-16 clang-17 clang-format-17 clang-tidy-17 cmake curl dos2unix g++-14 gcc-14 graphviz libboost-all-dev libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld-17 man parallel postgresql-server-dev-all valgrind &
 
                 if ! git submodule update --jobs 5 --init --recursive; then

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -e
+set -x
+
 if [[ -z $HYRISE_HEADLESS_SETUP ]]; then
     read -p 'This script installs the dependencies of Hyrise. It might upgrade already installed packages. Continue? [y|n] ' -n 1 -r < /dev/tty
 else
@@ -52,7 +55,8 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
                 sudo apt-get install --no-install-recommends -y software-properties-common lsb-release
 
                 # Packages added here should also be added to the Dockerfile
-                sudo apt-get install --no-install-recommends -y autoconf bash-completion bc clang-16 clang-17 clang-format-17 clang-tidy-17 cmake curl dos2unix g++-14 gcc-14 git graphviz libboost-all-dev libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld-17 man parallel postgresql-server-dev-all python3 python3-pip valgrind
+                sudo apt-get install --no-install-recommends -y python3 python3-pip
+                sudo apt-get install --no-install-recommends -y autoconf bash-completion bc clang-16 clang-17 clang-format-17 clang-tidy-17 cmake curl dos2unix g++-14 gcc-14 git graphviz libboost-all-dev libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld-17 man parallel postgresql-server-dev-all valgrind
 
                 if ! git submodule update --jobs 5 --init --recursive; then
                     echo "Error during git fetching submodules."

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -50,15 +50,9 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
             echo "Installing dependencies (this may take a while)..."
             if sudo apt-get update >/dev/null; then
                 # Packages added here should also be added to the Dockerfile
-                # Some packages are not installed in the background since they are required for this script to complete
 
-                if ! sudo apt-get install --no-install-recommends -y software-properties-common lsb-release git python3 python3-pip; then
-                    echo "Error during apt-get1."
-                    exit 1
-                fi
-
-                if ! sudo apt-get install --no-install-recommends -y autoconf bash-completion bc clang-16 clang-17 clang-format-17 clang-tidy-17 cmake curl dos2unix g++-14 gcc-14 graphviz libboost-all-dev libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld-17 man parallel postgresql-server-dev-all valgrind & then
-                    echo "Error during apt-get2."
+                if ! sudo apt-get install --no-install-recommends -y software-properties-common lsb-release git python3 python3-pip autoconf bash-completion bc clang-16 clang-17 clang-format-17 clang-tidy-17 cmake curl dos2unix g++-14 gcc-14 graphviz libboost-all-dev libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld-17 man parallel postgresql-server-dev-all valgrind; then
+                    echo "Error during apt-get installations."
                     exit 1
                 fi
 
@@ -69,13 +63,6 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
 
                 if ! pip3 install --break-system-packages -r requirements.txt; then
                     echo "Error during installation of python requirements."
-                    exit 1
-                fi
-
-                wait $!
-                apt=$?
-                if [ $apt -ne 0 ]; then
-                    echo "Error during apt-get installations."
                     exit 1
                 fi
 

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -51,9 +51,7 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
             if sudo apt-get update >/dev/null; then
                 # Packages added here should also be added to the Dockerfile
                 # Some packages are not installed in the background since they are required for this script to complete
-                sudo apt-get install --no-install-recommends -y software-properties-common lsb-release git python3 python3-pip
-                sudo apt-get install --no-install-recommends -y autoconf bash-completion bc clang-16 clang-17 clang-format-17 clang-tidy-17 cmake curl dos2unix g++-14 gcc-14 graphviz libboost-all-dev libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld-17 man parallel postgresql-server-dev-all valgrind &
-
+                
                 if ! sudo apt-get install --no-install-recommends -y software-properties-common lsb-release git python3 python3-pip; then
                     echo "Error during git fetching submodules."
                     exit 1

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -66,7 +66,7 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
                     exit 1
                 fi
 
-                sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 90 --slave /usr/bin/g++ g++ /usr/bin/g++-13
+                sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 90 --slave /usr/bin/g++ g++ /usr/bin/g++-14
                 sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-17 90 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-17 --slave /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-17 --slave /usr/bin/llvm-profdata llvm-profdata /usr/bin/llvm-profdata-17 --slave /usr/bin/llvm-cov llvm-cov /usr/bin/llvm-cov-17 --slave /usr/bin/clang-format clang-format /usr/bin/clang-format-17  --slave /usr/bin/ld.lld ld.lld /usr/bin/ld.lld-17
             else
                 echo "Error during installation."

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -e
+set -x
+
 if [[ -z $HYRISE_HEADLESS_SETUP ]]; then
     read -p 'This script installs the dependencies of Hyrise. It might upgrade already installed packages. Continue? [y|n] ' -n 1 -r < /dev/tty
 else
@@ -53,13 +56,7 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
 
                 # Packages added here should also be added to the Dockerfile
                 sudo apt-get install --no-install-recommends -y git python3 python3-pip
-
-                if ! sudo apt-get install --no-install-recommends -y autoconf bash-completionnn bc; then
-                    echo "Error during apt."
-                    exit 1
-                fi
-
-                sudo apt-get install --no-install-recommends -y clang-16 clang-17 clang-format-17 clang-tidy-17 cmake curl dos2unix g++-14 gcc-14 graphviz libboost-all-dev libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld-17 man parallel postgresql-server-dev-all valgrind &
+                sudo apt-get install --no-install-recommends -y autoconf bash-completion bc clang-16 clang-17 clang-format-17 clang-tidy-17 cmake curl dos2unix g++-14 gcc-14 graphviz libboost-all-dev libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld-17 man parallel postgresql-server-dev-all valgrind &
 
                 if ! git submodule update --jobs 5 --init --recursive; then
                     echo "Error during git fetching submodules."

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -53,12 +53,12 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
                 # Some packages are not installed in the background since they are required for this script to complete
 
                 if ! sudo apt-get install --no-install-recommends -y software-properties-common lsb-release git python3 python3-pip; then
-                    echo "Error during apt-get."
+                    echo "Error during apt-get1."
                     exit 1
                 fi
 
                 if ! sudo apt-get install --no-install-recommends -y autoconf bash-completion bc clang-16 clang-17 clang-format-17 clang-tidy-17 cmake curl dos2unix g++-14 gcc-14 graphviz libboost-all-dev libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld-17 man parallel postgresql-server-dev-all valgrind & then
-                    echo "Error during apt-get."
+                    echo "Error during apt-get2."
                     exit 1
                 fi
 

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-set -e
-set -x
-
 if [[ -z $HYRISE_HEADLESS_SETUP ]]; then
     read -p 'This script installs the dependencies of Hyrise. It might upgrade already installed packages. Continue? [y|n] ' -n 1 -r < /dev/tty
 else
@@ -56,7 +53,13 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
 
                 # Packages added here should also be added to the Dockerfile
                 sudo apt-get install --no-install-recommends -y git python3 python3-pip
-                sudo apt-get install --no-install-recommends -y autoconf bash-completion bc clang-16 clang-17 clang-format-17 clang-tidy-17 cmake curl dos2unix g++-14 gcc-14 graphviz libboost-all-dev libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld-17 man parallel postgresql-server-dev-all valgrind &
+
+                if ! sudo apt-get install --no-install-recommends -y autoconf bash-completionnn bc; then
+                    echo "Error during apt."
+                    exit 1
+                fi
+
+                sudo apt-get install --no-install-recommends -y clang-16 clang-17 clang-format-17 clang-tidy-17 cmake curl dos2unix g++-14 gcc-14 graphviz libboost-all-dev libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld-17 man parallel postgresql-server-dev-all valgrind &
 
                 if ! git submodule update --jobs 5 --init --recursive; then
                     echo "Error during git fetching submodules."

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-set -e
-set -x
-
 if [[ -z $HYRISE_HEADLESS_SETUP ]]; then
     read -p 'This script installs the dependencies of Hyrise. It might upgrade already installed packages. Continue? [y|n] ' -n 1 -r < /dev/tty
 else
@@ -56,6 +53,16 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
                 # Some packages are not installed in the background since they are required for this script to complete
                 sudo apt-get install --no-install-recommends -y software-properties-common lsb-release git python3 python3-pip
                 sudo apt-get install --no-install-recommends -y autoconf bash-completion bc clang-16 clang-17 clang-format-17 clang-tidy-17 cmake curl dos2unix g++-14 gcc-14 graphviz libboost-all-dev libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld-17 man parallel postgresql-server-dev-all valgrind &
+
+                if ! sudo apt-get install --no-install-recommends -y software-properties-common lsb-release git python3 python3-pip; then
+                    echo "Error during git fetching submodules."
+                    exit 1
+                fi
+
+                if ! sudo apt-get install --no-install-recommends -y autoconf bash-completion bc clang-16 clang-17 clang-format-17 clang-tidy-17 cmake curl dos2unix g++-14 gcc-14 graphviz libboost-all-dev libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld-17 man parallel postgresql-server-dev-all valgrind & then
+                    echo "Error during git fetching submodules."
+                    exit 1
+                fi
 
                 if ! git submodule update --jobs 5 --init --recursive; then
                     echo "Error during git fetching submodules."

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -55,8 +55,8 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
                 sudo apt-get install --no-install-recommends -y software-properties-common lsb-release
 
                 # Packages added here should also be added to the Dockerfile
-                sudo apt-get install --no-install-recommends -y python3 python3-pip
-                sudo apt-get install --no-install-recommends -y autoconf bash-completion bc clang-16 clang-17 clang-format-17 clang-tidy-17 cmake curl dos2unix g++-14 gcc-14 git graphviz libboost-all-dev libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld-17 man parallel postgresql-server-dev-all valgrind &
+                sudo apt-get install --no-install-recommends -y git python3 python3-pip
+                sudo apt-get install --no-install-recommends -y autoconf bash-completion bc clang-16 clang-17 clang-format-17 clang-tidy-17 cmake curl dos2unix g++-14 gcc-14 graphviz libboost-all-dev libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld-17 man parallel postgresql-server-dev-all valgrind &
 
                 if ! git submodule update --jobs 5 --init --recursive; then
                     echo "Error during git fetching submodules."

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -51,14 +51,14 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
             if sudo apt-get update >/dev/null; then
                 # Packages added here should also be added to the Dockerfile
                 # Some packages are not installed in the background since they are required for this script to complete
-                
+
                 if ! sudo apt-get install --no-install-recommends -y software-properties-common lsb-release git python3 python3-pip; then
-                    echo "Error during git fetching submodules."
+                    echo "Error during apt-get."
                     exit 1
                 fi
 
                 if ! sudo apt-get install --no-install-recommends -y autoconf bash-completion bc clang-16 clang-17 clang-format-17 clang-tidy-17 cmake curl dos2unix g++-14 gcc-14 graphviz libboost-all-dev libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld-17 man parallel postgresql-server-dev-all valgrind & then
-                    echo "Error during git fetching submodules."
+                    echo "Error during apt-get."
                     exit 1
                 fi
 
@@ -95,4 +95,5 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
     fi
 fi
 
+echo "Dependencies installed successfully."
 exit 0


### PR DESCRIPTION
The `install_dependencies.sh` runs apt in the background, so the python requirements can be installed simultaneously.
This fails if `pip3` is called before it is installed via `apt-get`:
```
Processing triggers for dbus (1.14.10-4ubuntu4.1) ...
+ sudo apt-get install --no-install-recommends -y autoconf bash-completion bc clang-16 clang-17 clang-format-17 clang-tidy-17 cmake curl dos2unix g++-14 gcc-14 git graphviz libboost-all-dev libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld-17 man parallel postgresql-server-dev-all python3 python3-pip valgrind
+ git submodule update --jobs 5 --init --recursive
+ pip3 install --break-system-packages -r requirements.txt
./install_dependencies.sh: line 64: pip3: command not found
+ echo 'Error during installation of python requirements.'
Error during installation of python requirements.
+ exit 1
Reading package lists... Done
```