### PR TITLE
Add cacheability information to optimization rules

### DIFF
--- a/src/lib/logical_query_plan/data_dependencies/functional_dependency.cpp
+++ b/src/lib/logical_query_plan/data_dependencies/functional_dependency.cpp
@@ -4,7 +4,6 @@
 #include <cstddef>
 #include <functional>
 #include <ostream>
-#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -15,10 +14,8 @@
 namespace hyrise {
 
 FunctionalDependency::FunctionalDependency(ExpressionUnorderedSet&& init_determinants,
-                                           ExpressionUnorderedSet&& init_dependents, bool is_time_independent)
-    : determinants(std::move(init_determinants)),
-      dependents(std::move(init_dependents)),
-      _is_time_independent(is_time_independent) {
+                                           ExpressionUnorderedSet&& init_dependents)
+    : determinants(std::move(init_determinants)), dependents(std::move(init_dependents)) {
   DebugAssert(!determinants.empty() && !dependents.empty(), "FunctionalDependency cannot be empty");
 }
 
@@ -50,10 +47,6 @@ bool FunctionalDependency::operator==(const FunctionalDependency& other) const {
 
 bool FunctionalDependency::operator!=(const FunctionalDependency& other) const {
   return !(other == *this);
-}
-
-bool FunctionalDependency::is_time_independent() const {
-  return _is_time_independent;
 }
 
 size_t FunctionalDependency::hash() const {
@@ -89,7 +82,7 @@ FunctionalDependencies inflate_fds(const FunctionalDependencies& fds) {
     } else {
       for (const auto& dependent : fd.dependents) {
         auto determinants = fd.determinants;
-        inflated_fds.emplace(std::move(determinants), ExpressionUnorderedSet{dependent}, fd.is_time_independent());
+        inflated_fds.emplace(std::move(determinants), ExpressionUnorderedSet{dependent});
       }
     }
   }
@@ -103,14 +96,14 @@ FunctionalDependencies deflate_fds(const FunctionalDependencies& fds) {
   }
 
   // We cannot use a set here as we want to add dependents to existing FDs and objects in sets are immutable.
-  auto existing_fds = std::vector<std::tuple<ExpressionUnorderedSet, ExpressionUnorderedSet, bool>>{};
+  auto existing_fds = std::vector<std::pair<ExpressionUnorderedSet, ExpressionUnorderedSet>>{};
   existing_fds.reserve(fds.size());
 
   for (const auto& fd_to_add : fds) {
     // Check if we have seen an FD with the same determinants.
     auto existing_fd = std::find_if(existing_fds.begin(), existing_fds.end(), [&](const auto& fd) {
       // Quick check for cardinality.
-      const auto& determinants = std::get<0>(fd);
+      const auto& determinants = fd.first;
       if (determinants.size() != fd_to_add.determinants.size()) {
         return false;
       }
@@ -125,18 +118,17 @@ FunctionalDependencies deflate_fds(const FunctionalDependencies& fds) {
       return true;
     });
 
-    // If we have found an FD with same determinants and the same time dependence, add the dependents. Otherwise, add a
-    // new FD.
-    if (existing_fd != existing_fds.end() && std::get<2>(*existing_fd) == fd_to_add.is_time_independent()) {
-      std::get<1>(*existing_fd).insert(fd_to_add.dependents.cbegin(), fd_to_add.dependents.cend());
+    // If we have found an FD with same determinants, add the dependents. Otherwise, add a new FD.
+    if (existing_fd != existing_fds.end()) {
+      existing_fd->second.insert(fd_to_add.dependents.cbegin(), fd_to_add.dependents.cend());
     } else {
-      existing_fds.emplace_back(fd_to_add.determinants, fd_to_add.dependents, fd_to_add.is_time_independent());
+      existing_fds.emplace_back(fd_to_add.determinants, fd_to_add.dependents);
     }
   }
 
   auto deflated_fds = FunctionalDependencies(fds.size());
-  for (auto [determinants, dependents, is_time_independent] : existing_fds) {
-    deflated_fds.emplace(std::move(determinants), std::move(dependents), is_time_independent);
+  for (auto [determinants, dependents] : existing_fds) {
+    deflated_fds.emplace(std::move(determinants), std::move(dependents));
   }
 
   return deflated_fds;

--- a/src/lib/logical_query_plan/data_dependencies/functional_dependency.hpp
+++ b/src/lib/logical_query_plan/data_dependencies/functional_dependency.hpp
@@ -28,15 +28,9 @@ namespace hyrise {
  *
  * Currently, the determinant expressions are required to be non-nullable to be involved in FDs. Combining null values
  * and FDs is not trivial. For more reference, see https://arxiv.org/abs/1404.4963.
- *
- * If the FD may become invalid in the future (because it is not based on a schema constraint, but on the data
- * incidentally fulfilling the constraint at the moment), the FD is marked as being not permanent.
- * This information is important because query plans that were optimized using a non-permanent FD are probably
- * not cacheable.
  */
 struct FunctionalDependency {
-  FunctionalDependency(ExpressionUnorderedSet&& init_determinants, ExpressionUnorderedSet&& init_dependents,
-                       bool is_time_independent = true);
+  FunctionalDependency(ExpressionUnorderedSet&& init_determinants, ExpressionUnorderedSet&& init_dependents);
 
   bool operator==(const FunctionalDependency& other) const;
   bool operator!=(const FunctionalDependency& other) const;
@@ -44,11 +38,6 @@ struct FunctionalDependency {
 
   ExpressionUnorderedSet determinants;
   ExpressionUnorderedSet dependents;
-
-  bool is_time_independent() const;
-
- private:
-  bool _is_time_independent;
 };
 
 std::ostream& operator<<(std::ostream& stream, const FunctionalDependency& fd);
@@ -67,8 +56,7 @@ FunctionalDependencies inflate_fds(const FunctionalDependencies& fds);
 
 /**
  * @return Reduces the given vector of FDs, so that there are no more FD objects with the same determinant expressions.
- *         Note that FDs that do not share the same time dependence are not merged. As a result, FDs become deflated as
- *          follows (assuming all FDs are time-independent):
+ *         As a result, FDs become deflated as follows:
  *
  *                             {a} => {b}
  *                             {a} => {c}         -->   {a} => {b, c, d}

--- a/src/lib/logical_query_plan/data_dependencies/functional_dependency.hpp
+++ b/src/lib/logical_query_plan/data_dependencies/functional_dependency.hpp
@@ -28,9 +28,15 @@ namespace hyrise {
  *
  * Currently, the determinant expressions are required to be non-nullable to be involved in FDs. Combining null values
  * and FDs is not trivial. For more reference, see https://arxiv.org/abs/1404.4963.
+ *
+ * If the FD may become invalid in the future (because it is not based on a schema constraint, but on the data
+ * incidentally fulfilling the constraint at the moment), the FD is marked as being not permanent.
+ * This information is important because query plans that were optimized using a non-permanent FD are probably
+ * not cacheable.
  */
 struct FunctionalDependency {
-  FunctionalDependency(ExpressionUnorderedSet&& init_determinants, ExpressionUnorderedSet&& init_dependents);
+  FunctionalDependency(ExpressionUnorderedSet&& init_determinants, ExpressionUnorderedSet&& init_dependents,
+                       bool is_time_independent = true);
 
   bool operator==(const FunctionalDependency& other) const;
   bool operator!=(const FunctionalDependency& other) const;
@@ -38,6 +44,11 @@ struct FunctionalDependency {
 
   ExpressionUnorderedSet determinants;
   ExpressionUnorderedSet dependents;
+
+  bool is_time_independent() const;
+
+ private:
+  bool _is_time_independent;
 };
 
 std::ostream& operator<<(std::ostream& stream, const FunctionalDependency& fd);
@@ -56,7 +67,8 @@ FunctionalDependencies inflate_fds(const FunctionalDependencies& fds);
 
 /**
  * @return Reduces the given vector of FDs, so that there are no more FD objects with the same determinant expressions.
- *         As a result, FDs become deflated as follows:
+ *         Note that FDs that do not share the same time dependence are not merged. As a result, FDs become deflated as
+ *          follows (assuming all FDs are time-independent):
  *
  *                             {a} => {b}
  *                             {a} => {c}         -->   {a} => {b, c, d}

--- a/src/lib/logical_query_plan/mock_node.cpp
+++ b/src/lib/logical_query_plan/mock_node.cpp
@@ -190,12 +190,7 @@ const TableKeyConstraints& MockNode::key_constraints() const {
 }
 
 void MockNode::set_non_trivial_functional_dependencies(const FunctionalDependencies& fds) {
-  // _functional_dependencies = fds;
-  _functional_dependencies.clear();
-
-  for (const auto& fd : fds) {
-    _functional_dependencies.emplace(fd);
-  }
+  _functional_dependencies = fds;
 }
 
 FunctionalDependencies MockNode::non_trivial_functional_dependencies() const {

--- a/src/lib/logical_query_plan/mock_node.cpp
+++ b/src/lib/logical_query_plan/mock_node.cpp
@@ -190,7 +190,12 @@ const TableKeyConstraints& MockNode::key_constraints() const {
 }
 
 void MockNode::set_non_trivial_functional_dependencies(const FunctionalDependencies& fds) {
-  _functional_dependencies = fds;
+  // _functional_dependencies = fds;
+  _functional_dependencies.clear();
+
+  for (const auto& fd : fds) {
+    _functional_dependencies.emplace(fd);
+  }
 }
 
 FunctionalDependencies MockNode::non_trivial_functional_dependencies() const {

--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -16,6 +16,7 @@
 #include "logical_query_plan/change_meta_table_node.hpp"
 #include "logical_query_plan/logical_plan_root_node.hpp"
 #include "logical_query_plan/lqp_utils.hpp"
+#include "strategy/abstract_rule.hpp"
 #include "strategy/between_composition_rule.hpp"
 #include "strategy/chunk_pruning_rule.hpp"
 #include "strategy/column_pruning_rule.hpp"
@@ -278,7 +279,7 @@ void Optimizer::add_rule(std::unique_ptr<AbstractRule> rule) {
   _rules.emplace_back(std::move(rule));
 }
 
-std::shared_ptr<AbstractLQPNode> Optimizer::optimize(
+std::pair<std::shared_ptr<AbstractLQPNode>, IsCacheable> Optimizer::optimize(
     std::shared_ptr<AbstractLQPNode> input,
     const std::shared_ptr<std::vector<OptimizerRuleMetrics>>& rule_durations) const {
   // We cannot allow multiple owners of the LQP as one owner could decide to optimize the plan and others might hold a
@@ -295,10 +296,10 @@ std::shared_ptr<AbstractLQPNode> Optimizer::optimize(
   if constexpr (HYRISE_DEBUG) {
     validate_lqp(root_node);
   }
-
+  auto cacheable = IsCacheable::Yes;
   for (const auto& rule : _rules) {
     auto rule_timer = Timer{};
-    rule->apply_to_plan(root_node);
+    cacheable = cacheable && rule->apply_to_plan(root_node);
 
     if (rule_durations) {
       rule_durations->emplace_back(rule->name(), rule_timer.lap());
@@ -318,7 +319,7 @@ std::shared_ptr<AbstractLQPNode> Optimizer::optimize(
   auto optimized_node = root_node->left_input();
   root_node->set_left_input(nullptr);
 
-  return optimized_node;
+  return {optimized_node, cacheable};
 }
 
 void Optimizer::validate_lqp(const std::shared_ptr<AbstractLQPNode>& root_node) {

--- a/src/lib/optimizer/optimizer.hpp
+++ b/src/lib/optimizer/optimizer.hpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "cost_estimation/cost_estimator_logical.hpp"
@@ -42,7 +43,7 @@ class Optimizer final {
    * Returns optimized version of @param input.
    * @param rule_durations may be set in order to retrieve runtime information for each applied rule.
    */
-  std::shared_ptr<AbstractLQPNode> optimize(
+  std::pair<std::shared_ptr<AbstractLQPNode>, IsCacheable> optimize(
       std::shared_ptr<AbstractLQPNode> input,
       const std::shared_ptr<std::vector<OptimizerRuleMetrics>>& rule_durations = nullptr) const;
 

--- a/src/lib/optimizer/strategy/abstract_rule.hpp
+++ b/src/lib/optimizer/strategy/abstract_rule.hpp
@@ -11,10 +11,15 @@ class AbstractLQPNode;
 class LogicalPlanRootNode;
 class LQPSubqueryExpression;
 
+enum class IsCacheable : bool { Yes = true, No = false };
+
+constexpr IsCacheable operator&&(IsCacheable lhs, IsCacheable rhs) {
+  return lhs == IsCacheable::Yes && rhs == IsCacheable::Yes ? IsCacheable::Yes : IsCacheable::No;
+}
+
 class AbstractRule {
  public:
   virtual ~AbstractRule() = default;
-
   /**
    * This function applies the concrete Optimizer Rule to an LQP.
    * The default implementation
@@ -37,8 +42,12 @@ class AbstractRule {
    *
    * Rules can define their own strategy of optimizing subquery LQPs by overriding this function. See, for example, the
    * StoredTableColumnAlignmentRule.
+   *
+   * @return Whether the resulting optimized LQP can be cached by the optimizer. A plan may only be cached if the root
+   *    LQP and all subquery LQPs are cacheable. An optimized plan might be not cacheable for example if we used a UCC
+   *    for optimization of which we cannot be sure that it will still be valid the next time the same query occurs.
    */
-  virtual void apply_to_plan(const std::shared_ptr<LogicalPlanRootNode>& lqp_root) const;
+  virtual IsCacheable apply_to_plan(const std::shared_ptr<LogicalPlanRootNode>& lqp_root) const;
 
   virtual std::string name() const = 0;
 
@@ -53,8 +62,12 @@ class AbstractRule {
    *  left and the right side of the diamond. On both sides, we would reach the bottom of the diamond. From there, we
    *  would look at each node twice. visit_lqp prevents this by tracking which nodes have already been visited and
    *  avoiding visiting a node twice.
+   *
+   *  @return Whether the resulting optimized LQP can be cached by the optimizer. An optimized plan might be not
+   *    cacheable for example if we used a UCC for optimization of which we cannot be sure that it will still be valid
+   *    the next time the same query comes around.
    */
-  virtual void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const = 0;
+  virtual IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const = 0;
 };
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/between_composition_rule.cpp
+++ b/src/lib/optimizer/strategy/between_composition_rule.cpp
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "abstract_rule.hpp"
 #include "expression/abstract_expression.hpp"
 #include "expression/between_expression.hpp"
 #include "expression/binary_predicate_expression.hpp"
@@ -62,7 +63,8 @@ std::string BetweenCompositionRule::name() const {
  *   b) The BetweenCompositionRule searches for arbitrary PredicateNodes that are directly linked. Therefore,
  *      predicate chains can start and end in the midst of LQPs.
  */
-void BetweenCompositionRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
+IsCacheable BetweenCompositionRule::_apply_to_plan_without_subqueries(
+    const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   std::unordered_set<std::shared_ptr<AbstractLQPNode>> visited_nodes;
   std::vector<PredicateChain> predicate_chains;
 
@@ -128,6 +130,8 @@ void BetweenCompositionRule::_apply_to_plan_without_subqueries(const std::shared
   for (const auto& predicate_chain : predicate_chains) {
     _substitute_predicates_with_between_expressions(predicate_chain);
   }
+
+  return IsCacheable::Yes;
 }
 
 /**

--- a/src/lib/optimizer/strategy/between_composition_rule.hpp
+++ b/src/lib/optimizer/strategy/between_composition_rule.hpp
@@ -29,7 +29,7 @@ class BetweenCompositionRule : public AbstractRule {
   std::string name() const override;
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 
  private:
   using PredicateChain = std::vector<std::shared_ptr<PredicateNode>>;

--- a/src/lib/optimizer/strategy/chunk_pruning_rule.cpp
+++ b/src/lib/optimizer/strategy/chunk_pruning_rule.cpp
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include "abstract_rule.hpp"
 #include "expression/abstract_expression.hpp"
 #include "expression/abstract_predicate_expression.hpp"
 #include "expression/expression_utils.hpp"
@@ -148,7 +149,8 @@ std::string ChunkPruningRule::name() const {
   return name;
 }
 
-void ChunkPruningRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
+IsCacheable ChunkPruningRule::_apply_to_plan_without_subqueries(
+    const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   auto predicate_pruning_chains_by_stored_table_node =
       std::unordered_map<std::shared_ptr<StoredTableNode>, std::vector<PredicatePruningChain>>{};
 
@@ -252,6 +254,8 @@ void ChunkPruningRule::_apply_to_plan_without_subqueries(const std::shared_ptr<A
       stored_table_node->set_prunable_subquery_predicates(prunable_subquery_predicates);
     }
   }
+
+  return IsCacheable::Yes;
 }
 
 /**

--- a/src/lib/optimizer/strategy/chunk_pruning_rule.hpp
+++ b/src/lib/optimizer/strategy/chunk_pruning_rule.hpp
@@ -29,7 +29,7 @@ class ChunkPruningRule : public AbstractRule {
   std::string name() const override;
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 
   static std::vector<PredicatePruningChain> _find_predicate_pruning_chains_by_stored_table_node(
       const std::shared_ptr<StoredTableNode>& stored_table_node);

--- a/src/lib/optimizer/strategy/column_pruning_rule.cpp
+++ b/src/lib/optimizer/strategy/column_pruning_rule.cpp
@@ -7,6 +7,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "abstract_rule.hpp"
 #include "expression/abstract_expression.hpp"
 #include "expression/expression_utils.hpp"
 #include "expression/lqp_column_expression.hpp"
@@ -327,7 +328,8 @@ std::string ColumnPruningRule::name() const {
   return name;
 }
 
-void ColumnPruningRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
+IsCacheable ColumnPruningRule::_apply_to_plan_without_subqueries(
+    const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   // For each node, required_expressions_by_node will hold the expressions either needed by this node or by one of its
   // successors (i.e., nodes to which this node is an input). After collecting this information, we walk through all
   // identified nodes and perform the pruning.
@@ -391,6 +393,8 @@ void ColumnPruningRule::_apply_to_plan_without_subqueries(const std::shared_ptr<
         break;  // Node cannot be pruned
     }
   }
+
+  return IsCacheable::Yes;
 }
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/column_pruning_rule.hpp
+++ b/src/lib/optimizer/strategy/column_pruning_rule.hpp
@@ -24,7 +24,7 @@ class ColumnPruningRule : public AbstractRule {
   std::string name() const override;
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/dependent_group_by_reduction_rule.hpp
+++ b/src/lib/optimizer/strategy/dependent_group_by_reduction_rule.hpp
@@ -16,7 +16,9 @@ namespace hyrise {
  * speaking, the fact that c_custkey is the primary key of the customer table.
  * This rule identifies cases where functionally dependent columns are given as group-by columns while the functional
  * dependencies's determinant column(s) is a/are also group-by column(s). It then replaces that column (e.g., c_name)
- * with a dummy aggregate function ANY(c_name). This reduces the grouping cost in the aggregate operator.
+ * with a dummy aggregate function ANY(c_name). This reduces the grouping cost in the aggregate operator. During the
+ * application of this rule we prioritize functional dependencies with fewer determinants, as they are more likely to
+ * be useful for the rewrite. When the amount of determinants is equal, we prioritize time independent dependencies.
  * As the aggregate operators first produce all group-by columns, followed by all aggregate columns (including ANY),
  * the order might be changed. Unless a following operation redefines the order anyway (e.g., a projection or another
  * aggregate), a new projection is inserted to restore the original column order.
@@ -44,7 +46,7 @@ class DependentGroupByReductionRule : public AbstractRule {
   std::string name() const override;
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/expression_reduction_rule.cpp
+++ b/src/lib/optimizer/strategy/expression_reduction_rule.cpp
@@ -9,6 +9,7 @@
 
 #include <boost/variant/get.hpp>
 
+#include "abstract_rule.hpp"
 #include "all_type_variant.hpp"
 #include "expression/abstract_expression.hpp"
 #include "expression/evaluation/expression_evaluator.hpp"
@@ -38,7 +39,7 @@ std::string ExpressionReductionRule::name() const {
   return name;
 }
 
-void ExpressionReductionRule::_apply_to_plan_without_subqueries(
+IsCacheable ExpressionReductionRule::_apply_to_plan_without_subqueries(
     const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   Assert(lqp_root->type == LQPNodeType::Root, "ExpressionReductionRule needs root to hold onto.");
 
@@ -66,6 +67,8 @@ void ExpressionReductionRule::_apply_to_plan_without_subqueries(
 
     return LQPVisitation::VisitInputs;
   });
+
+  return IsCacheable::Yes;
 }
 
 const std::shared_ptr<AbstractExpression>& ExpressionReductionRule::reduce_distributivity(

--- a/src/lib/optimizer/strategy/expression_reduction_rule.hpp
+++ b/src/lib/optimizer/strategy/expression_reduction_rule.hpp
@@ -84,7 +84,7 @@ class ExpressionReductionRule : public AbstractRule {
   static void unnest_unary_in_expression(std::shared_ptr<AbstractExpression>& input_expression);
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/in_expression_rewrite_rule.cpp
+++ b/src/lib/optimizer/strategy/in_expression_rewrite_rule.cpp
@@ -7,6 +7,7 @@
 #include <utility>
 #include <vector>
 
+#include "abstract_rule.hpp"
 #include "all_type_variant.hpp"
 #include "cost_estimation/abstract_cost_estimator.hpp"
 #include "expression/abstract_expression.hpp"
@@ -121,11 +122,11 @@ std::string InExpressionRewriteRule::name() const {
   return name;
 }
 
-void InExpressionRewriteRule::_apply_to_plan_without_subqueries(
+IsCacheable InExpressionRewriteRule::_apply_to_plan_without_subqueries(
     const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   if (strategy == Strategy::ExpressionEvaluator) {
     // This is the default anyway, i.e., what the SQLTranslator gave us
-    return;
+    return IsCacheable::Yes;
   }
 
   const auto& cardinality_estimator = cost_estimator->cardinality_estimator;
@@ -198,6 +199,8 @@ void InExpressionRewriteRule::_apply_to_plan_without_subqueries(
 
     return LQPVisitation::VisitInputs;
   });
+
+  return IsCacheable::Yes;
 }
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/in_expression_rewrite_rule.hpp
+++ b/src/lib/optimizer/strategy/in_expression_rewrite_rule.hpp
@@ -42,7 +42,7 @@ class InExpressionRewriteRule : public AbstractRule {
   Strategy strategy{Strategy::Auto};
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/index_scan_rule.cpp
+++ b/src/lib/optimizer/strategy/index_scan_rule.cpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+#include "abstract_rule.hpp"
 #include "all_parameter_variant.hpp"
 #include "cost_estimation/abstract_cost_estimator.hpp"
 #include "logical_query_plan/abstract_lqp_node.hpp"
@@ -85,7 +86,7 @@ std::string IndexScanRule::name() const {
   return name;
 }
 
-void IndexScanRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
+IsCacheable IndexScanRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   DebugAssert(cost_estimator, "IndexScanRule requires cost estimator to be set.");
   Assert(lqp_root->type == LQPNodeType::Root, "ExpressionReductionRule needs root to hold onto.");
 
@@ -108,6 +109,8 @@ void IndexScanRule::_apply_to_plan_without_subqueries(const std::shared_ptr<Abst
 
     return LQPVisitation::VisitInputs;
   });
+
+  return IsCacheable::Yes;
 }
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/index_scan_rule.hpp
+++ b/src/lib/optimizer/strategy/index_scan_rule.hpp
@@ -30,7 +30,7 @@ class IndexScanRule : public AbstractRule {
   std::string name() const override;
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/join_ordering_rule.cpp
+++ b/src/lib/optimizer/strategy/join_ordering_rule.cpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 
+#include "abstract_rule.hpp"
 #include "cost_estimation/abstract_cost_estimator.hpp"
 #include "expression/expression_utils.hpp"
 #include "logical_query_plan/abstract_lqp_node.hpp"
@@ -85,7 +86,8 @@ std::string JoinOrderingRule::name() const {
   return name;
 }
 
-void JoinOrderingRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
+IsCacheable JoinOrderingRule::_apply_to_plan_without_subqueries(
+    const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   DebugAssert(cost_estimator, "JoinOrderingRule requires cost estimator to be set.");
 
   /**
@@ -105,6 +107,8 @@ void JoinOrderingRule::_apply_to_plan_without_subqueries(const std::shared_ptr<A
   }
 
   lqp_root->set_left_input(result_lqp);
+
+  return IsCacheable::Yes;
 }
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/join_ordering_rule.hpp
+++ b/src/lib/optimizer/strategy/join_ordering_rule.hpp
@@ -25,7 +25,7 @@ class JoinOrderingRule : public AbstractRule {
   constexpr static auto MIN_VERTICES_FOR_HEURISTIC = size_t{9};
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/join_predicate_ordering_rule.cpp
+++ b/src/lib/optimizer/strategy/join_predicate_ordering_rule.cpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <unordered_map>
 
+#include "abstract_rule.hpp"
 #include "cost_estimation/abstract_cost_estimator.hpp"
 #include "expression/abstract_predicate_expression.hpp"
 #include "logical_query_plan/abstract_lqp_node.hpp"
@@ -21,7 +22,7 @@ std::string JoinPredicateOrderingRule::name() const {
   return name;
 }
 
-void JoinPredicateOrderingRule::_apply_to_plan_without_subqueries(
+IsCacheable JoinPredicateOrderingRule::_apply_to_plan_without_subqueries(
     const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   visit_lqp(lqp_root, [&](const auto& node) {
     // Check if this is a multi predicate join.
@@ -72,6 +73,8 @@ void JoinPredicateOrderingRule::_apply_to_plan_without_subqueries(
 
     return LQPVisitation::VisitInputs;
   });
+
+  return IsCacheable::Yes;
 }
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/join_predicate_ordering_rule.hpp
+++ b/src/lib/optimizer/strategy/join_predicate_ordering_rule.hpp
@@ -25,7 +25,7 @@ class JoinPredicateOrderingRule : public AbstractRule {
   std::string name() const override;
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/join_to_predicate_rewrite_rule.cpp
+++ b/src/lib/optimizer/strategy/join_to_predicate_rewrite_rule.cpp
@@ -26,7 +26,7 @@ using namespace hyrise::expression_functional;  // NOLINT(build/namespaces)
 void gather_rewrite_info(
     const std::shared_ptr<JoinNode>& join_node,
     std::vector<std::tuple<std::shared_ptr<JoinNode>, LQPInputSide, std::shared_ptr<PredicateNode>>>& rewritables,
-    IsCacheable& cacheable) { // NOLINT(misc-unused-parameters)
+    IsCacheable& cacheable) {  // NOLINT(misc-unused-parameters)
   const auto prunable_side = join_node->prunable_input_side();
   if (!prunable_side) {
     return;

--- a/src/lib/optimizer/strategy/join_to_predicate_rewrite_rule.cpp
+++ b/src/lib/optimizer/strategy/join_to_predicate_rewrite_rule.cpp
@@ -5,6 +5,7 @@
 #include <tuple>
 #include <vector>
 
+#include "abstract_rule.hpp"
 #include "expression/abstract_expression.hpp"
 #include "expression/binary_predicate_expression.hpp"
 #include "expression/expression_functional.hpp"
@@ -24,7 +25,8 @@ using namespace hyrise::expression_functional;  // NOLINT(build/namespaces)
 
 void gather_rewrite_info(
     const std::shared_ptr<JoinNode>& join_node,
-    std::vector<std::tuple<std::shared_ptr<JoinNode>, LQPInputSide, std::shared_ptr<PredicateNode>>>& rewritables) {
+    std::vector<std::tuple<std::shared_ptr<JoinNode>, LQPInputSide, std::shared_ptr<PredicateNode>>>& rewritables,
+    IsCacheable& cacheable) { // NOLINT(misc-unused-parameters)
   const auto prunable_side = join_node->prunable_input_side();
   if (!prunable_side) {
     return;
@@ -161,15 +163,16 @@ std::string JoinToPredicateRewriteRule::name() const {
   return name;
 }
 
-void JoinToPredicateRewriteRule::_apply_to_plan_without_subqueries(
+IsCacheable JoinToPredicateRewriteRule::_apply_to_plan_without_subqueries(
     const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   // `rewritables finally contains all rewritable join nodes, their unused input side, and the predicates to be used for
   // the rewrites.
   auto rewritables = std::vector<std::tuple<std::shared_ptr<JoinNode>, LQPInputSide, std::shared_ptr<PredicateNode>>>{};
+  auto cacheable = IsCacheable::Yes;
   visit_lqp(lqp_root, [&](const auto& node) {
     if (node->type == LQPNodeType::Join) {
       const auto join_node = std::static_pointer_cast<JoinNode>(node);
-      gather_rewrite_info(join_node, rewritables);
+      gather_rewrite_info(join_node, rewritables, cacheable);
     }
     return LQPVisitation::VisitInputs;
   });
@@ -177,6 +180,8 @@ void JoinToPredicateRewriteRule::_apply_to_plan_without_subqueries(
   for (const auto& [join_node, prunable_side, rewrite_predicate] : rewritables) {
     perform_rewrite(join_node, prunable_side, rewrite_predicate);
   }
+
+  return cacheable;
 }
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/join_to_predicate_rewrite_rule.hpp
+++ b/src/lib/optimizer/strategy/join_to_predicate_rewrite_rule.hpp
@@ -25,7 +25,7 @@ class JoinToPredicateRewriteRule : public AbstractRule {
   std::string name() const override;
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/join_to_semi_join_rule.cpp
+++ b/src/lib/optimizer/strategy/join_to_semi_join_rule.cpp
@@ -78,13 +78,13 @@ IsCacheable JoinToSemiJoinRule::_apply_to_plan_without_subqueries(
       // Determine which node to use for Semi-Join-filtering and check for the required uniqueness guarantees.
       if (*join_node->prunable_input_side() == LQPInputSide::Left &&
           join_node->left_input()->has_matching_ucc(equals_predicate_expressions_left)) {
-          join_node->join_mode = JoinMode::Semi;
-          const auto temp = join_node->left_input();
-          join_node->set_left_input(join_node->right_input());
-          join_node->set_right_input(temp);
+        join_node->join_mode = JoinMode::Semi;
+        const auto temp = join_node->left_input();
+        join_node->set_left_input(join_node->right_input());
+        join_node->set_right_input(temp);
       } else if (*join_node->prunable_input_side() == LQPInputSide::Right &&
                  join_node->right_input()->has_matching_ucc(equals_predicate_expressions_right)) {
-          join_node->join_mode = JoinMode::Semi;
+        join_node->join_mode = JoinMode::Semi;
       }
     }
 

--- a/src/lib/optimizer/strategy/join_to_semi_join_rule.hpp
+++ b/src/lib/optimizer/strategy/join_to_semi_join_rule.hpp
@@ -22,7 +22,7 @@ class JoinToSemiJoinRule : public AbstractRule {
   std::string name() const override;
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/null_scan_removal_rule.cpp
+++ b/src/lib/optimizer/strategy/null_scan_removal_rule.cpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+#include "abstract_rule.hpp"
 #include "cost_estimation/abstract_cost_estimator.hpp"
 #include "expression/is_null_expression.hpp"
 #include "expression/lqp_column_expression.hpp"
@@ -24,7 +25,7 @@ std::string NullScanRemovalRule::name() const {
   return name;
 }
 
-void NullScanRemovalRule::apply_to_plan(const std::shared_ptr<LogicalPlanRootNode>& root) const {
+IsCacheable NullScanRemovalRule::apply_to_plan(const std::shared_ptr<LogicalPlanRootNode>& root) const {
   Assert(root->type == LQPNodeType::Root, "NullScanRemovalRule needs root to hold onto.");
 
   std::vector<std::shared_ptr<AbstractLQPNode>> nodes_to_remove;
@@ -83,6 +84,8 @@ void NullScanRemovalRule::apply_to_plan(const std::shared_ptr<LogicalPlanRootNod
   visit_lqp(root, visitor);
 
   _remove_nodes(nodes_to_remove);
+
+  return IsCacheable::Yes;
 }
 
 void NullScanRemovalRule::_remove_nodes(const std::vector<std::shared_ptr<AbstractLQPNode>>& nodes) {
@@ -91,7 +94,7 @@ void NullScanRemovalRule::_remove_nodes(const std::vector<std::shared_ptr<Abstra
   }
 }
 
-void NullScanRemovalRule::_apply_to_plan_without_subqueries(
+IsCacheable NullScanRemovalRule::_apply_to_plan_without_subqueries(
     const std::shared_ptr<AbstractLQPNode>& /*lqp_root*/) const {
   Fail("Did not expect this function to be called.");
 }

--- a/src/lib/optimizer/strategy/null_scan_removal_rule.hpp
+++ b/src/lib/optimizer/strategy/null_scan_removal_rule.hpp
@@ -15,14 +15,14 @@ class PredicateNode;
 // It does not yet deal with IsNotNull predicates or cases where Is(Not)Null is nested within another expression.
 class NullScanRemovalRule : public AbstractRule {
  public:
-  void apply_to_plan(const std::shared_ptr<LogicalPlanRootNode>& root) const override;
+  IsCacheable apply_to_plan(const std::shared_ptr<LogicalPlanRootNode>& root) const override;
   std::string name() const override;
 
  private:
   static void _remove_nodes(const std::vector<std::shared_ptr<AbstractLQPNode>>& nodes);
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& /*lqp_root*/) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& /*lqp_root*/) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/predicate_merge_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_merge_rule.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include "abstract_rule.hpp"
 #include "expression/expression_functional.hpp"
 #include "logical_query_plan/abstract_lqp_node.hpp"
 #include "logical_query_plan/lqp_utils.hpp"
@@ -48,7 +49,8 @@ std::string PredicateMergeRule::name() const {
  * that are inputs to a merged subplan but do not necessarily belong to that subplan. When it becomes necessary, this
  * rule might be adapted to make more sophisticated decisions on which predicates to include.
  */
-void PredicateMergeRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
+IsCacheable PredicateMergeRule::_apply_to_plan_without_subqueries(
+    const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   Assert(lqp_root->type == LQPNodeType::Root, "PredicateMergeRule needs root to hold onto.");
 
   // (Potentially mergeable) subplans are identified by their topmost UnionNode. node_to_topmost holds a mapping from
@@ -113,6 +115,8 @@ void PredicateMergeRule::_apply_to_plan_without_subqueries(const std::shared_ptr
 
     node_queue.pop();
   }
+
+  return IsCacheable::Yes;
 }
 
 /**

--- a/src/lib/optimizer/strategy/predicate_merge_rule.hpp
+++ b/src/lib/optimizer/strategy/predicate_merge_rule.hpp
@@ -26,7 +26,7 @@ class PredicateMergeRule : public AbstractRule {
   size_t minimum_union_count{4};
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 
  private:
   void _merge_disjunction(const std::shared_ptr<UnionNode>& union_node) const;

--- a/src/lib/optimizer/strategy/predicate_placement_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.cpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include "abstract_rule.hpp"
 #include "cost_estimation/abstract_cost_estimator.hpp"
 #include "expression/abstract_expression.hpp"
 #include "expression/expression_utils.hpp"
@@ -28,7 +29,8 @@ std::string PredicatePlacementRule::name() const {
   return name;
 }
 
-void PredicatePlacementRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
+IsCacheable PredicatePlacementRule::_apply_to_plan_without_subqueries(
+    const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   // The traversal functions require the existence of a root of the LQP, so make sure we have that.
   const auto root_node = lqp_root->type == LQPNodeType::Root ? lqp_root : LogicalPlanRootNode::make(lqp_root);
 
@@ -39,6 +41,8 @@ void PredicatePlacementRule::_apply_to_plan_without_subqueries(const std::shared
   _push_down_traversal(root_node, LQPInputSide::Left, push_down_nodes, *estimator);
 
   _pull_up_traversal(root_node, LQPInputSide::Left);
+
+  return IsCacheable::Yes;
 }
 
 void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<AbstractLQPNode>& current_node,

--- a/src/lib/optimizer/strategy/predicate_placement_rule.hpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.hpp
@@ -26,7 +26,7 @@ class PredicatePlacementRule : public AbstractRule {
   std::string name() const override;
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 
  private:
   // Traverse the LQP and perform push downs of predicates.

--- a/src/lib/optimizer/strategy/predicate_reordering_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_reordering_rule.cpp
@@ -12,6 +12,7 @@
 #include "logical_query_plan/abstract_lqp_node.hpp"
 #include "logical_query_plan/join_node.hpp"
 #include "logical_query_plan/lqp_utils.hpp"
+#include "optimizer/strategy/abstract_rule.hpp"
 #include "statistics/cardinality_estimator.hpp"
 #include "types.hpp"
 
@@ -176,7 +177,7 @@ std::string PredicateReorderingRule::name() const {
   return name;
 }
 
-void PredicateReorderingRule::_apply_to_plan_without_subqueries(
+IsCacheable PredicateReorderingRule::_apply_to_plan_without_subqueries(
     const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   // We reorder recursively from leaves to root. Thus, the CardinalityEstimator may cache already estimated statistics.
   const auto caching_cost_estimator = cost_estimator->new_instance();
@@ -185,6 +186,8 @@ void PredicateReorderingRule::_apply_to_plan_without_subqueries(
   // We keep track of visited nodes, so that this rule touches nodes once only.
   auto visited_nodes = std::unordered_set<std::shared_ptr<AbstractLQPNode>>{};
   reorder_predicates_recursively(lqp_root, caching_cost_estimator, visited_nodes);
+
+  return IsCacheable::Yes;
 }
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/predicate_reordering_rule.hpp
+++ b/src/lib/optimizer/strategy/predicate_reordering_rule.hpp
@@ -41,7 +41,7 @@ class PredicateReorderingRule : public AbstractRule {
   constexpr static auto JOIN_PENALTY = 1.5f;
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/predicate_split_up_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_split_up_rule.cpp
@@ -7,6 +7,7 @@
 
 #include <boost/variant/apply_visitor.hpp>
 
+#include "abstract_rule.hpp"
 #include "expression/abstract_expression.hpp"
 #include "expression/binary_predicate_expression.hpp"
 #include "expression/expression_utils.hpp"
@@ -92,7 +93,8 @@ std::string PredicateSplitUpRule::name() const {
   return name;
 }
 
-void PredicateSplitUpRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
+IsCacheable PredicateSplitUpRule::_apply_to_plan_without_subqueries(
+    const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   Assert(lqp_root->type == LQPNodeType::Root, "PredicateSplitUpRule needs root to hold onto");
 
   auto predicate_nodes = std::vector<std::shared_ptr<PredicateNode>>{};
@@ -110,6 +112,8 @@ void PredicateSplitUpRule::_apply_to_plan_without_subqueries(const std::shared_p
       _split_disjunction(predicate_node);
     }
   }
+
+  return IsCacheable::Yes;
 }
 
 /**

--- a/src/lib/optimizer/strategy/predicate_split_up_rule.hpp
+++ b/src/lib/optimizer/strategy/predicate_split_up_rule.hpp
@@ -32,7 +32,7 @@ class PredicateSplitUpRule : public AbstractRule {
   std::string name() const override;
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 
  private:
   void _split_conjunction(const std::shared_ptr<PredicateNode>& predicate_node) const;

--- a/src/lib/optimizer/strategy/semi_join_reduction_rule.cpp
+++ b/src/lib/optimizer/strategy/semi_join_reduction_rule.cpp
@@ -5,6 +5,7 @@
 #include <tuple>
 #include <vector>
 
+#include "abstract_rule.hpp"
 #include "cost_estimation/abstract_cost_estimator.hpp"
 #include "expression/binary_predicate_expression.hpp"
 #include "expression/expression_utils.hpp"
@@ -22,7 +23,8 @@ std::string SemiJoinReductionRule::name() const {
   return name;
 }
 
-void SemiJoinReductionRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
+IsCacheable SemiJoinReductionRule::_apply_to_plan_without_subqueries(
+    const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   Assert(lqp_root->type == LQPNodeType::Root, "Rule needs root to hold onto.");
 
   // Adding semi joins inside visit_lqp might lead to endless recursions. Thus, we use visit_lqp to identify the
@@ -166,5 +168,7 @@ void SemiJoinReductionRule::_apply_to_plan_without_subqueries(const std::shared_
   for (const auto& [join_node, side_of_join, semi_join_reduction_node] : semi_join_reductions) {
     lqp_insert_node(join_node, side_of_join, semi_join_reduction_node, AllowRightInput::Yes);
   }
+
+  return IsCacheable::Yes;
 }
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/semi_join_reduction_rule.hpp
+++ b/src/lib/optimizer/strategy/semi_join_reduction_rule.hpp
@@ -55,7 +55,7 @@ class SemiJoinReductionRule : public AbstractRule {
   constexpr static auto MINIMUM_SELECTIVITY = .25;
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/stored_table_column_alignment_rule.cpp
+++ b/src/lib/optimizer/strategy/stored_table_column_alignment_rule.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/container_hash/hash.hpp>
 
+#include "abstract_rule.hpp"
 #include "logical_query_plan/abstract_lqp_node.hpp"
 #include "logical_query_plan/logical_plan_root_node.hpp"
 #include "logical_query_plan/lqp_utils.hpp"
@@ -111,7 +112,7 @@ std::string StoredTableColumnAlignmentRule::name() const {
  * The default implementation of this function optimizes a given LQP and all of its subquery LQPs individually.
  * However, as we do not want to align StoredTableNodes per plan but across all plans, we override it accordingly.
  */
-void StoredTableColumnAlignmentRule::apply_to_plan(const std::shared_ptr<LogicalPlanRootNode>& root_node) const {
+IsCacheable StoredTableColumnAlignmentRule::apply_to_plan(const std::shared_ptr<LogicalPlanRootNode>& root_node) const {
   // (1) Collect all plans
   auto lqps = std::vector<std::shared_ptr<AbstractLQPNode>>();
   lqps.emplace_back(std::static_pointer_cast<AbstractLQPNode>(root_node));
@@ -125,9 +126,11 @@ void StoredTableColumnAlignmentRule::apply_to_plan(const std::shared_ptr<Logical
 
   // (3) Align grouped StoredTableNodes
   align_pruned_column_ids(grouped_stored_table_nodes);
+
+  return IsCacheable::Yes;
 }
 
-void StoredTableColumnAlignmentRule::_apply_to_plan_without_subqueries(
+IsCacheable StoredTableColumnAlignmentRule::_apply_to_plan_without_subqueries(
     const std::shared_ptr<AbstractLQPNode>& /*lqp_root*/) const {
   Fail("Did not expect this function to be called.");
 }

--- a/src/lib/optimizer/strategy/stored_table_column_alignment_rule.hpp
+++ b/src/lib/optimizer/strategy/stored_table_column_alignment_rule.hpp
@@ -64,11 +64,11 @@ namespace hyrise {
 
 class StoredTableColumnAlignmentRule : public AbstractRule {
  public:
-  void apply_to_plan(const std::shared_ptr<LogicalPlanRootNode>& root_node) const override;
+  IsCacheable apply_to_plan(const std::shared_ptr<LogicalPlanRootNode>& root_node) const override;
   std::string name() const override;
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& /*lqp_root*/) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& /*lqp_root*/) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/subquery_to_join_rule.cpp
+++ b/src/lib/optimizer/strategy/subquery_to_join_rule.cpp
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include "abstract_rule.hpp"
 #include "expression/abstract_expression.hpp"
 #include "expression/abstract_predicate_expression.hpp"
 #include "expression/arithmetic_expression.hpp"
@@ -554,7 +555,8 @@ SubqueryToJoinRule::PredicatePullUpResult SubqueryToJoinRule::pull_up_correlated
   return pull_up_correlated_predicates_recursive(node, parameter_mapping, result_cache, false).first;
 }
 
-void SubqueryToJoinRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
+IsCacheable SubqueryToJoinRule::_apply_to_plan_without_subqueries(
+    const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   // While visiting the LQP, PredicateNodes might become replaced with JoinNodes. Instead of using recursion, we use
   // a node queue to schedule visitation of replaced/newly-inserted nodes.
   auto visited_nodes = std::unordered_set<std::shared_ptr<AbstractLQPNode>>{};
@@ -672,6 +674,8 @@ void SubqueryToJoinRule::_apply_to_plan_without_subqueries(const std::shared_ptr
       return LQPVisitation::DoNotVisitInputs;
     });
   }
+
+  return IsCacheable::Yes;
 }
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/subquery_to_join_rule.hpp
+++ b/src/lib/optimizer/strategy/subquery_to_join_rule.hpp
@@ -131,7 +131,7 @@ class SubqueryToJoinRule : public AbstractRule {
       const std::map<ParameterID, std::shared_ptr<AbstractExpression>>& parameter_mapping);
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/server/query_handler.cpp
+++ b/src/lib/server/query_handler.cpp
@@ -111,7 +111,7 @@ std::shared_ptr<AbstractOperator> QueryHandler::bind_prepared_plan(const Prepare
 
   auto lqp = prepared_plan->instantiate(parameter_expressions);
   const auto optimizer = Optimizer::create_default_optimizer();
-  lqp = optimizer->optimize(std::move(lqp));
+  lqp = optimizer->optimize(std::move(lqp)).first;
 
   auto pqp = LQPTranslator{}.translate_node(lqp);
 

--- a/src/lib/sql/sql_pipeline.cpp
+++ b/src/lib/sql/sql_pipeline.cpp
@@ -186,7 +186,7 @@ const std::vector<std::shared_ptr<AbstractLQPNode>>& SQLPipeline::get_optimized_
 
   _optimized_logical_plans.reserve(statement_count());
   for (auto& pipeline_statement : _sql_pipeline_statements) {
-    _optimized_logical_plans.emplace_back(pipeline_statement->get_optimized_logical_plan());
+    _optimized_logical_plans.emplace_back(pipeline_statement->get_optimized_logical_plan().first);
   }
 
   return _optimized_logical_plans;

--- a/src/lib/sql/sql_pipeline_statement.hpp
+++ b/src/lib/sql/sql_pipeline_statement.hpp
@@ -11,6 +11,7 @@
 #include "concurrency/transaction_context.hpp"
 #include "logical_query_plan/lqp_translator.hpp"
 #include "optimizer/optimizer.hpp"
+#include "optimizer/strategy/abstract_rule.hpp"
 #include "scheduler/abstract_task.hpp"
 #include "scheduler/job_task.hpp"
 #include "scheduler/operator_task.hpp"
@@ -77,8 +78,8 @@ class SQLPipelineStatement : public Noncopyable {
   // Returns information obtained during SQL parsing.
   const SQLTranslationInfo& get_sql_translation_info();
 
-  // Returns the optimized LQP for this statement.
-  const std::shared_ptr<AbstractLQPNode>& get_optimized_logical_plan();
+  // Returns the optimized LQP for this statement. TODO: make const
+  std::pair<std::shared_ptr<AbstractLQPNode>, IsCacheable>& get_optimized_logical_plan();
 
   // Returns the PQP for this statement.
   // The physical plan is either retrieved from the SQLPhysicalPlanCache or, if unavailable, translated from the
@@ -125,7 +126,7 @@ class SQLPipelineStatement : public Noncopyable {
   // Execution results
   std::shared_ptr<hsql::SQLParserResult> _parsed_sql_statement;
   std::shared_ptr<AbstractLQPNode> _unoptimized_logical_plan;
-  std::shared_ptr<AbstractLQPNode> _optimized_logical_plan;
+  std::pair<std::shared_ptr<AbstractLQPNode>, IsCacheable> _optimized_logical_plan;
   std::shared_ptr<AbstractOperator> _physical_plan;
 
   std::shared_ptr<OperatorTask> _root_operator_task;

--- a/src/test/lib/optimizer/strategy/between_composition_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/between_composition_rule_test.cpp
@@ -2,6 +2,7 @@
 #include <string>
 #include <vector>
 
+#include "expression/abstract_expression.hpp"
 #include "expression/expression_functional.hpp"
 #include "logical_query_plan/aggregate_node.hpp"
 #include "logical_query_plan/join_node.hpp"
@@ -446,6 +447,13 @@ TEST_F(BetweenCompositionRuleTest, HandleMultipleEqualExpressions) {
   _apply_rule(_rule, _lqp);
 
   EXPECT_LQP_EQ(_lqp, expected_lqp);
+}
+
+TEST_F(BetweenCompositionRuleTest, CheckCacheability) {
+  auto input_lqp = std::dynamic_pointer_cast<AbstractLQPNode>(
+      PredicateNode::make(equals_(_a_a, 100), PredicateNode::make(equals_(_a_b, 100), _node_a)));
+  const auto is_cacheable = _apply_rule(_rule, input_lqp);
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));
 }
 
 }  // namespace hyrise

--- a/src/test/lib/optimizer/strategy/column_pruning_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/column_pruning_rule_test.cpp
@@ -1,3 +1,6 @@
+#include <memory>
+
+#include "expression/abstract_expression.hpp"
 #include "expression/expression_functional.hpp"
 #include "logical_query_plan/aggregate_node.hpp"
 #include "logical_query_plan/change_meta_table_node.hpp"
@@ -451,6 +454,14 @@ TEST_F(ColumnPruningRuleTest, AnnotatePrunableJoinInput) {
       EXPECT_EQ(*join_node->prunable_input_side(), prunable_input_side);
     }
   }
+}
+
+TEST_F(ColumnPruningRuleTest, CheckCacheability) {
+  auto lqp = std::dynamic_pointer_cast<AbstractLQPNode>(
+      ExportNode::make("dummy.csv", FileType::Auto, PredicateNode::make(greater_than_(a, 5), node_abc)));
+
+  const auto is_cacheable = _apply_rule(rule, lqp);
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));
 }
 
 }  // namespace hyrise

--- a/src/test/lib/optimizer/strategy/dependent_group_by_reduction_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/dependent_group_by_reduction_rule_test.cpp
@@ -1,3 +1,4 @@
+#include <gtest/gtest.h>
 #include "expression/expression_functional.hpp"
 #include "logical_query_plan/aggregate_node.hpp"
 #include "logical_query_plan/join_node.hpp"
@@ -8,6 +9,7 @@
 #include "logical_query_plan/stored_table_node.hpp"
 #include "optimizer/strategy/dependent_group_by_reduction_rule.hpp"
 #include "strategy_base_test.hpp"
+#include "types.hpp"
 
 namespace hyrise {
 
@@ -85,7 +87,9 @@ TEST_F(DependentGroupByReductionRuleTest, SimpleCases) {
     _lqp = PredicateNode::make(equals_(column_a_0, 17), stored_table_node_a);
 
     const auto expected_lqp = _lqp->deep_copy();
-    _apply_rule(rule, _lqp);
+    const auto is_cacheable = _apply_rule(rule, _lqp);
+
+    EXPECT_TRUE(static_cast<bool>(is_cacheable));
     EXPECT_LQP_EQ(_lqp, expected_lqp);
   }
 
@@ -94,7 +98,9 @@ TEST_F(DependentGroupByReductionRuleTest, SimpleCases) {
     _lqp = AggregateNode::make(expression_vector(column_d_0), expression_vector(sum_(column_d_0)), stored_table_node_d);
 
     const auto expected_lqp = _lqp->deep_copy();
-    _apply_rule(rule, _lqp);
+    const auto is_cacheable = _apply_rule(rule, _lqp);
+
+    EXPECT_TRUE(static_cast<bool>(is_cacheable));
     EXPECT_LQP_EQ(_lqp, expected_lqp);
   }
 }
@@ -113,7 +119,9 @@ TEST_F(DependentGroupByReductionRuleTest, SingleKeyReduction) {
         stored_table_node_a));
     // clang-format on
 
-    _apply_rule(rule, _lqp);
+    const auto is_cacheable = _apply_rule(rule, _lqp);
+
+    EXPECT_TRUE(static_cast<bool>(is_cacheable));
     EXPECT_LQP_EQ(_lqp, expected_lqp);
   }
   {
@@ -128,8 +136,9 @@ TEST_F(DependentGroupByReductionRuleTest, SingleKeyReduction) {
         stored_table_node_a));
     // clang-format on
 
-    _apply_rule(rule, _lqp);
+    const auto is_cacheable = _apply_rule(rule, _lqp);
 
+    EXPECT_TRUE(static_cast<bool>(is_cacheable));
     EXPECT_LQP_EQ(_lqp, expected_lqp);
   }
 }
@@ -143,8 +152,9 @@ TEST_F(DependentGroupByReductionRuleTest, IncompleteKey) {
   // clang-format on
 
   const auto expected_lqp = _lqp->deep_copy();
-  _apply_rule(rule, _lqp);
+  const auto is_cacheable = _apply_rule(rule, _lqp);
 
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));
   EXPECT_LQP_EQ(_lqp, expected_lqp);
 }
 
