### PR TITLE
Default Encoding

### DIFF
--- a/src/benchmark/tpch_data_micro_benchmark.cpp
+++ b/src/benchmark/tpch_data_micro_benchmark.cpp
@@ -16,7 +16,6 @@
 #include "scheduler/node_queue_scheduler.hpp"
 #include "scheduler/operator_task.hpp"
 #include "statistics/statistics_objects/equal_distinct_count_histogram.hpp"
-#include "storage/encoding_type.hpp"
 #include "tpch/tpch_constants.hpp"
 #include "tpch/tpch_table_generator.hpp"
 #include "types.hpp"
@@ -36,8 +35,7 @@ class TPCHDataMicroBenchmarkFixture : public MicroBenchmarkBasicFixture {
     const auto benchmark_config = std::make_shared<BenchmarkConfig>();
 
     if (!sm.has_table("lineitem")) {
-      std::cout << "Generating TPC-H data set with scale factor " << scale_factor << " and "
-                << benchmark_config->encoding_config.default_encoding_spec << " encoding:\n";
+      std::cout << "Generating TPC-H data set with scale factor " << scale_factor << " and automatic encoding:\n";
       TPCHTableGenerator(scale_factor, ClusteringConfiguration::None, benchmark_config).generate_and_store();
     }
 

--- a/src/benchmarklib/abstract_table_generator.hpp
+++ b/src/benchmarklib/abstract_table_generator.hpp
@@ -8,8 +8,9 @@
 #include <unordered_map>
 #include <vector>
 
-#include "encoding_config.hpp"
-#include "storage/chunk.hpp"
+#include "nlohmann/json.hpp"
+
+#include "storage/table.hpp"
 #include "types.hpp"
 
 namespace hyrise {

--- a/src/benchmarklib/benchmark_config.hpp
+++ b/src/benchmarklib/benchmark_config.hpp
@@ -13,7 +13,7 @@ namespace hyrise {
  * "Ordered" runs each item a number of times and then the next one.
  * "Shuffled" runs the items in a random order.
  */
-enum class BenchmarkMode { Ordered, Shuffled };
+enum class BenchmarkMode : std::uint8_t { Ordered, Shuffled };
 
 using Duration = std::chrono::nanoseconds;
 // `steady_clock` guarantees that the clock is not adjusted while benchmarking.
@@ -39,13 +39,13 @@ class BenchmarkConfig {
 
   BenchmarkMode benchmark_mode{BenchmarkMode::Ordered};
   ChunkOffset chunk_size{Chunk::DEFAULT_SIZE};
-  EncodingConfig encoding_config{};
+  EncodingConfig encoding_config;
   bool chunk_indexes{false};
   bool table_indexes{false};
   int64_t max_runs{-1};
   Duration max_duration{std::chrono::seconds{60}};
   Duration warmup_duration{0};
-  std::optional<std::string> output_file_path{};
+  std::optional<std::string> output_file_path;
   bool enable_scheduler{false};
   uint32_t cores{0};
   uint32_t data_preparation_cores{0};
@@ -57,7 +57,7 @@ class BenchmarkConfig {
   bool cache_binary_tables{false};
   bool system_metrics{false};
   bool pipeline_metrics{false};
-  std::vector<std::string> plugins{};
+  std::vector<std::string> plugins;
 };
 
 }  // namespace hyrise

--- a/src/benchmarklib/encoding_config.hpp
+++ b/src/benchmarklib/encoding_config.hpp
@@ -6,7 +6,6 @@
 
 #include "nlohmann/json_fwd.hpp"
 
-#include "storage/chunk_encoder.hpp"
 #include "storage/encoding_type.hpp"
 
 namespace hyrise {
@@ -20,14 +19,13 @@ using TableSegmentEncodingMapping =
 // View EncodingConfig::description to see format of encoding JSON
 class EncodingConfig {
  public:
-  EncodingConfig();
-  EncodingConfig(const SegmentEncodingSpec& default_encoding_spec, DataTypeEncodingMapping type_encoding_mapping,
-                 TableSegmentEncodingMapping encoding_mapping);
-  explicit EncodingConfig(const SegmentEncodingSpec& default_encoding_spec);
+  explicit EncodingConfig(const std::optional<SegmentEncodingSpec> default_encoding_spec = std::nullopt,
+                          DataTypeEncodingMapping type_encoding_mapping = {},
+                          TableSegmentEncodingMapping encoding_mapping = {});
 
   static EncodingConfig unencoded();
 
-  SegmentEncodingSpec default_encoding_spec;
+  std::optional<SegmentEncodingSpec> default_encoding_spec;
   DataTypeEncodingMapping type_encoding_mapping;
   TableSegmentEncodingMapping custom_encoding_mapping;
 

--- a/src/lib/operators/import.cpp
+++ b/src/lib/operators/import.cpp
@@ -71,9 +71,8 @@ std::shared_ptr<const Table> Import::_on_execute() {
 
   Hyrise::get().storage_manager.add_table(_tablename, table);
 
-  // If a table encoding is specified, encode the table accordingly. The default encoding is
-  // `EncodingType::Dictionary`, except for binary files. For binary files, the default is the encoding of the file.
-  if (_target_encoding || _file_type != FileType::Binary) {
+  // For binary files, the default is the encoding of the file.
+  if (_file_type != FileType::Binary) {
     auto chunk_encoding_spec = ChunkEncodingSpec{};
 
     for (auto column_id = ColumnID{0}; column_id < table->column_count(); ++column_id) {

--- a/src/lib/storage/segment_encoding_utils.cpp
+++ b/src/lib/storage/segment_encoding_utils.cpp
@@ -74,4 +74,22 @@ VectorCompressionType parent_vector_compression_type(const CompressedVectorType 
   Fail("Invalid enum value.");
 }
 
+SegmentEncodingSpec auto_select_segment_encoding_spec(const DataType& type, const bool is_unique) {
+  if (is_unique) {
+    return SegmentEncodingSpec{EncodingType::Unencoded};
+  }
+
+  switch (type) {
+    case DataType::Double:
+    case DataType::Float:
+    case DataType::Int:
+    case DataType::Long:
+      return SegmentEncodingSpec{EncodingType::FrameOfReference};
+    case DataType::String:
+      return SegmentEncodingSpec{EncodingType::Dictionary};
+    case DataType::Null:
+      return SegmentEncodingSpec{EncodingType::RunLength};
+  }
+}
+
 }  // namespace hyrise

--- a/src/lib/storage/segment_encoding_utils.cpp
+++ b/src/lib/storage/segment_encoding_utils.cpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <optional>
 
+#include "all_type_variant.hpp"
 #include "storage/abstract_segment.hpp"
 #include "storage/dictionary_segment/dictionary_encoder.hpp"
 #include "storage/encoding_type.hpp"
@@ -75,18 +76,18 @@ VectorCompressionType parent_vector_compression_type(const CompressedVectorType 
 }
 
 SegmentEncodingSpec auto_select_segment_encoding_spec(const DataType& type, const bool is_unique) {
-  if (is_unique) {
-    return SegmentEncodingSpec{EncodingType::Unencoded};
-  }
-
   switch (type) {
-    case DataType::Double:
-    case DataType::Float:
     case DataType::Int:
     case DataType::Long:
       return SegmentEncodingSpec{EncodingType::FrameOfReference};
     case DataType::String:
-      return SegmentEncodingSpec{EncodingType::Dictionary};
+    case DataType::Double:
+    case DataType::Float:
+      if (is_unique) {
+        return SegmentEncodingSpec{EncodingType::Unencoded};
+      } else {
+        return SegmentEncodingSpec{EncodingType::Dictionary};
+      }
     case DataType::Null:
       return SegmentEncodingSpec{EncodingType::RunLength};
   }

--- a/src/lib/storage/segment_encoding_utils.hpp
+++ b/src/lib/storage/segment_encoding_utils.hpp
@@ -1,9 +1,7 @@
 #pragma once
 
 #include <memory>
-#include <optional>
 
-#include "all_type_variant.hpp"
 #include "storage/abstract_segment.hpp"
 #include "storage/encoding_type.hpp"
 #include "storage/vector_compression/vector_compression.hpp"
@@ -30,5 +28,7 @@ SegmentEncodingSpec get_segment_encoding_spec(const std::shared_ptr<const Abstra
  * For the difference of the two, please take a look at compressed_vector_type.hpp.
  */
 VectorCompressionType parent_vector_compression_type(const CompressedVectorType compressed_vector_type);
+
+SegmentEncodingSpec auto_select_segment_encoding_spec(const DataType& type, const bool is_unique = false);
 
 }  // namespace hyrise

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -191,6 +191,40 @@ std::vector<bool> Table::columns_are_nullable() const {
   return nullable;
 }
 
+bool Table::column_is_unique(const ColumnID column_id) const {
+  Assert(column_id < _column_definitions.size(), "ColumnID out of range.");
+  for (const auto& key_constraint : soft_key_constraints()) {
+    const auto& key_type = key_constraint.key_type();
+    if (key_type != KeyConstraintType::PRIMARY_KEY && key_type != KeyConstraintType::UNIQUE) {
+      continue;
+    }
+
+    for (const auto& constraint_column_id : key_constraint.columns()) {
+      if (constraint_column_id == column_id) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+std::vector<bool> Table::columns_are_unique() const {
+  auto unique = std::vector<bool>(column_count(), false);
+  for (const auto& key_constraint : soft_key_constraints()) {
+    const auto key_type = key_constraint.key_type();
+    if (key_type != KeyConstraintType::PRIMARY_KEY && key_type != KeyConstraintType::UNIQUE) {
+      continue;
+    }
+
+    for (const auto& column_id : key_constraint.columns()) {
+      unique[column_id] = true;
+    }
+  }
+
+  return unique;
+}
+
 ColumnID Table::column_id_by_name(const std::string& column_name) const {
   const auto iter =
       std::find_if(_column_definitions.begin(), _column_definitions.end(), [&](const auto& column_definition) {

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -71,6 +71,9 @@ class Table : private Noncopyable {
   bool column_is_nullable(const ColumnID column_id) const;
   std::vector<bool> columns_are_nullable() const;
 
+  bool column_is_unique(const ColumnID column_id) const;
+  std::vector<bool> columns_are_unique() const;
+
   // Fail()s, if there is no column of that name
   ColumnID column_id_by_name(const std::string& column_name) const;
 
@@ -286,8 +289,8 @@ class Table : private Noncopyable {
   ForeignKeyConstraints _referenced_foreign_key_constraints;
 
   std::vector<ColumnID> _value_clustered_by;
-  std::shared_ptr<TableStatistics> _table_statistics{};
-  std::mutex _append_mutex{};
+  std::shared_ptr<TableStatistics> _table_statistics;
+  std::mutex _append_mutex;
   std::vector<ChunkIndexStatistics> _chunk_indexes_statistics;
   std::vector<TableIndexStatistics> _table_indexes_statistics;
   pmr_vector<std::shared_ptr<PartialHashIndex>> _table_indexes;


### PR DESCRIPTION
This PR changes the default encoding from dictionary to a type and uniqueness dependent encoding. The import operator and the benchmark table encoder both now consult a helper function to decide the encoding of the columns.