### PR TITLE
Disable clang-tidy for the test folder

### DIFF
--- a/src/test/.clang-tidy
+++ b/src/test/.clang-tidy
@@ -1,0 +1,3 @@
+# Disables all checks in the test folder, which are not linted anyway.
+# This way clangd does not highlight errors in test files in your IDE.
+Checks: '-*'


### PR DESCRIPTION
Clangd highlights linter errors in VSCode (and other IDEs). It also does this for test files, which turn out very red and unreadable. This PR disables linting for the test folder, by placing a .clang-tidy file in the test folder that disables all rules. 