@@ -157,8 +167,9 @@ TEST_F(DependentGroupByReductionRuleTest, FullKeyGroupBy) {
   // clang-format on
 
   const auto expected_lqp = _lqp->deep_copy();
-  _apply_rule(rule, _lqp);
+  const auto is_cacheable = _apply_rule(rule, _lqp);
 
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));
   EXPECT_LQP_EQ(_lqp, expected_lqp);
 }
 
@@ -175,8 +186,9 @@ TEST_F(DependentGroupByReductionRuleTest, FullInconsecutiveKeyGroupBy) {
       stored_table_node_c));
   // clang-format on
 
-  _apply_rule(rule, _lqp);
+  const auto is_cacheable = _apply_rule(rule, _lqp);
 
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));
   EXPECT_LQP_EQ(_lqp, expected_lqp);
 }
 
@@ -199,8 +211,9 @@ TEST_F(DependentGroupByReductionRuleTest, JoinSingleKeyPrimaryKey) {
         stored_table_node_b)));
   // clang-format on
 
-  _apply_rule(rule, _lqp);
+  const auto is_cacheable = _apply_rule(rule, _lqp);
 
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));
   EXPECT_LQP_EQ(_lqp, expected_lqp);
 }
 
@@ -237,8 +250,9 @@ TEST_F(DependentGroupByReductionRuleTest, AggregateButNoChanges) {
   // clang-format on
 
   const auto expected_lqp = _lqp->deep_copy();
-  _apply_rule(rule, _lqp);
+  const auto is_cacheable = _apply_rule(rule, _lqp);
 
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));
   EXPECT_LQP_EQ(_lqp, expected_lqp);
 }
 
