### PR TITLE
Add concurrency control and utilities for (key) constraints of a table

### DIFF
--- a/src/lib/logical_query_plan/static_table_node.cpp
+++ b/src/lib/logical_query_plan/static_table_node.cpp
@@ -38,6 +38,7 @@ std::string StaticTableNode::description(const DescriptionMode /*mode*/) const {
     }
   }
 
+  const auto key_contraints_read_lock = table->acquire_constraints_read_mutex();
   if (!table->soft_key_constraints().empty()) {
     stream << ", ";
     print_table_key_constraints(table, stream);
@@ -65,6 +66,7 @@ std::vector<std::shared_ptr<AbstractExpression>> StaticTableNode::output_express
 UniqueColumnCombinations StaticTableNode::unique_column_combinations() const {
   // Generate from table key constraints.
   auto unique_column_combinations = UniqueColumnCombinations{};
+  const auto table_constraints_read_lock = table->acquire_constraints_read_mutex();
   const auto table_key_constraints = table->soft_key_constraints();
 
   for (const auto& table_key_constraint : table_key_constraints) {
@@ -90,6 +92,8 @@ size_t StaticTableNode::_on_shallow_hash() const {
   for (const auto& column_definition : table->column_definitions()) {
     boost::hash_combine(hash, column_definition.hash());
   }
+
+  const auto constraint_read_lock = table->acquire_constraints_read_mutex();
   const auto& soft_key_constraints = table->soft_key_constraints();
   for (const auto& table_key_constraint : soft_key_constraints) {
     // To make the hash independent of the expressions' order, we have to use a commutative operator like XOR.
@@ -105,6 +109,10 @@ std::shared_ptr<AbstractLQPNode> StaticTableNode::_on_shallow_copy(LQPNodeMappin
 
 bool StaticTableNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& /*node_mapping*/) const {
   const auto& static_table_node = static_cast<const StaticTableNode&>(rhs);
+
+  const auto lhs_constraint_read_lock = table->acquire_constraints_read_mutex();
+  const auto rhs_constraint_read_lock = static_table_node.table->acquire_constraints_read_mutex();
+
   return table->column_definitions() == static_table_node.table->column_definitions() &&
          table->soft_key_constraints() == static_table_node.table->soft_key_constraints();
 }

--- a/src/lib/operators/insert.cpp
+++ b/src/lib/operators/insert.cpp
@@ -144,8 +144,8 @@ std::shared_ptr<const Table> Insert::_on_execute(std::shared_ptr<TransactionCont
         const auto transaction_id = context->transaction_id();
         const auto end_offset = target_chunk->size() + num_rows_for_target_chunk;
         for (auto target_chunk_offset = target_chunk->size(); target_chunk_offset < end_offset; ++target_chunk_offset) {
-          DebugAssert(mvcc_data->get_begin_cid(target_chunk_offset) == MvccData::MAX_COMMIT_ID, "Invalid begin CID.");
-          DebugAssert(mvcc_data->get_end_cid(target_chunk_offset) == MvccData::MAX_COMMIT_ID, "Invalid end CID.");
+          DebugAssert(mvcc_data->get_begin_cid(target_chunk_offset) == MAX_COMMIT_ID, "Invalid begin CID.");
+          DebugAssert(mvcc_data->get_end_cid(target_chunk_offset) == MAX_COMMIT_ID, "Invalid end CID.");
           mvcc_data->set_tid(target_chunk_offset, transaction_id, std::memory_order_relaxed);
         }
       }

--- a/src/lib/operators/maintenance/create_table.cpp
+++ b/src/lib/operators/maintenance/create_table.cpp
@@ -56,6 +56,7 @@ std::string CreateTable::description(DescriptionMode description_mode) const {
     }
   }
 
+  const auto input_table_constraints_read_lock = input_table->acquire_constraints_read_mutex();
   if (!input_table->soft_key_constraints().empty()) {
     stream << separator;
     print_table_key_constraints(input_table, stream, separator);
@@ -79,6 +80,7 @@ std::shared_ptr<const Table> CreateTable::_on_execute(std::shared_ptr<Transactio
     const auto table = std::make_shared<Table>(column_definitions, TableType::Data, Chunk::DEFAULT_SIZE, UseMvcc::Yes);
     Hyrise::get().storage_manager.add_table(table_name, table);
 
+    const auto left_input_constraints_read_lock = _left_input->get_output()->acquire_constraints_read_mutex();
     for (const auto& table_key_constraint : _left_input->get_output()->soft_key_constraints()) {
       table->add_soft_constraint(table_key_constraint);
     }

--- a/src/lib/operators/print.cpp
+++ b/src/lib/operators/print.cpp
@@ -165,8 +165,8 @@ std::shared_ptr<const Table> Print::_on_execute() {
         auto end = mvcc_data->get_end_cid(chunk_offset);
         auto tid = mvcc_data->get_tid(chunk_offset);
 
-        auto begin_string = begin == MvccData::MAX_COMMIT_ID ? "" : std::to_string(begin);
-        auto end_string = end == MvccData::MAX_COMMIT_ID ? "" : std::to_string(end);
+        auto begin_string = begin == MAX_COMMIT_ID ? "" : std::to_string(begin);
+        auto end_string = end == MAX_COMMIT_ID ? "" : std::to_string(end);
         auto tid_string = tid == 0 ? "" : std::to_string(tid);
 
         _out << "|" << std::setw(6) << begin_string << std::setw(0);

--- a/src/lib/storage/chunk.cpp
+++ b/src/lib/storage/chunk.cpp
@@ -120,7 +120,7 @@ void Chunk::set_immutable() {
   DebugAssert(success, "Value exchanged but value was actually false.");
 
   // Only perform the `max_begin_cid` check if it has not already been set.
-  if (has_mvcc_data() && _mvcc_data->max_begin_cid.load() == MvccData::MAX_COMMIT_ID) {
+  if (has_mvcc_data() && _mvcc_data->max_begin_cid.load() == MAX_COMMIT_ID) {
     const auto chunk_size = size();
     Assert(chunk_size > 0, "`set_immutable()` should not be called on an empty chunk.");
     auto max_begin_cid = CommitID{0};
@@ -129,7 +129,7 @@ void Chunk::set_immutable() {
     }
     set_atomic_max(_mvcc_data->max_begin_cid, max_begin_cid);
 
-    Assert(_mvcc_data->max_begin_cid != MvccData::MAX_COMMIT_ID,
+    Assert(_mvcc_data->max_begin_cid != MAX_COMMIT_ID,
            "`max_begin_cid` should not be MAX_COMMIT_ID when marking a chunk as immutable.");
   }
 }

--- a/src/lib/storage/constraints/constraint_utils.cpp
+++ b/src/lib/storage/constraints/constraint_utils.cpp
@@ -1,5 +1,6 @@
 #include "constraint_utils.hpp"
 
+#include <cstdint>
 #include <memory>
 #include <set>
 #include <string>
@@ -76,6 +77,56 @@ void order_constraint(const std::shared_ptr<Table>& table, const std::vector<std
   auto ordered_column_ids = column_ids_by_name(table, ordered_columns);
 
   table->add_soft_constraint(TableOrderConstraint{std::move(ordering_column_ids), std::move(ordered_column_ids)});
+}
+
+bool is_constraint_confidently_valid(const std::shared_ptr<Table>& table,
+                                     const TableKeyConstraint& table_key_constraint) {
+  if (!table_key_constraint.can_become_invalid()) {
+    return true;
+  }
+
+  if (!table_key_constraint.last_validated_on() ||
+      (table_key_constraint.last_invalidated_on() &&
+       table_key_constraint.last_validated_on() < *table_key_constraint.last_invalidated_on())) {
+    return false;
+  }
+
+  const auto chunk_count = table->chunk_count();
+  // Due to Hyrise being a append-only database the most recent chunks are the last ones added to the table. Therefore
+  // we iterate backwards through all chunks of the table to potentially return faster.
+  for (auto prev_chunk_id = static_cast<int32_t>(chunk_count - 1); prev_chunk_id >= 0; --prev_chunk_id) {
+    const auto source_chunk = table->get_chunk(static_cast<ChunkID>(prev_chunk_id));
+
+    // We use `max_begin_cid` here. This can lead to overly pessimistic results, but as of right now we don't have a
+    // better way to determine the last valid commit id here.
+    const auto max_begin_cid = source_chunk->mvcc_data()->max_begin_cid.load();
+    if (max_begin_cid != MAX_COMMIT_ID && max_begin_cid > table_key_constraint.last_validated_on()) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool is_constraint_confidently_invalid(const std::shared_ptr<Table>& table,
+                                       const TableKeyConstraint& table_key_constraint) {
+  if (!table_key_constraint.last_invalidated_on()) {
+    return false;
+  }
+
+  const auto chunk_count = table->chunk_count();
+  // Due to Hyrise being a append-only database the most recent chunks are the last ones added to the table. Therefore
+  // we iterate backwards through all chunks of the table to potentially return faster.
+  for (auto prev_chunk_id = static_cast<int32_t>(chunk_count - 1); prev_chunk_id >= 0; --prev_chunk_id) {
+    const auto source_chunk = table->get_chunk(static_cast<ChunkID>(prev_chunk_id));
+
+    const auto max_end_cid = source_chunk->mvcc_data()->max_end_cid.load();
+    if (max_end_cid != MAX_COMMIT_ID && max_end_cid > table_key_constraint.last_invalidated_on()) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 }  // namespace hyrise

--- a/src/lib/storage/constraints/constraint_utils.hpp
+++ b/src/lib/storage/constraints/constraint_utils.hpp
@@ -5,13 +5,16 @@
 #include <string>
 #include <vector>
 
+#include "storage/constraints/table_key_constraint.hpp"
+
 namespace hyrise {
 
 class Table;
 
 /**
- * This file provides convenience helper functions to create and add constraints to tables. Besides improved
- * readability, these helper functions ensure that only column names from the correct tables are used.
+ * This file provides helper functions for creating constraints, adding them to tables, and verifying their validity. 
+ * Besides improving readability, these functions ensure that only column names from the correct tables are used and
+ * that constraints are guaranteed to be valid.
  *
  * Instead of:
  *   customer_table->add_soft_constraint(
@@ -35,5 +38,16 @@ void foreign_key_constraint(const std::shared_ptr<Table>& foreign_key_table,
 
 void order_constraint(const std::shared_ptr<Table>& table, const std::vector<std::string>& ordering_columns,
                       const std::vector<std::string>& ordered_columns);
+
+/**
+* Check if MVCC data tells us that the existing UCC is guaranteed to be still valid. To do this, we can simply check
+* if the table chunks have seen any inserts/deletions since the last validation of the UCC. This information is
+* contained in the MVCC data of the chunks.
+*/
+bool is_constraint_confidently_valid(const std::shared_ptr<Table>& table,
+                                     const TableKeyConstraint& table_key_constraint);
+
+bool is_constraint_confidently_invalid(const std::shared_ptr<Table>& table,
+                                       const TableKeyConstraint& table_key_constraint);
 
 }  // namespace hyrise

--- a/src/lib/storage/mvcc_data.hpp
+++ b/src/lib/storage/mvcc_data.hpp
@@ -17,9 +17,6 @@ struct MvccData {
   friend std::ostream& operator<<(std::ostream& stream, const MvccData& mvcc_data);
 
  public:
-  // The last commit id is reserved for uncommitted changes
-  static constexpr CommitID MAX_COMMIT_ID = CommitID{std::numeric_limits<CommitID::base_type>::max() - 1};
-
   // This is used for optimizing the validation process. It is set during `Chunk::set_immutable()` and for each
   // commit of an Insert/Delete operator. Consult `Validate::_on_execute()` for further details.
   std::atomic<CommitID> max_begin_cid{MAX_COMMIT_ID};

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -228,7 +228,7 @@ void Table::append_mutable_chunk() {
 
   auto mvcc_data = std::shared_ptr<MvccData>{};
   if (_use_mvcc == UseMvcc::Yes) {
-    mvcc_data = std::make_shared<MvccData>(_target_chunk_size, MvccData::MAX_COMMIT_ID);
+    mvcc_data = std::make_shared<MvccData>(_target_chunk_size, MAX_COMMIT_ID);
   }
 
   append_chunk(segments, mvcc_data);

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <shared_mutex>
 #include <string>
 #include <vector>
 
@@ -185,6 +186,9 @@ class Table : private Noncopyable {
 
   std::unique_lock<std::mutex> acquire_append_mutex();
 
+  std::unique_lock<std::shared_mutex> acquire_constraints_modify_mutex();
+  std::shared_lock<std::shared_mutex> acquire_constraints_read_mutex() const;
+
   /**
    * Tables, typically those stored in the StorageManager, can be associated with statistics to perform Cardinality
    * estimation during optimization.
@@ -210,8 +214,10 @@ class Table : private Noncopyable {
 
   /**
    * NOTE: constraints are currently NOT ENFORCED and are only used to develop optimization rules.
-   * We call them "soft" constraints to draw attention to that.
+   * We call them "soft" constraints to draw attention to that. The version with the`_unsafe` postfix does not acquire
+   * a write lock for the constraints of this table.
    */
+  void add_soft_constraint_unsafe(const AbstractTableConstraint& table_constraint);
   void add_soft_constraint(const AbstractTableConstraint& table_constraint);
 
   const TableKeyConstraints& soft_key_constraints() const;
@@ -274,6 +280,7 @@ class Table : private Noncopyable {
    */
   tbb::concurrent_vector<std::shared_ptr<Chunk>, ZeroAllocator<std::shared_ptr<Chunk>>> _chunks;
 
+  mutable std::shared_mutex _constraint_mutex{};
   TableKeyConstraints _table_key_constraints;
   TableOrderConstraints _table_order_constraints;
   ForeignKeyConstraints _foreign_key_constraints;

--- a/src/lib/tasks/chunk_compression_task.cpp
+++ b/src/lib/tasks/chunk_compression_task.cpp
@@ -51,7 +51,7 @@ bool ChunkCompressionTask::_chunk_is_completed(const std::shared_ptr<Chunk>& chu
     // TODO(anybody) Reading the non-atomic begin_cid (which is written to in Insert without a write lock) is likely UB
     //               When activating the ChunkCompressionTask, please look for a different means of determining whether
     //               all Inserts to a Chunk finished.
-    if (mvcc_data->get_begin_cid(chunk_offset) == MvccData::MAX_COMMIT_ID) {
+    if (mvcc_data->get_begin_cid(chunk_offset) == MAX_COMMIT_ID) {
       return false;
     }
   }

--- a/src/lib/types.hpp
+++ b/src/lib/types.hpp
@@ -135,6 +135,9 @@ constexpr CpuID INVALID_CPU_ID{std::numeric_limits<CpuID::base_type>::max()};
 constexpr WorkerID INVALID_WORKER_ID{std::numeric_limits<WorkerID::base_type>::max()};
 constexpr ColumnID INVALID_COLUMN_ID{std::numeric_limits<ColumnID::base_type>::max()};
 
+// The last commit id is reserved for uncommitted changes.
+constexpr CommitID MAX_COMMIT_ID = CommitID{std::numeric_limits<CommitID::base_type>::max() - 1};
+
 // TransactionID = 0 means "not set" in the MVCC data. This is the case if the row has (a) just been reserved, but not
 // yet filled with content, (b) been inserted, committed and not marked for deletion, or (c) inserted but deleted in
 // the same transaction (which has not yet committed)

--- a/src/lib/utils/atomic_max.hpp
+++ b/src/lib/utils/atomic_max.hpp
@@ -16,7 +16,7 @@ inline void set_atomic_max(std::atomic<T>& maximum_value, const T& value) noexce
 template <>
 inline void set_atomic_max(std::atomic<CommitID>& maximum_value, const CommitID& value) noexcept {
   auto prev_value = maximum_value.load();
-  while ((prev_value == MvccData::MAX_COMMIT_ID || prev_value < value) &&
+  while ((prev_value == MAX_COMMIT_ID || prev_value < value) &&
          !maximum_value.compare_exchange_weak(prev_value, value)) {}
 }
 

--- a/src/plugins/mvcc_delete_plugin.cpp
+++ b/src/plugins/mvcc_delete_plugin.cpp
@@ -82,7 +82,7 @@ void MvccDeletePlugin::_logical_delete_loop() {
         const auto chunk_size = chunk->size();
         for (auto chunk_offset = ChunkOffset{0}; chunk_offset < chunk_size; ++chunk_offset) {
           const auto commit_id = chunk->mvcc_data()->get_end_cid(chunk_offset);
-          if (commit_id != MvccData::MAX_COMMIT_ID && commit_id > highest_end_commit_id) {
+          if (commit_id != MAX_COMMIT_ID && commit_id > highest_end_commit_id) {
             highest_end_commit_id = commit_id;
           }
         }

--- a/src/test/lib/concurrency/stress_test.cpp
+++ b/src/test/lib/concurrency/stress_test.cpp
@@ -3,11 +3,14 @@
 #include <cmath>
 #include <future>
 #include <numeric>
+#include <optional>
 #include <thread>
 
+#include "../utils/plugin_test_utils.hpp"
 #include "base_test.hpp"
 #include "benchmark_config.hpp"
 #include "hyrise.hpp"
+#include "logical_query_plan/static_table_node.hpp"
 #include "operators/insert.hpp"
 #include "operators/table_wrapper.hpp"
 #include "operators/union_all.hpp"
@@ -15,11 +18,14 @@
 #include "scheduler/node_queue_scheduler.hpp"
 #include "scheduler/task_queue.hpp"
 #include "sql/sql_pipeline_builder.hpp"
+#include "storage/constraints/table_key_constraint.hpp"
 #include "storage/table.hpp"
 #include "storage/table_column_definition.hpp"
 #include "tpch/tpch_constants.hpp"
 #include "tpch/tpch_table_generator.hpp"
+#include "ucc_discovery_plugin.hpp"
 #include "utils/atomic_max.hpp"
+#include "utils/plugin_manager.hpp"
 
 namespace hyrise {
 
@@ -693,6 +699,78 @@ TEST_F(StressTest, VisibilityOfInsertsBeingRolledBack) {
       thread.join();
     }
   }
+}
+
+/**
+ * Check that adding, deleting and modifying a the TableKeyConstraints of a table concurrently does not lead to 
+ * deadlocks or inconsistencies (e.g. duplicate constraints)
+ */
+TEST_F(StressTest, AddRemoveModifyTableKeyConstraintsConcurrently) {
+  // Create a table with multiple TableKeyConstraints
+  auto table = std::make_shared<Table>(
+      TableColumnDefinitions{{"a", DataType::Int, false}, {"b", DataType::Int, false}, {"c", DataType::Int, false}},
+      TableType::Data, std::nullopt, UseMvcc::Yes);
+  table->add_soft_constraint(TableKeyConstraint{{ColumnID{0}}, KeyConstraintType::PRIMARY_KEY});
+
+  table->append({1, 1, 1});
+  table->append({2, 2, 2});
+  table->append({3, 3, 1});
+
+  Hyrise::get().storage_manager.add_table("dummy_table", table);
+
+  /** Run multiple modifications, deletions and additions concurrently that require locks:
+   * - `Table::delete_key_constraint`
+   * - `UccDiscoveryPlugin::_validate_ucc_candidates`
+   * - `StaticTableNode::unique_column_combinations`
+   * NOTE: We do not execute `Table::add_soft_constraint` because we do not have the knowledge whether or not the
+   * constraint already exists.
+   */
+
+  Hyrise::get().default_pqp_cache = std::make_shared<SQLPhysicalPlanCache>();
+  Hyrise::get().default_lqp_cache = std::make_shared<SQLLogicalPlanCache>();
+  auto& pm = Hyrise::get().plugin_manager;
+
+  pm.load_plugin(build_dylib_path("libhyriseUccDiscoveryPlugin"));
+  const auto validate_constraint = [&] {
+    // Populate the plan cache.
+    const std::string sql = "SELECT b,c FROM dummy_table GROUP BY b,c;";
+    auto pipeline = SQLPipelineBuilder{sql}.create_pipeline();
+    pipeline.get_result_table();
+
+    pm.exec_user_function("hyriseUccDiscoveryPlugin", "DiscoverUCCs");
+  };
+
+  const auto static_table_node_constraint_access = [&] {
+    const auto static_table_node = StaticTableNode::make(table);
+    // Simply access the unique column combinations to require a `shared_lock`.
+    static_table_node->unique_column_combinations();
+  };
+
+  // Start running the different modifications in parallel
+  const auto thread_count = 100;
+  auto threads = std::vector<std::thread>{};
+  threads.reserve(thread_count);
+
+  for (auto thread_id = uint32_t{0}; thread_id < thread_count; ++thread_id) {
+    switch (thread_id % 2) {
+      case 0:
+        threads.emplace_back(validate_constraint);
+        break;
+      case 1:
+        threads.emplace_back(static_table_node_constraint_access);
+        break;
+      default:
+        break;
+    }
+  }
+
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  // Check that the set of TableKeyConstraints does not contain any duplicates.
+  ASSERT_LE(table->soft_key_constraints().size(), 3);
+  ASSERT_GE(table->soft_key_constraints().size(), 1);
 }
 
 }  // namespace hyrise

--- a/src/test/lib/operators/delete_test.cpp
+++ b/src/test/lib/operators/delete_test.cpp
@@ -75,11 +75,11 @@ void OperatorsDeleteTest::helper(bool commit) {
     expected_end_cid = transaction_context->commit_id();
   } else {
     transaction_context->rollback(RollbackReason::User);
-    expected_end_cid = MvccData::MAX_COMMIT_ID;
+    expected_end_cid = MAX_COMMIT_ID;
   }
 
   EXPECT_EQ(_table->get_chunk(ChunkID{0})->mvcc_data()->get_end_cid(ChunkOffset{0}), expected_end_cid);
-  EXPECT_EQ(_table->get_chunk(ChunkID{0})->mvcc_data()->get_end_cid(ChunkOffset{1}), MvccData::MAX_COMMIT_ID);
+  EXPECT_EQ(_table->get_chunk(ChunkID{0})->mvcc_data()->get_end_cid(ChunkOffset{1}), MAX_COMMIT_ID);
   EXPECT_EQ(_table->get_chunk(ChunkID{0})->mvcc_data()->get_end_cid(ChunkOffset{2}), expected_end_cid);
 
   auto expected_tid = commit ? transaction_context->transaction_id() : 0u;
@@ -363,11 +363,11 @@ TEST_F(OperatorsDeleteTest, PrunedInputTable) {
   const auto expected_end_cid = transaction_context->commit_id();
   EXPECT_EQ(_table2->get_chunk(ChunkID{0})->mvcc_data()->get_end_cid(ChunkOffset{0}), expected_end_cid);
   EXPECT_EQ(_table2->get_chunk(ChunkID{0})->mvcc_data()->get_end_cid(ChunkOffset{1}), expected_end_cid);
-  EXPECT_EQ(_table2->get_chunk(ChunkID{0})->mvcc_data()->get_end_cid(ChunkOffset{2}), MvccData::MAX_COMMIT_ID);
-  EXPECT_EQ(_table2->get_chunk(ChunkID{1})->mvcc_data()->get_end_cid(ChunkOffset{0}), MvccData::MAX_COMMIT_ID);
-  EXPECT_EQ(_table2->get_chunk(ChunkID{1})->mvcc_data()->get_end_cid(ChunkOffset{1}), MvccData::MAX_COMMIT_ID);
-  EXPECT_EQ(_table2->get_chunk(ChunkID{1})->mvcc_data()->get_end_cid(ChunkOffset{2}), MvccData::MAX_COMMIT_ID);
-  EXPECT_EQ(_table2->get_chunk(ChunkID{2})->mvcc_data()->get_end_cid(ChunkOffset{0}), MvccData::MAX_COMMIT_ID);
+  EXPECT_EQ(_table2->get_chunk(ChunkID{0})->mvcc_data()->get_end_cid(ChunkOffset{2}), MAX_COMMIT_ID);
+  EXPECT_EQ(_table2->get_chunk(ChunkID{1})->mvcc_data()->get_end_cid(ChunkOffset{0}), MAX_COMMIT_ID);
+  EXPECT_EQ(_table2->get_chunk(ChunkID{1})->mvcc_data()->get_end_cid(ChunkOffset{1}), MAX_COMMIT_ID);
+  EXPECT_EQ(_table2->get_chunk(ChunkID{1})->mvcc_data()->get_end_cid(ChunkOffset{2}), MAX_COMMIT_ID);
+  EXPECT_EQ(_table2->get_chunk(ChunkID{2})->mvcc_data()->get_end_cid(ChunkOffset{0}), MAX_COMMIT_ID);
   EXPECT_EQ(_table2->get_chunk(ChunkID{2})->mvcc_data()->get_end_cid(ChunkOffset{1}), expected_end_cid);
 }
 
@@ -385,7 +385,7 @@ TEST_F(OperatorsDeleteTest, SetMaxEndCID) {
 
   const auto& chunk = _table->get_chunk(ChunkID{0});
   ASSERT_TRUE(chunk->mvcc_data());
-  EXPECT_EQ(chunk->mvcc_data()->max_end_cid.load(), MvccData::MAX_COMMIT_ID);
+  EXPECT_EQ(chunk->mvcc_data()->max_end_cid.load(), MAX_COMMIT_ID);
 
   transaction_context->commit();
 
@@ -441,7 +441,7 @@ TEST_F(OperatorsDeleteTest, DifferentPosLists) {
   const auto& mvcc_data_1 = _table3->get_chunk(ChunkID{0})->mvcc_data();
   EXPECT_EQ(mvcc_data_1->get_end_cid(ChunkOffset{0}), expected_end_cid);
   EXPECT_EQ(mvcc_data_1->get_end_cid(ChunkOffset{1}), expected_end_cid);
-  EXPECT_EQ(mvcc_data_1->get_end_cid(ChunkOffset{2}), MvccData::MAX_COMMIT_ID);
+  EXPECT_EQ(mvcc_data_1->get_end_cid(ChunkOffset{2}), MAX_COMMIT_ID);
   EXPECT_EQ(mvcc_data_1->max_end_cid.load(), expected_end_cid);
   EXPECT_EQ(_table3->get_chunk(ChunkID{0})->invalid_row_count(), 2);
 
@@ -455,14 +455,14 @@ TEST_F(OperatorsDeleteTest, DifferentPosLists) {
   const auto& mvcc_data_3 = _table3->get_chunk(ChunkID{2})->mvcc_data();
   EXPECT_EQ(mvcc_data_3->get_end_cid(ChunkOffset{0}), expected_end_cid);
   EXPECT_EQ(mvcc_data_3->get_end_cid(ChunkOffset{1}), expected_end_cid);
-  EXPECT_EQ(mvcc_data_3->get_end_cid(ChunkOffset{2}), MvccData::MAX_COMMIT_ID);
+  EXPECT_EQ(mvcc_data_3->get_end_cid(ChunkOffset{2}), MAX_COMMIT_ID);
   EXPECT_EQ(mvcc_data_3->max_end_cid.load(), expected_end_cid);
   EXPECT_EQ(_table3->get_chunk(ChunkID{2})->invalid_row_count(), 2);
 
   const auto& mvcc_data_4 = _table3->get_chunk(ChunkID{3})->mvcc_data();
   EXPECT_EQ(mvcc_data_4->get_end_cid(ChunkOffset{0}), expected_end_cid);
-  EXPECT_EQ(mvcc_data_4->get_end_cid(ChunkOffset{1}), MvccData::MAX_COMMIT_ID);
-  EXPECT_EQ(mvcc_data_4->get_end_cid(ChunkOffset{2}), MvccData::MAX_COMMIT_ID);
+  EXPECT_EQ(mvcc_data_4->get_end_cid(ChunkOffset{1}), MAX_COMMIT_ID);
+  EXPECT_EQ(mvcc_data_4->get_end_cid(ChunkOffset{2}), MAX_COMMIT_ID);
   EXPECT_EQ(mvcc_data_4->max_end_cid.load(), expected_end_cid);
   EXPECT_EQ(_table3->get_chunk(ChunkID{3})->invalid_row_count(), 1);
 
@@ -476,7 +476,7 @@ TEST_F(OperatorsDeleteTest, DifferentPosLists) {
   const auto& mvcc_data_6 = _table3->get_chunk(ChunkID{5})->mvcc_data();
   EXPECT_EQ(mvcc_data_6->get_end_cid(ChunkOffset{0}), expected_end_cid);
   EXPECT_EQ(mvcc_data_6->get_end_cid(ChunkOffset{1}), expected_end_cid);
-  EXPECT_EQ(mvcc_data_6->get_end_cid(ChunkOffset{2}), MvccData::MAX_COMMIT_ID);
+  EXPECT_EQ(mvcc_data_6->get_end_cid(ChunkOffset{2}), MAX_COMMIT_ID);
   EXPECT_EQ(mvcc_data_6->max_end_cid.load(), expected_end_cid);
   EXPECT_EQ(_table3->get_chunk(ChunkID{5})->invalid_row_count(), 2);
 
@@ -487,9 +487,9 @@ TEST_F(OperatorsDeleteTest, DifferentPosLists) {
     const auto chunk_size = chunk->size();
 
     for (auto chunk_offset = ChunkOffset{0}; chunk_offset < chunk_size; ++chunk_offset) {
-      EXPECT_EQ(mvcc_data->get_end_cid(chunk_offset), MvccData::MAX_COMMIT_ID);
+      EXPECT_EQ(mvcc_data->get_end_cid(chunk_offset), MAX_COMMIT_ID);
     }
-    EXPECT_EQ(mvcc_data->max_end_cid.load(), MvccData::MAX_COMMIT_ID);
+    EXPECT_EQ(mvcc_data->max_end_cid.load(), MAX_COMMIT_ID);
     EXPECT_EQ(_table3->get_chunk(chunk_id)->invalid_row_count(), 0);
   }
 }

--- a/src/test/lib/operators/insert_test.cpp
+++ b/src/test/lib/operators/insert_test.cpp
@@ -346,7 +346,7 @@ TEST_F(OperatorsInsertTest, SetMaxBeginCID) {
 
   const auto& chunk = target_table->get_chunk(ChunkID{0});
   ASSERT_TRUE(chunk->mvcc_data());
-  EXPECT_EQ(chunk->mvcc_data()->max_begin_cid.load(), MvccData::MAX_COMMIT_ID);
+  EXPECT_EQ(chunk->mvcc_data()->max_begin_cid.load(), MAX_COMMIT_ID);
 
   context->commit();
 

--- a/src/test/lib/operators/validate_test.cpp
+++ b/src/test/lib/operators/validate_test.cpp
@@ -66,7 +66,7 @@ void OperatorsValidateTest::set_all_records_visible(Table& table) {
     const auto chunk_size = chunk->size();
     for (auto index = ChunkOffset{0}; index < chunk_size; ++index) {
       mvcc_data->set_begin_cid(index, CommitID{0});
-      mvcc_data->set_end_cid(index, MvccData::MAX_COMMIT_ID);
+      mvcc_data->set_end_cid(index, MAX_COMMIT_ID);
     }
   }
 }

--- a/src/test/lib/sql/sql_pipeline_test.cpp
+++ b/src/test/lib/sql/sql_pipeline_test.cpp
@@ -441,15 +441,15 @@ TEST_F(SQLPipelineTest, UpdateWithTransactionFailure) {
 
   // No row should have been touched
   EXPECT_EQ(first_chunk_mvcc_data->get_tid(ChunkOffset{0}), TransactionID{0});
-  EXPECT_EQ(first_chunk_mvcc_data->get_end_cid(ChunkOffset{0}), MvccData::MAX_COMMIT_ID);
+  EXPECT_EQ(first_chunk_mvcc_data->get_end_cid(ChunkOffset{0}), MAX_COMMIT_ID);
 
   EXPECT_EQ(first_chunk_mvcc_data->get_tid(ChunkOffset{1}), TransactionID{17});
-  EXPECT_EQ(first_chunk_mvcc_data->get_end_cid(ChunkOffset{1}), MvccData::MAX_COMMIT_ID);
+  EXPECT_EQ(first_chunk_mvcc_data->get_end_cid(ChunkOffset{1}), MAX_COMMIT_ID);
 
   auto second_chunk_mvcc_data = _table_a->get_chunk(ChunkID{1})->mvcc_data();
 
   EXPECT_EQ(second_chunk_mvcc_data->get_tid(ChunkOffset{0}), TransactionID{0});
-  EXPECT_EQ(second_chunk_mvcc_data->get_end_cid(ChunkOffset{0}), MvccData::MAX_COMMIT_ID);
+  EXPECT_EQ(second_chunk_mvcc_data->get_end_cid(ChunkOffset{0}), MAX_COMMIT_ID);
 }
 
 TEST_F(SQLPipelineTest, UpdateWithTransactionFailureAutoCommit) {
@@ -476,13 +476,13 @@ TEST_F(SQLPipelineTest, UpdateWithTransactionFailureAutoCommit) {
 
   // This row was being modified by a different transaction, so it should not have been touched
   EXPECT_EQ(first_chunk_mvcc_data->get_tid(ChunkOffset{1}), TransactionID{17});
-  EXPECT_EQ(first_chunk_mvcc_data->get_end_cid(ChunkOffset{1}), MvccData::MAX_COMMIT_ID);
+  EXPECT_EQ(first_chunk_mvcc_data->get_end_cid(ChunkOffset{1}), MAX_COMMIT_ID);
 
   // We had to abort before we got to the third statement
   auto second_chunk_mvcc_data = _table_a->get_chunk(ChunkID{1})->mvcc_data();
 
   EXPECT_EQ(second_chunk_mvcc_data->get_tid(ChunkOffset{0}), TransactionID{0});
-  EXPECT_EQ(second_chunk_mvcc_data->get_end_cid(ChunkOffset{0}), MvccData::MAX_COMMIT_ID);
+  EXPECT_EQ(second_chunk_mvcc_data->get_end_cid(ChunkOffset{0}), MAX_COMMIT_ID);
 }
 
 TEST_F(SQLPipelineTest, GetTimes) {

--- a/src/test/lib/storage/constraints/constraint_utils_test.cpp
+++ b/src/test/lib/storage/constraints/constraint_utils_test.cpp
@@ -1,4 +1,7 @@
+#include <gtest/gtest.h>
+
 #include <memory>
+#include <optional>
 #include <set>
 #include <string>
 #include <utility>
@@ -9,7 +12,9 @@
 #include "storage/constraints/foreign_key_constraint.hpp"
 #include "storage/constraints/table_key_constraint.hpp"
 #include "storage/constraints/table_order_constraint.hpp"
+#include "storage/mvcc_data.hpp"
 #include "storage/table.hpp"
+#include "storage/table_column_definition.hpp"
 #include "types.hpp"
 
 namespace hyrise {
@@ -23,7 +28,8 @@ class ConstraintUtilsTest : public BaseTest {
                                           {"d", DataType::Int, false},
                                           {"e", DataType::Int, false},
                                           {"f", DataType::Int, false}});
-    _table_b = Table::create_dummy_table({{"x", DataType::Int, false}, {"y", DataType::Int, false}});
+    _table_b = std::make_shared<Table>(TableColumnDefinitions{{"x", DataType::Int, false}, {"y", DataType::Int, false}},
+                                       TableType::Data, std::nullopt, UseMvcc::Yes);
   }
 
   std::shared_ptr<Table> _table_a;
@@ -126,6 +132,42 @@ TEST_F(ConstraintUtilsTest, TableOrderConstraint) {
   EXPECT_THROW(order_constraint(_table_a, {"e", "a"}, {"c", "d"}), std::logic_error);
   EXPECT_THROW(order_constraint(_table_a, {"a", "b"}, {"e", "c"}), std::logic_error);
   EXPECT_THROW(order_constraint(_table_a, {"a", "b"}, {"c", "e"}), std::logic_error);
+}
+
+TEST_F(ConstraintUtilsTest, CheckIfTableKeyConstraintIsKnownToBeValid) {
+  EXPECT_TRUE(is_constraint_confidently_valid(_table_b, {{ColumnID{0}}, KeyConstraintType::PRIMARY_KEY}));
+  EXPECT_TRUE(is_constraint_confidently_valid(_table_b, {{ColumnID{1}}, KeyConstraintType::UNIQUE, CommitID{0}}));
+
+  EXPECT_FALSE(is_constraint_confidently_valid(_table_b, {{ColumnID{1}}, KeyConstraintType::UNIQUE, {}, CommitID{0}}));
+
+  // Manually modify the max_begin_cid of the chunk to simulate an insert to the table.
+  _table_b->get_chunk(ChunkID{0})->mvcc_data()->max_begin_cid = CommitID{1};
+
+  // The first constraint is permanent and therefore valid, the second was verified on a previous CommitID so we do not
+  // know whether or not it is still valid and the last constraint has a CommmitID that is up-to-date and is therefore
+  // certainly valid.
+  EXPECT_TRUE(is_constraint_confidently_valid(_table_b, {{ColumnID{0}}, KeyConstraintType::PRIMARY_KEY}));
+  EXPECT_FALSE(is_constraint_confidently_valid(_table_b, {{ColumnID{1}}, KeyConstraintType::UNIQUE, CommitID{0}}));
+  EXPECT_FALSE(
+      is_constraint_confidently_valid(_table_b, {{ColumnID{1}}, KeyConstraintType::UNIQUE, CommitID{0}, CommitID{1}}));
+}
+
+TEST_F(ConstraintUtilsTest, CheckIfTableKeyConstraintIsKnownToBeInvalid) {
+  EXPECT_FALSE(
+      is_constraint_confidently_invalid(_table_b, {{ColumnID{0}}, KeyConstraintType::PRIMARY_KEY, CommitID{0}, {}}));
+  EXPECT_TRUE(is_constraint_confidently_invalid(_table_b, {{ColumnID{1}}, KeyConstraintType::UNIQUE, {}, CommitID{0}}));
+
+  // Manually modify the max_end_cid of the chunk to simulate a delete to the table.
+  _table_b->get_chunk(ChunkID{0})->mvcc_data()->max_end_cid = CommitID{1};
+
+  // The first constraint is permanent and therefore NOT confidently invalid, the second was never verified but only
+  // invalidated on a CommitID prior to the deletion so it is also NOT confidently invalid and the last constraint was
+  // invalidated on a CommitID that is up-to-date and therefore certainly invalid.
+  EXPECT_FALSE(is_constraint_confidently_invalid(_table_b, {{ColumnID{0}}, KeyConstraintType::PRIMARY_KEY}));
+  EXPECT_FALSE(
+      is_constraint_confidently_invalid(_table_b, {{ColumnID{1}}, KeyConstraintType::UNIQUE, {}, CommitID{0}}));
+  EXPECT_TRUE(is_constraint_confidently_invalid(_table_b,
+                                                {{ColumnID{1}}, KeyConstraintType::UNIQUE, CommitID{0}, CommitID{1}}));
 }
 
 }  // namespace hyrise

--- a/src/test/lib/storage/constraints/constraint_utils_test.cpp
+++ b/src/test/lib/storage/constraints/constraint_utils_test.cpp
@@ -141,6 +141,7 @@ TEST_F(ConstraintUtilsTest, CheckIfTableKeyConstraintIsKnownToBeValid) {
   EXPECT_FALSE(is_constraint_confidently_valid(_table_b, {{ColumnID{1}}, KeyConstraintType::UNIQUE, {}, CommitID{0}}));
 
   // Manually modify the max_begin_cid of the chunk to simulate an insert to the table.
+  _table_b->append({0, 1});
   _table_b->get_chunk(ChunkID{0})->mvcc_data()->max_begin_cid = CommitID{1};
 
   // The first constraint is permanent and therefore valid, the second was verified on a previous CommitID so we do not
@@ -158,6 +159,7 @@ TEST_F(ConstraintUtilsTest, CheckIfTableKeyConstraintIsKnownToBeInvalid) {
   EXPECT_TRUE(is_constraint_confidently_invalid(_table_b, {{ColumnID{1}}, KeyConstraintType::UNIQUE, {}, CommitID{0}}));
 
   // Manually modify the max_end_cid of the chunk to simulate a delete to the table.
+  _table_b->append({0, 1});
   _table_b->get_chunk(ChunkID{0})->mvcc_data()->max_end_cid = CommitID{1};
 
   // The first constraint is permanent and therefore NOT confidently invalid, the second was never verified but only

--- a/src/test/lib/storage/constraints/table_key_constraint_test.cpp
+++ b/src/test/lib/storage/constraints/table_key_constraint_test.cpp
@@ -177,4 +177,12 @@ TEST_F(TableKeyConstraintTest, OrderIndependence) {
   EXPECT_EQ(*std::next(key_constraints_a.begin()), *std::next(key_constraints_b.begin()));
 }
 
+TEST_F(TableKeyConstraintTest, CanBecomeInvalid) {
+  const auto key_constraint_invalid = TableKeyConstraint{{ColumnID{0}}, KeyConstraintType::UNIQUE, CommitID{0}};
+  const auto key_constraint_valid = TableKeyConstraint{{ColumnID{0}}, KeyConstraintType::UNIQUE};
+
+  EXPECT_TRUE(key_constraint_invalid.can_become_invalid());
+  EXPECT_FALSE(key_constraint_valid.can_become_invalid());
+}
+
 }  // namespace hyrise

--- a/src/test/lib/storage/mvcc_data_test.cpp
+++ b/src/test/lib/storage/mvcc_data_test.cpp
@@ -43,7 +43,7 @@ TEST_F(MvccDataTest, GetCIDsAndTIDs) {
   EXPECT_EQ(_mvcc_data->get_tid(ChunkOffset{1}), TransactionID{1});
 
   EXPECT_EQ(_mvcc_data->get_begin_cid(ChunkOffset{2}), CommitID{1});
-  EXPECT_EQ(_mvcc_data->get_end_cid(ChunkOffset{2}), MvccData::MAX_COMMIT_ID);
+  EXPECT_EQ(_mvcc_data->get_end_cid(ChunkOffset{2}), MAX_COMMIT_ID);
   EXPECT_EQ(_mvcc_data->get_tid(ChunkOffset{2}), INVALID_TRANSACTION_ID);
 
   if constexpr (HYRISE_DEBUG) {
@@ -57,7 +57,7 @@ TEST_F(MvccDataTest, SetCIDsAndTIDs) {
   // Profound testing of MVCC functionality is part of the Insert/Delete tests. Concurrency tests can be found in
   // `stress_test.cpp`
   EXPECT_EQ(_mvcc_data->get_begin_cid(ChunkOffset{2}), CommitID{1});
-  EXPECT_EQ(_mvcc_data->get_end_cid(ChunkOffset{2}), MvccData::MAX_COMMIT_ID);
+  EXPECT_EQ(_mvcc_data->get_end_cid(ChunkOffset{2}), MAX_COMMIT_ID);
   EXPECT_EQ(_mvcc_data->get_tid(ChunkOffset{2}), INVALID_TRANSACTION_ID);
 
   _mvcc_data->set_begin_cid(ChunkOffset{2}, CommitID{5});
@@ -101,8 +101,8 @@ TEST_F(MvccDataTest, Description) {
 }
 
 TEST_F(MvccDataTest, MaxBeginAndEndCID) {
-  EXPECT_EQ(_mvcc_data->max_begin_cid.load(), MvccData::MAX_COMMIT_ID);
-  EXPECT_EQ(_mvcc_data->max_end_cid.load(), MvccData::MAX_COMMIT_ID);
+  EXPECT_EQ(_mvcc_data->max_begin_cid.load(), MAX_COMMIT_ID);
+  EXPECT_EQ(_mvcc_data->max_end_cid.load(), MAX_COMMIT_ID);
 
   _mvcc_data->max_begin_cid = CommitID{1};
   _mvcc_data->max_end_cid = CommitID{2};

--- a/src/test/lib/storage/table_test.cpp
+++ b/src/test/lib/storage/table_test.cpp
@@ -142,7 +142,7 @@ TEST_F(StorageTableTest, FillingUpAChunkSetImmutable) {
   const auto chunk = table->get_chunk(ChunkID{0});
   const auto mvcc_data = chunk->mvcc_data();
   ASSERT_TRUE(mvcc_data);
-  EXPECT_EQ(mvcc_data->max_begin_cid.load(), MvccData::MAX_COMMIT_ID);
+  EXPECT_EQ(mvcc_data->max_begin_cid.load(), MAX_COMMIT_ID);
   EXPECT_TRUE(chunk->is_mutable());
 
   table->append({6, "world"});

--- a/src/test/lib/utils/atomic_max_test.cpp
+++ b/src/test/lib/utils/atomic_max_test.cpp
@@ -17,9 +17,9 @@ TEST_F(AtomicMaxTest, SingleUpdate) {
 
 TEST_F(AtomicMaxTest, IgnoreMaxCommitID) {
   // The CommitID specialization should treat MAX_COMMIT_ID like an unset value.
-  auto counter = std::atomic<CommitID>{MvccData::MAX_COMMIT_ID};
+  auto counter = std::atomic<CommitID>{MAX_COMMIT_ID};
 
-  EXPECT_EQ(counter.load(), MvccData::MAX_COMMIT_ID);
+  EXPECT_EQ(counter.load(), MAX_COMMIT_ID);
 
   set_atomic_max(counter, CommitID{0});
   EXPECT_EQ(counter.load(), CommitID{0});


### PR DESCRIPTION
This PR adds locking to the constraints stored for a table. Specifically a `_constraint_mutex` is added to a table. To acquire this mutex `acquire_constraints_modify_mutex` can be used.

To avoid redundant validation or invalidation of key constraints that are already known to be valid or invalid, two new timestamp attributes are introduced: `_last_validated_on` and `_last_invalidated_on`. These store the CommitID of the most recent validation or invalidation.

With this data, we can determine whether a `TableKeyConstraint` is still confidently valid or invalid by comparing the stored CommitIDs with those of the table’s chunks. This logic is implemented in two new methods: `is_constraint_confidently_valid` and `is_constraint_confidently_invalid`, located in `constraint_utils.cpp`.

As these methods are not yet used in the `UCCDiscoveryPlugin`, we can only add tests in the following locations:
- `src/test/lib/concurrency/stress_test.cpp`
- `src/test/lib/storage/constraints/constraint_utils_test.cpp`