@@ -256,8 +270,9 @@ TEST_F(DependentGroupByReductionRuleTest, SimpleAggregateFollowsAdaptedAggregate
       stored_table_node_a));
   // clang-format on
 
-  _apply_rule(rule, _lqp);
+  const auto is_cacheable = _apply_rule(rule, _lqp);
 
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));
   EXPECT_LQP_EQ(_lqp, expected_lqp);
 }
 
@@ -277,8 +292,9 @@ TEST_F(DependentGroupByReductionRuleTest, SortFollowsAggregate) {
         stored_table_node_a)));
   // clang-format on
 
-  _apply_rule(rule, _lqp);
+  const auto is_cacheable = _apply_rule(rule, _lqp);
 
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));
   EXPECT_LQP_EQ(_lqp, expected_lqp);
 }
 
@@ -293,8 +309,9 @@ TEST_F(DependentGroupByReductionRuleTest, NoAdaptionForNullableColumns) {
   // clang-format on
 
   const auto expected_lqp = _lqp->deep_copy();
-  _apply_rule(rule, _lqp);
+  const auto is_cacheable = _apply_rule(rule, _lqp);
 
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));  // Cacheable because rule was not applied.
   EXPECT_LQP_EQ(_lqp, expected_lqp);
 }
 
@@ -311,8 +328,9 @@ TEST_F(DependentGroupByReductionRuleTest, ShortConstraintsFirst) {
       stored_table_node_e));
   // clang-format on
 
-  _apply_rule(rule, _lqp);
+  const auto is_cacheable = _apply_rule(rule, _lqp);
 
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));  // Cacheable because used FD was derived from permanent UCC.
   EXPECT_LQP_EQ(_lqp, expected_lqp);
 }
 
@@ -342,8 +360,10 @@ TEST_F(DependentGroupByReductionRuleTest, MultiKeyReduction) {
       mock_node));
   // clang-format on
 
-  _apply_rule(rule, _lqp);
+  const auto is_cacheable = _apply_rule(rule, _lqp);
 
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));  // Cacheable because FD was explicitly constructed to be permanent in
+                                                 // this test.
   EXPECT_LQP_EQ(_lqp, expected_lqp);
 }
 
@@ -364,7 +384,9 @@ TEST_F(DependentGroupByReductionRuleTest, RemoveSuperfluousDistinctAggregateSimp
     stored_table_node_a->set_pruned_column_ids({ColumnID{1}, ColumnID{2}, ColumnID{3}});
 
     const auto expected_lqp = stored_table_node_a->deep_copy();
-    _apply_rule(rule, _lqp);
+    const auto is_cacheable = _apply_rule(rule, _lqp);
+
+    EXPECT_TRUE(static_cast<bool>(is_cacheable));
     EXPECT_LQP_EQ(_lqp, expected_lqp);
   }
 
@@ -382,7 +404,9 @@ TEST_F(DependentGroupByReductionRuleTest, RemoveSuperfluousDistinctAggregateSimp
       stored_table_node_a);
     // clang-format on
 
-    _apply_rule(rule, _lqp);
+    const auto is_cacheable = _apply_rule(rule, _lqp);
+
+    EXPECT_TRUE(static_cast<bool>(is_cacheable));
     EXPECT_LQP_EQ(_lqp, expected_lqp);
   }
 }
@@ -401,7 +425,9 @@ TEST_F(DependentGroupByReductionRuleTest, RemoveSuperfluousDistinctAggregateProj
       stored_table_node_a);
     // clang-format on
 
-    _apply_rule(rule, _lqp);
+    const auto is_cacheable = _apply_rule(rule, _lqp);
+
+    EXPECT_TRUE(static_cast<bool>(is_cacheable));
     EXPECT_LQP_EQ(_lqp, expected_lqp);
   }
 
@@ -418,7 +444,9 @@ TEST_F(DependentGroupByReductionRuleTest, RemoveSuperfluousDistinctAggregateProj
       stored_table_node_e);
     // clang-format on
 
-    _apply_rule(rule, _lqp);
+    const auto is_cacheable = _apply_rule(rule, _lqp);
+
+    EXPECT_TRUE(static_cast<bool>(is_cacheable));  // Cacheable because UCC used is permanent.
     EXPECT_LQP_EQ(_lqp, expected_lqp);
   }
 }
@@ -434,7 +462,9 @@ TEST_F(DependentGroupByReductionRuleTest, DoNotRemoveRequiredDistinctAggregate) 
     // clang-format on
 
     const auto expected_lqp = _lqp->deep_copy();
-    _apply_rule(rule, _lqp);
+    const auto is_cacheable = _apply_rule(rule, _lqp);
+
+    EXPECT_TRUE(static_cast<bool>(is_cacheable));
     EXPECT_LQP_EQ(_lqp, expected_lqp);
   }
 
@@ -447,7 +477,9 @@ TEST_F(DependentGroupByReductionRuleTest, DoNotRemoveRequiredDistinctAggregate) 
     // clang-format on
 
     const auto expected_lqp = _lqp->deep_copy();
-    _apply_rule(rule, _lqp);
+    const auto is_cacheable = _apply_rule(rule, _lqp);
+
+    EXPECT_TRUE(static_cast<bool>(is_cacheable));
     EXPECT_LQP_EQ(_lqp, expected_lqp);
   }
 }

--- a/src/test/lib/optimizer/strategy/dependent_group_by_reduction_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/dependent_group_by_reduction_rule_test.cpp
@@ -1,4 +1,3 @@
-#include <gtest/gtest.h>
 #include "expression/expression_functional.hpp"
 #include "logical_query_plan/aggregate_node.hpp"
 #include "logical_query_plan/join_node.hpp"
@@ -9,7 +8,6 @@
 #include "logical_query_plan/stored_table_node.hpp"
 #include "optimizer/strategy/dependent_group_by_reduction_rule.hpp"
 #include "strategy_base_test.hpp"
-#include "types.hpp"
 
 namespace hyrise {
 
@@ -311,7 +309,7 @@ TEST_F(DependentGroupByReductionRuleTest, NoAdaptionForNullableColumns) {
   const auto expected_lqp = _lqp->deep_copy();
   const auto is_cacheable = _apply_rule(rule, _lqp);
 
-  EXPECT_TRUE(static_cast<bool>(is_cacheable));  // Cacheable because rule was not applied.
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));
   EXPECT_LQP_EQ(_lqp, expected_lqp);
 }
 
@@ -330,7 +328,7 @@ TEST_F(DependentGroupByReductionRuleTest, ShortConstraintsFirst) {
 
   const auto is_cacheable = _apply_rule(rule, _lqp);
 
-  EXPECT_TRUE(static_cast<bool>(is_cacheable));  // Cacheable because used FD was derived from permanent UCC.
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));
   EXPECT_LQP_EQ(_lqp, expected_lqp);
 }
 
@@ -362,8 +360,7 @@ TEST_F(DependentGroupByReductionRuleTest, MultiKeyReduction) {
 
   const auto is_cacheable = _apply_rule(rule, _lqp);
 
-  EXPECT_TRUE(static_cast<bool>(is_cacheable));  // Cacheable because FD was explicitly constructed to be permanent in
-                                                 // this test.
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));
   EXPECT_LQP_EQ(_lqp, expected_lqp);
 }
 
@@ -446,7 +443,7 @@ TEST_F(DependentGroupByReductionRuleTest, RemoveSuperfluousDistinctAggregateProj
 
     const auto is_cacheable = _apply_rule(rule, _lqp);
 
-    EXPECT_TRUE(static_cast<bool>(is_cacheable));  // Cacheable because UCC used is permanent.
+    EXPECT_TRUE(static_cast<bool>(is_cacheable));
     EXPECT_LQP_EQ(_lqp, expected_lqp);
   }
 }

--- a/src/test/lib/optimizer/strategy/in_expression_rewrite_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/in_expression_rewrite_rule_test.cpp
@@ -1,3 +1,6 @@
+#include <memory>
+
+#include "expression/abstract_expression.hpp"
 #include "logical_query_plan/join_node.hpp"
 #include "logical_query_plan/predicate_node.hpp"
 #include "logical_query_plan/static_table_node.hpp"
@@ -393,4 +396,11 @@ TEST_F(InExpressionRewriteRuleTest, AutoStrategy) {
   }
 }
 
+TEST_F(InExpressionRewriteRuleTest, CheckCacheability) {
+  auto rule = std::make_shared<InExpressionRewriteRule>();
+  rule->strategy = InExpressionRewriteRule::Strategy::ExpressionEvaluator;
+  auto input_lqp = std::dynamic_pointer_cast<AbstractLQPNode>(PredicateNode::make(single_element_in_expression, node));
+  const auto is_cacheable = _apply_rule(rule, input_lqp);
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));
+}
 }  // namespace hyrise

--- a/src/test/lib/optimizer/strategy/index_scan_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/index_scan_rule_test.cpp
@@ -188,4 +188,13 @@ TEST_F(IndexScanRuleTest, NoIndexScanForSecondPredicate) {
   EXPECT_EQ(predicate_node->scan_type, ScanType::TableScan);
 }
 
+TEST_F(IndexScanRuleTest, CheckCacheability) {
+  auto predicate_node_0 = std::dynamic_pointer_cast<AbstractLQPNode>(PredicateNode::make(greater_than_(a, 10)));
+  predicate_node_0->set_left_input(stored_table_node);
+
+  EXPECT_EQ(std::dynamic_pointer_cast<PredicateNode>(predicate_node_0)->scan_type, ScanType::TableScan);
+  const auto is_cacheable = _apply_rule(rule, predicate_node_0);
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));
+}
+
 }  // namespace hyrise

--- a/src/test/lib/optimizer/strategy/join_to_predicate_rewrite_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/join_to_predicate_rewrite_rule_test.cpp
@@ -85,7 +85,7 @@ TEST_P(JoinToPredicateRewriteRuleJoinModeTest, PerformRewrite) {
   }
   const auto is_cacheable = _apply_rule(rule, _lqp);
 
-  EXPECT_TRUE(static_cast<bool>(is_cacheable)); // Cacheable because rule was not applied.
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));  // Cacheable because rule was not applied.
   EXPECT_LQP_EQ(_lqp, expected_lqp);
 }
 

--- a/src/test/lib/optimizer/strategy/join_to_predicate_rewrite_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/join_to_predicate_rewrite_rule_test.cpp
@@ -83,8 +83,9 @@ TEST_P(JoinToPredicateRewriteRuleJoinModeTest, PerformRewrite) {
   if (GetParam() != JoinMode::Inner && GetParam() != JoinMode::Semi) {
     expected_lqp = _lqp->deep_copy();
   }
-  _apply_rule(rule, _lqp);
+  const auto is_cacheable = _apply_rule(rule, _lqp);
 
+  EXPECT_TRUE(static_cast<bool>(is_cacheable)); // Cacheable because rule was not applied.
   EXPECT_LQP_EQ(_lqp, expected_lqp);
 }
 
@@ -106,7 +107,8 @@ TEST_F(JoinToPredicateRewriteRuleTest, MissingPredicate) {
   _apply_rule(std::make_shared<ColumnPruningRule>(), _lqp);
   const auto expected_lqp = _lqp->deep_copy();
 
-  _apply_rule(rule, _lqp);
+  const auto is_cacheable = _apply_rule(rule, _lqp);
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));  // Cacheable because rule was not applied.
   EXPECT_LQP_EQ(_lqp, expected_lqp);
 }
 
@@ -128,7 +130,8 @@ TEST_F(JoinToPredicateRewriteRuleTest, MissingUccOnPredicateColumn) {
   _apply_rule(std::make_shared<ColumnPruningRule>(), _lqp);
   const auto expected_lqp = _lqp->deep_copy();
 
-  _apply_rule(rule, _lqp);
+  const auto is_cacheable = _apply_rule(rule, _lqp);
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));  // Cacheable because rule was not applied.
   EXPECT_LQP_EQ(_lqp, expected_lqp);
 }
 
@@ -149,7 +152,8 @@ TEST_F(JoinToPredicateRewriteRuleTest, MissingUccOnJoinColumn) {
   _apply_rule(std::make_shared<ColumnPruningRule>(), _lqp);
   const auto expected_lqp = _lqp->deep_copy();
 
-  _apply_rule(rule, _lqp);
+  const auto is_cacheable = _apply_rule(rule, _lqp);
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));  // Cacheable because rule was not applied.
   EXPECT_LQP_EQ(_lqp, expected_lqp);
 }
 
@@ -172,7 +176,8 @@ TEST_F(JoinToPredicateRewriteRuleTest, NoUnusedJoinSide) {
   _apply_rule(std::make_shared<ColumnPruningRule>(), _lqp);
   const auto expected_lqp = _lqp->deep_copy();
 
-  _apply_rule(rule, _lqp);
+  const auto is_cacheable = _apply_rule(rule, _lqp);
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));  // Cacheable because rule was not applied.
   EXPECT_LQP_EQ(_lqp, expected_lqp);
 }
 
@@ -198,7 +203,8 @@ TEST_F(JoinToPredicateRewriteRuleTest, Union) {
   _apply_rule(std::make_shared<ColumnPruningRule>(), _lqp);
   const auto expected_lqp = _lqp->deep_copy();
 
-  _apply_rule(rule, _lqp);
+  const auto is_cacheable = _apply_rule(rule, _lqp);
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));  // Cacheable because rule was not applied.
   EXPECT_LQP_EQ(_lqp, expected_lqp);
 }
 

--- a/src/test/lib/optimizer/strategy/join_to_semi_join_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/join_to_semi_join_rule_test.cpp
@@ -15,6 +15,7 @@
 #include "optimizer/strategy/column_pruning_rule.hpp"
 #include "optimizer/strategy/join_to_semi_join_rule.hpp"
 #include "strategy_base_test.hpp"
+#include "types.hpp"
 
 namespace hyrise {
 
@@ -76,8 +77,9 @@ TEST_F(JoinToSemiJoinRuleTest, InnerJoinToSemiJoin) {
   // clang-format on
 
   static_cast<JoinNode&>(*_lqp->left_input()).mark_input_side_as_prunable(LQPInputSide::Right);
-  _apply_rule(rule, _lqp);
+  const auto is_cacheable = _apply_rule(rule, _lqp);
 
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));
   EXPECT_LQP_EQ(_lqp, expected_lqp);
 }
 
@@ -117,7 +119,9 @@ TEST_F(JoinToSemiJoinRuleTest, MultiPredicateInnerJoinToSemiJoinWithSingleEqui) 
   // clang-format on
 
   static_cast<JoinNode&>(*_lqp->left_input()).mark_input_side_as_prunable(LQPInputSide::Right);
-  _apply_rule(rule, _lqp);
+  const auto is_cacheable = _apply_rule(rule, _lqp);
+
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));  // Not cacheable because UCC used is not permanent.
 
   EXPECT_LQP_EQ(_lqp, expected_lqp);
 }
@@ -161,8 +165,9 @@ TEST_F(JoinToSemiJoinRuleTest, MultiPredicateInnerJoinToSemiJoinWithMultiEqui) {
   // clang-format on
 
   static_cast<JoinNode&>(*_lqp->left_input()).mark_input_side_as_prunable(LQPInputSide::Right);
-  _apply_rule(rule, _lqp);
+  const auto is_cacheable = _apply_rule(rule, _lqp);
 
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));  // Not cacheable because UCC used is not permanent.
   EXPECT_LQP_EQ(_lqp, expected_lqp);
 }
 
@@ -192,8 +197,9 @@ TEST_F(JoinToSemiJoinRuleTest, DoNotTouchInnerJoinWithNonEqui) {
 
   static_cast<JoinNode&>(*_lqp->left_input()).mark_input_side_as_prunable(LQPInputSide::Right);
   const auto expected_lqp = _lqp->deep_copy();
-  _apply_rule(rule, _lqp);
+  const auto is_cacheable = _apply_rule(rule, _lqp);
 
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));  // Cacheable because rule was not applied.
   EXPECT_LQP_EQ(_lqp, expected_lqp);
 }
 
@@ -222,8 +228,9 @@ TEST_F(JoinToSemiJoinRuleTest, DoNotTouchInnerJoinWithoutUcc) {
 
   static_cast<JoinNode&>(*_lqp->left_input()).mark_input_side_as_prunable(LQPInputSide::Right);
   const auto expected_lqp = _lqp->deep_copy();
-  _apply_rule(rule, _lqp);
+  const auto is_cacheable = _apply_rule(rule, _lqp);
 
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));  // Cacheable because rule was not applied.
   EXPECT_LQP_EQ(_lqp, expected_lqp);
 }
 
@@ -232,8 +239,8 @@ TEST_F(JoinToSemiJoinRuleTest, DoNotTouchInnerJoinWithoutMatchingUcc) {
    * Based on the InnerJoinToSemiJoin test.
    *
    * We define a multi-column UCC (column0, column1), but only a single Equals-predicate for the inner join
-   * (a == column0). Hence, the resulting unique column combination does not match the expressions of the single equals
-   * predicate and we should not see a semi join reformulation.
+   * `(a == column0)`. Hence, the resulting unique column combination does not match the expressions of the single
+   * equals predicate and we should not see a semi join reformulation.
    */
 
   {
@@ -262,8 +269,9 @@ TEST_F(JoinToSemiJoinRuleTest, DoNotTouchInnerJoinWithoutMatchingUcc) {
 
   static_cast<JoinNode&>(*_lqp->left_input()).mark_input_side_as_prunable(LQPInputSide::Right);
   const auto expected_lqp = _lqp->deep_copy();
-  _apply_rule(rule, _lqp);
+  const auto is_cacheable = _apply_rule(rule, _lqp);
 
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));  // Cacheable because rule was not applied.
   EXPECT_LQP_EQ(_lqp, expected_lqp);
 }
 
@@ -294,8 +302,9 @@ TEST_F(JoinToSemiJoinRuleTest, DoNotTouchNonInnerJoin) {
 
   static_cast<JoinNode&>(*_lqp->left_input()).mark_input_side_as_prunable(LQPInputSide::Right);
   const auto expected_lqp = _lqp->deep_copy();
-  _apply_rule(rule, _lqp);
+  const auto is_cacheable = _apply_rule(rule, _lqp);
 
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));  // Cacheable because rule was not applied.
   EXPECT_LQP_EQ(_lqp, expected_lqp);
 }
 

--- a/src/test/lib/optimizer/strategy/null_scan_removal_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/null_scan_removal_rule_test.cpp
@@ -1,3 +1,8 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "expression/abstract_expression.hpp"
 #include "expression/expression_functional.hpp"
 #include "logical_query_plan/lqp_utils.hpp"
 #include "logical_query_plan/predicate_node.hpp"
@@ -101,6 +106,13 @@ TEST_F(NullScanRemovalRuleTest, TableColumnDefinitionIsNotNullable) {
   _apply_rule(rule, _lqp);
 
   EXPECT_LQP_EQ(_lqp, expected_lqp);
+}
+
+TEST_F(NullScanRemovalRuleTest, CheckCacheability) {
+  auto input_lqp =
+      std::dynamic_pointer_cast<AbstractLQPNode>(PredicateNode::make(is_not_null_(table_node_column), table_node));
+  const auto is_cacheable = _apply_rule(rule, input_lqp);
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));
 }
 
 }  // namespace hyrise

--- a/src/test/lib/optimizer/strategy/predicate_merge_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/predicate_merge_rule_test.cpp
@@ -1,3 +1,6 @@
+#include <memory>
+
+#include "expression/abstract_expression.hpp"
 #include "expression/expression_functional.hpp"
 #include "logical_query_plan/join_node.hpp"
 #include "logical_query_plan/mock_node.hpp"
@@ -389,6 +392,12 @@ TEST_F(PredicateMergeRuleTest, NoRewriteDifferentSetOperationMode) {
   _apply_rule(rule, _lqp);
 
   EXPECT_LQP_EQ(_lqp, expected_lqp);
+}
+
+TEST_F(PredicateMergeRuleTest, CheckCacheability) {
+  auto input_lqp = std::dynamic_pointer_cast<AbstractLQPNode>(PredicateNode::make(less_than_(a_a, 10), node_a));
+  const auto is_cacheable = _apply_rule(rule, input_lqp);
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));
 }
 
 }  // namespace hyrise

--- a/src/test/lib/optimizer/strategy/predicate_placement_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/predicate_placement_rule_test.cpp
@@ -1,5 +1,6 @@
 #include <memory>
 
+#include "expression/abstract_expression.hpp"
 #include "expression/expression_functional.hpp"
 #include "logical_query_plan/aggregate_node.hpp"
 #include "logical_query_plan/join_node.hpp"
@@ -11,6 +12,7 @@
 #include "logical_query_plan/union_node.hpp"
 #include "logical_query_plan/update_node.hpp"
 #include "logical_query_plan/validate_node.hpp"
+#include "optimizer/strategy/abstract_rule.hpp"
 #include "optimizer/strategy/predicate_placement_rule.hpp"
 #include "strategy_base_test.hpp"
 #include "types.hpp"
@@ -989,6 +991,14 @@ TEST_F(PredicatePlacementRuleTest, DoNotMoveMultiPredicateSemiAndAntiJoins) {
 
     EXPECT_LQP_EQ(_lqp, expected_lqp);
   }
+}
+
+TEST_F(PredicatePlacementRuleTest, CheckCacheability) {
+  auto input_lqp = std::dynamic_pointer_cast<AbstractLQPNode>(PredicateNode::make(
+      or_(and_(equals_(_d_b, 1), equals_(_e_a, 10)), and_(equals_(_d_b, 2), equals_(_e_a, 1))),  // NOLINT
+      JoinNode::make(JoinMode::Left, equals_(_d_a, _e_a), _stored_table_d, _stored_table_e)));
+  const auto is_cacheable = _apply_rule(_rule, input_lqp);
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));
 }
 
 }  // namespace hyrise

--- a/src/test/lib/optimizer/strategy/predicate_reordering_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/predicate_reordering_rule_test.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "expression/abstract_expression.hpp"
 #include "expression/expression_functional.hpp"
 #include "logical_query_plan/join_node.hpp"
@@ -312,6 +314,13 @@ TEST_F(PredicateReorderingTest, PreferPredicatesOverJoins) {
 
   _apply_rule(_rule, _lqp);
   EXPECT_LQP_EQ(_lqp, expected_lqp);
+}
+
+TEST_F(PredicateReorderingTest, CheckCacheability) {
+  auto input_lqp =
+      std::dynamic_pointer_cast<AbstractLQPNode>(PredicateNode::make(greater_than_(a, 60), ValidateNode::make(node)));
+  const auto is_cacheable = _apply_rule(_rule, input_lqp);
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));
 }
 
 }  // namespace hyrise

--- a/src/test/lib/optimizer/strategy/predicate_split_up_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/predicate_split_up_rule_test.cpp
@@ -1,3 +1,6 @@
+#include <memory>
+
+#include "expression/abstract_expression.hpp"
 #include "expression/expression_functional.hpp"
 #include "logical_query_plan/join_node.hpp"
 #include "logical_query_plan/mock_node.hpp"
@@ -346,6 +349,12 @@ TEST_F(PredicateSplitUpRuleTest, NoRewriteSimplePredicate) {
   _apply_rule(rule, _lqp);
 
   EXPECT_LQP_EQ(_lqp, expected_lqp);
+}
+
+TEST_F(PredicateSplitUpRuleTest, CheckCacheability) {
+  auto input_lqp = std::dynamic_pointer_cast<AbstractLQPNode>(PredicateNode::make(less_than_(a_a, value_(10)), node_a));
+  const auto is_cacheable = _apply_rule(rule, input_lqp);
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));
 }
 
 }  // namespace hyrise

--- a/src/test/lib/optimizer/strategy/semi_join_reduction_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/semi_join_reduction_rule_test.cpp
@@ -1,3 +1,8 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "expression/abstract_expression.hpp"
 #include "logical_query_plan/join_node.hpp"
 #include "optimizer/strategy/semi_join_reduction_rule.hpp"
 #include "strategy_base_test.hpp"
@@ -222,6 +227,13 @@ TEST_F(SemiJoinReductionRuleTest, NoReductionForAntiJoin) {
 
   _apply_rule(_rule, _lqp);
   EXPECT_LQP_EQ(_lqp, expected_lqp);
+}
+
+TEST_F(SemiJoinReductionRuleTest, CheckCacheability) {
+  auto input_lqp = std::dynamic_pointer_cast<AbstractLQPNode>(
+      JoinNode::make(JoinMode::AntiNullAsTrue, equals_(_a_a, _b_a), _node_a, _node_b));
+  const auto is_cacheable = _apply_rule(_rule, input_lqp);
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));
 }
 
 }  // namespace hyrise

--- a/src/test/lib/optimizer/strategy/stored_table_column_alignment_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/stored_table_column_alignment_rule_test.cpp
@@ -1,3 +1,6 @@
+#include <memory>
+
+#include "expression/abstract_expression.hpp"
 #include "logical_query_plan/projection_node.hpp"
 #include "logical_query_plan/stored_table_node.hpp"
 #include "logical_query_plan/union_node.hpp"
@@ -106,6 +109,12 @@ TEST_F(StoredTableColumnAlignmentRuleTest, CoverSubqueries) {
   EXPECT_EQ(_stored_table_node_left->pruned_column_ids(), pruned_column_set_a);
   EXPECT_EQ(_stored_table_node_right->pruned_column_ids(), pruned_column_set_a);
   EXPECT_EQ(stn_subquery->pruned_column_ids(), pruned_column_set_a);
+}
+
+TEST_F(StoredTableColumnAlignmentRuleTest, CheckCacheability) {
+  auto _union_node_abstract = _union_node->deep_copy();
+  const auto is_cacheable = _apply_rule(_rule, _union_node_abstract);
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));
 }
 
 }  // namespace hyrise

--- a/src/test/lib/optimizer/strategy/strategy_base_test.cpp
+++ b/src/test/lib/optimizer/strategy/strategy_base_test.cpp
@@ -5,12 +5,14 @@
 #include "cost_estimation/cost_estimator_logical.hpp"
 #include "logical_query_plan/abstract_lqp_node.hpp"
 #include "logical_query_plan/logical_plan_root_node.hpp"
+#include "optimizer/optimizer.hpp"
 #include "optimizer/strategy/abstract_rule.hpp"
 #include "statistics/cardinality_estimator.hpp"
 
 namespace hyrise {
 
-void StrategyBaseTest::_apply_rule(const std::shared_ptr<AbstractRule>& rule, std::shared_ptr<AbstractLQPNode>& input) {
+IsCacheable StrategyBaseTest::_apply_rule(const std::shared_ptr<AbstractRule>& rule,
+                                          std::shared_ptr<AbstractLQPNode>& input) {
   // Make sure there is no reference to the input as an uncopied expected plan.
   Assert(input.use_count() == 1, "LQP is referenced multiple times. Did you mean to make a deep copy?");
 
@@ -23,7 +25,7 @@ void StrategyBaseTest::_apply_rule(const std::shared_ptr<AbstractRule>& rule, st
   const auto cost_estimator = std::make_shared<CostEstimatorLogical>(cardinality_estimator);
   rule->cost_estimator = cost_estimator;
 
-  rule->apply_to_plan(root_node);
+  const auto cacheable = rule->apply_to_plan(root_node);
 
   // The optimizer rules can remove the original input node completely from the plan, so we replace it by the top
   // LQPNode.
@@ -31,6 +33,8 @@ void StrategyBaseTest::_apply_rule(const std::shared_ptr<AbstractRule>& rule, st
 
   // Remove LogicalPlanRootNode.
   root_node->set_left_input(nullptr);
+
+  return cacheable;
 }
 
 }  // namespace hyrise

--- a/src/test/lib/optimizer/strategy/strategy_base_test.hpp
+++ b/src/test/lib/optimizer/strategy/strategy_base_test.hpp
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "base_test.hpp"
+#include "optimizer/strategy/abstract_rule.hpp"
 
 namespace hyrise {
 
@@ -25,7 +26,7 @@ class StrategyBaseTest : public BaseTest {
    * Always use `EXPECT_LQP_EQ(...);` rather than `EXPECT_EQ(...);` to compare LQPs: the first macro checks that both
    * LQPs are equivalent, the second macro checks that both point to the same instance.
    */
-  void _apply_rule(const std::shared_ptr<AbstractRule>& rule, std::shared_ptr<AbstractLQPNode>& input);
+  IsCacheable _apply_rule(const std::shared_ptr<AbstractRule>& rule, std::shared_ptr<AbstractLQPNode>& input);
 
   /**
    * We declare a member variable of the abstract class to account for rewrites that replace nodes with nodes of a

--- a/src/test/lib/optimizer/strategy/subquery_to_join_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/subquery_to_join_rule_test.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "expression/expression_functional.hpp"
 #include "expression/expression_utils.hpp"
 #include "expression/lqp_column_expression.hpp"
@@ -1553,6 +1555,12 @@ TEST_F(SubqueryToJoinRuleTest, ComplexArithmeticExpression) {
 
   _apply_rule(_rule, _lqp);
   EXPECT_LQP_EQ(_lqp, expected_lqp);
+}
+
+TEST_F(SubqueryToJoinRuleTest, CheckCacheability) {
+  auto input_lqp = std::dynamic_pointer_cast<AbstractLQPNode>(PredicateNode::make(in_(a_a, list_(1, 2, 3)), node_a));
+  const auto is_cacheable = _apply_rule(_rule, input_lqp);
+  EXPECT_TRUE(static_cast<bool>(is_cacheable));
 }
 
 }  // namespace hyrise

--- a/src/test/lib/sql/sql_pipeline_statement_test.cpp
+++ b/src/test/lib/sql/sql_pipeline_statement_test.cpp
@@ -1,6 +1,5 @@
 #include <memory>
 #include <string>
-#include <utility>
 
 #include "SQLParser.h"
 #include "SQLParserResult.h"
@@ -9,7 +8,6 @@
 #include "hyrise.hpp"
 #include "logical_query_plan/join_node.hpp"
 #include "operators/abstract_join_operator.hpp"
-#include "operators/print.hpp"
 #include "operators/validate.hpp"
 #include "scheduler/job_task.hpp"
 #include "scheduler/node_queue_scheduler.hpp"
@@ -40,6 +38,8 @@ class SQLPipelineStatementTest : public BaseTest {
  protected:
   void SetUp() override {
     _table_a = load_table("resources/test_data/tbl/int_float.tbl", ChunkOffset{2});
+    _table_a->add_soft_constraint(
+        TableKeyConstraint{{_table_a->column_id_by_name("a")}, KeyConstraintType::UNIQUE, CommitID{0}});
     Hyrise::get().storage_manager.add_table("table_a", _table_a);
 
     _table_b = load_table("resources/test_data/tbl/int_float2.tbl", ChunkOffset{2});
@@ -91,6 +91,8 @@ class SQLPipelineStatementTest : public BaseTest {
   std::shared_ptr<SQLPhysicalPlanCache> _pqp_cache;
 
   const std::string _select_query_a = "SELECT * FROM table_a";
+  const std::string _select_query_using_join_to_semi_join_optimization_a =
+      "SELECT table_b.a FROM table_a, table_b WHERE table_a.a = table_b.a";
   const std::string _invalid_sql = "SELECT FROM table_a";
   const std::string _join_query =
       "SELECT table_a.a, table_a.b, table_b.b AS bb FROM table_a, table_b WHERE table_a.a = table_b.a AND table_a.a "
@@ -250,7 +252,7 @@ TEST_F(SQLPipelineStatementTest, GetOptimizedLQP) {
   auto sql_pipeline = SQLPipelineBuilder{_join_query}.create_pipeline();
   auto statement = get_sql_pipeline_statements(sql_pipeline).at(0);
 
-  const auto& lqp = statement->get_optimized_logical_plan();
+  const auto& lqp = statement->get_optimized_logical_plan().first;
 
   EXPECT_FALSE(contained_in_lqp(lqp, contains_cross));
 }
@@ -260,7 +262,7 @@ TEST_F(SQLPipelineStatementTest, GetOptimizedLQPTwice) {
   auto statement = get_sql_pipeline_statements(sql_pipeline).at(0);
 
   statement->get_optimized_logical_plan();
-  const auto& lqp = statement->get_optimized_logical_plan();
+  const auto& lqp = statement->get_optimized_logical_plan().first;
 
   EXPECT_FALSE(contained_in_lqp(lqp, contains_cross));
 }
@@ -269,7 +271,7 @@ TEST_F(SQLPipelineStatementTest, GetOptimizedLQPValidated) {
   auto sql_pipeline = SQLPipelineBuilder{_select_query_a}.create_pipeline();
   auto statement = get_sql_pipeline_statements(sql_pipeline).at(0);
 
-  const auto& lqp = statement->get_optimized_logical_plan();
+  const auto& lqp = statement->get_optimized_logical_plan().first;
 
   // We did not need the context yet
   EXPECT_EQ(statement->transaction_context(), nullptr);
@@ -280,7 +282,7 @@ TEST_F(SQLPipelineStatementTest, GetOptimizedLQPNotValidated) {
   auto sql_pipeline = SQLPipelineBuilder{_select_query_a}.disable_mvcc().create_pipeline();
   auto statement = get_sql_pipeline_statements(sql_pipeline).at(0);
 
-  const auto& lqp = statement->get_optimized_logical_plan();
+  const auto& lqp = statement->get_optimized_logical_plan().first;
 
   // We did not need the context yet
   EXPECT_EQ(statement->transaction_context(), nullptr);
@@ -292,9 +294,9 @@ TEST_F(SQLPipelineStatementTest, GetCachedOptimizedLQPValidated) {
   EXPECT_FALSE(_lqp_cache->has(_select_query_a));
 
   auto validated_sql_pipeline = SQLPipelineBuilder{_select_query_a}.with_lqp_cache(_lqp_cache).create_pipeline();
-  auto& validated_statement = get_sql_pipeline_statements(validated_sql_pipeline).at(0);
+  const auto& validated_statement = get_sql_pipeline_statements(validated_sql_pipeline).at(0);
 
-  const auto& validated_lqp = validated_statement->get_optimized_logical_plan();
+  const auto& validated_lqp = validated_statement->get_optimized_logical_plan().first;
   EXPECT_TRUE(lqp_is_validated(validated_lqp));
 
   // Expect cache to contain validated LQP
@@ -305,8 +307,8 @@ TEST_F(SQLPipelineStatementTest, GetCachedOptimizedLQPValidated) {
   // Evict validated version by requesting a not validated version
   auto not_validated_sql_pipeline =
       SQLPipelineBuilder{_select_query_a}.with_lqp_cache(_lqp_cache).disable_mvcc().create_pipeline();
-  auto& not_validated_statement = get_sql_pipeline_statements(not_validated_sql_pipeline).at(0);
-  const auto& not_validated_lqp = not_validated_statement->get_optimized_logical_plan();
+  const auto& not_validated_statement = get_sql_pipeline_statements(not_validated_sql_pipeline).at(0);
+  const auto& not_validated_lqp = not_validated_statement->get_optimized_logical_plan().first;
   EXPECT_FALSE(lqp_is_validated(not_validated_lqp));
 
   // Expect cache to contain not validated LQP
@@ -316,28 +318,28 @@ TEST_F(SQLPipelineStatementTest, GetCachedOptimizedLQPValidated) {
 }
 
 TEST_F(SQLPipelineStatementTest, GetCachedOptimizedLQPNotValidated) {
-  // Expect cache to be empty
+  // Expect cache to be empty.
   EXPECT_FALSE(_lqp_cache->has(_select_query_a));
 
   auto not_validated_sql_pipeline =
       SQLPipelineBuilder{_select_query_a}.with_lqp_cache(_lqp_cache).disable_mvcc().create_pipeline();
-  auto& not_validated_statement = get_sql_pipeline_statements(not_validated_sql_pipeline).at(0);
+  const auto& not_validated_statement = get_sql_pipeline_statements(not_validated_sql_pipeline).at(0);
 
-  const auto& not_validated_lqp = not_validated_statement->get_optimized_logical_plan();
+  const auto& not_validated_lqp = not_validated_statement->get_optimized_logical_plan().first;
   EXPECT_FALSE(lqp_is_validated(not_validated_lqp));
 
-  // Expect cache to contain not validated LQP
+  // Expect cache to contain not validated LQP.
   EXPECT_TRUE(_lqp_cache->has(_select_query_a));
   const auto not_validated_cached_lqp = _lqp_cache->try_get(_select_query_a);
   EXPECT_FALSE(lqp_is_validated(*not_validated_cached_lqp));
 
-  // Evict not validated version by requesting a validated version
+  // Evict not validated version by requesting a validated version.
   auto validated_sql_pipeline = SQLPipelineBuilder{_select_query_a}.with_lqp_cache(_lqp_cache).create_pipeline();
-  auto& validated_statement = get_sql_pipeline_statements(validated_sql_pipeline).at(0);
-  const auto& validated_lqp = validated_statement->get_optimized_logical_plan();
+  const auto& validated_statement = get_sql_pipeline_statements(validated_sql_pipeline).at(0);
+  const auto& validated_lqp = validated_statement->get_optimized_logical_plan().first;
   EXPECT_TRUE(lqp_is_validated(validated_lqp));
 
-  // Expect cache to contain not validated LQP
+  // Expect cache to contain not validated LQP.
   EXPECT_TRUE(_lqp_cache->has(_select_query_a));
   const auto validated_cached_lqp = _lqp_cache->try_get(_select_query_a);
   EXPECT_TRUE(lqp_is_validated(*validated_cached_lqp));
@@ -353,7 +355,7 @@ TEST_F(SQLPipelineStatementTest, GetOptimizedLQPDoesNotInfluenceUnoptimizedLQP) 
   // Copy the structure to check that it is equal after optimizing.
   std::shared_ptr<AbstractLQPNode> unoptimized_copy = unoptimized_lqp->deep_copy();
 
-  // Optimize the LQP node
+  // Optimize the LQP node.
   statement->get_optimized_logical_plan();
   const auto& unoptimized_lqp_new = statement->get_unoptimized_logical_plan();
 


### PR DESCRIPTION
We only want Hyrise to cache query plans that will stay valid over time because using a (logical or physical) plan that becomes invalid could cause wrong results. Plans might turn invalid if they depend on temporary data patterns, like non-permanent UCCs found by the UccDiscoveryPlugin, or on related rules (FDs) based on those patterns. 

To avoid this, each optimization rule tells Hyrise whether the resulting plan is safe to store in the cache.

Note: This PR relies on #2599. We could also skip this and only depend on `master` but then #2600 would become messy because it relies on both cacheability information (this PR) and non-permanent UCCs (#2599).