### PR TITLE
Reduce CI pipeline runtime

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,350 +66,350 @@ try {
     //   def hyriseCI = docker.image('hyrise/hyrise-ci:24.04');
     //   hyriseCI.pull()
 
-      // LSAN (executed as part of ASAN) requires elevated privileges. Therefore, we had to add --cap-add SYS_PTRACE.
-      // Even if the CI run sometimes succeeds without SYS_PTRACE, you should not remove it until you know what you are
-      // doing. See also: https://github.com/google/sanitizers/issues/764
-      hyriseCI.inside("--cap-add SYS_PTRACE -u 0:0") {
-        try {
-          stage("Setup") {
-            checkout scm
+    //   // LSAN (executed as part of ASAN) requires elevated privileges. Therefore, we had to add --cap-add SYS_PTRACE.
+    //   // Even if the CI run sometimes succeeds without SYS_PTRACE, you should not remove it until you know what you are
+    //   // doing. See also: https://github.com/google/sanitizers/issues/764
+    //   hyriseCI.inside("--cap-add SYS_PTRACE -u 0:0") {
+    //     try {
+    //       stage("Setup") {
+    //         checkout scm
 
-            // Check if ninja-build is installed. As make is sufficient to work with Hyrise, ninja-build is not
-            // installed via install_dependencies.sh but is part of the hyrise-ci docker image.
-            sh "ninja --version > /dev/null"
+    //         // Check if ninja-build is installed. As make is sufficient to work with Hyrise, ninja-build is not
+    //         // installed via install_dependencies.sh but is part of the hyrise-ci docker image.
+    //         sh "ninja --version > /dev/null"
 
-            // During CI runs, the user is different from the owner of the directories, which blocks the execution of
-            // git commands since the fix of the git vulnerability CVE-2022-24765. git commands can then only be
-            // executed if the corresponding directories are added as safe directories.
-            sh '''
-            git config --global --add safe.directory $WORKSPACE
-            # Get the paths of the submodules; for each path, add it as a git safe.directory
-            grep path .gitmodules | sed 's/.*=//' | xargs -n 1 -I '{}' git config --global --add safe.directory $WORKSPACE/'{}'
-            '''
+    //         // During CI runs, the user is different from the owner of the directories, which blocks the execution of
+    //         // git commands since the fix of the git vulnerability CVE-2022-24765. git commands can then only be
+    //         // executed if the corresponding directories are added as safe directories.
+    //         sh '''
+    //         git config --global --add safe.directory $WORKSPACE
+    //         # Get the paths of the submodules; for each path, add it as a git safe.directory
+    //         grep path .gitmodules | sed 's/.*=//' | xargs -n 1 -I '{}' git config --global --add safe.directory $WORKSPACE/'{}'
+    //         '''
 
-            sh "./install_dependencies.sh"
+    //         sh "./install_dependencies.sh"
 
-            cmake = 'cmake -DCI_BUILD=ON'
+    //         cmake = 'cmake -DCI_BUILD=ON'
 
-            // We do not use unity builds with clang-tidy (see below).
-            unity = '-DCMAKE_UNITY_BUILD=ON'
+    //         // We do not use unity builds with clang-tidy (see below).
+    //         unity = '-DCMAKE_UNITY_BUILD=ON'
 
-            // To speed compiling up, we use ninja for most builds.
-            ninja = '-GNinja'
+    //         // To speed compiling up, we use ninja for most builds.
+    //         ninja = '-GNinja'
 
-            // With Hyrise, we aim to support the most recent compiler versions and do not invest a lot of work to
-            // support older versions. We test LLVM 16 (older versions might work, but LLVM 15 has issues with libstdc++
-            // of GCC 14) and GCC 13.2 (oldest version supported by Hyrise). We execute at least debug runs for them. If
-            // you want to upgrade compiler versions, please update install_dependencies.sh, DEPENDENCIES.md, and the
-            // documentation (README, Wiki).
-            clang = '-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++'
-            clang16 = '-DCMAKE_C_COMPILER=clang-16 -DCMAKE_CXX_COMPILER=clang++-16'
-            gcc = '-DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14'
-            gcc13 = '-DCMAKE_C_COMPILER=gcc-13 -DCMAKE_CXX_COMPILER=g++-13'
+    //         // With Hyrise, we aim to support the most recent compiler versions and do not invest a lot of work to
+    //         // support older versions. We test LLVM 16 (older versions might work, but LLVM 15 has issues with libstdc++
+    //         // of GCC 14) and GCC 13.2 (oldest version supported by Hyrise). We execute at least debug runs for them. If
+    //         // you want to upgrade compiler versions, please update install_dependencies.sh, DEPENDENCIES.md, and the
+    //         // documentation (README, Wiki).
+    //         clang = '-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++'
+    //         clang16 = '-DCMAKE_C_COMPILER=clang-16 -DCMAKE_CXX_COMPILER=clang++-16'
+    //         gcc = '-DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14'
+    //         gcc13 = '-DCMAKE_C_COMPILER=gcc-13 -DCMAKE_CXX_COMPILER=g++-13'
 
-            debug = '-DCMAKE_BUILD_TYPE=Debug'
-            release = '-DCMAKE_BUILD_TYPE=Release'
-            relwithdebinfo = '-DCMAKE_BUILD_TYPE=RelWithDebInfo'
+    //         debug = '-DCMAKE_BUILD_TYPE=Debug'
+    //         release = '-DCMAKE_BUILD_TYPE=Release'
+    //         relwithdebinfo = '-DCMAKE_BUILD_TYPE=RelWithDebInfo'
 
-            // LTO is automatically disabled for debug and sanitizer builds. As LTO linking with GCC and gold (lld is
-            // not supported when using GCC and LTO) takes over an hour, we skip LTO for the GCC release build.
-            no_lto = '-DNO_LTO=TRUE'
+    //         // LTO is automatically disabled for debug and sanitizer builds. As LTO linking with GCC and gold (lld is
+    //         // not supported when using GCC and LTO) takes over an hour, we skip LTO for the GCC release build.
+    //         no_lto = '-DNO_LTO=TRUE'
 
-            // jemalloc's autoconf operates outside of the build folder (#1413). If we start two cmake instances at the
-            // same time, we run into conflicts. Thus, run this one (any one, really) first, so that the autoconf step
-            // can finish in peace.
-            sh "mkdir clang-debug && cd clang-debug &&                                                   ${cmake} ${debug}          ${clang}  ${unity} .. && make -j \$(nproc) libjemalloc-build"
+    //         // jemalloc's autoconf operates outside of the build folder (#1413). If we start two cmake instances at the
+    //         // same time, we run into conflicts. Thus, run this one (any one, really) first, so that the autoconf step
+    //         // can finish in peace.
+    //         sh "mkdir clang-debug && cd clang-debug &&                                                   ${cmake} ${debug}          ${clang}  ${unity} .. && make -j \$(nproc) libjemalloc-build"
 
-            // Configure the rest in parallel. We use unity builds to decrease build times. The only exception is the
-            // clang-tidy build as it might otherwise miss some issues (e.g., missing includes).
-            sh "mkdir clang-debug-tidy && cd clang-debug-tidy &&                                         ${cmake} ${debug}          ${clang}                      ${ninja} -DENABLE_CLANG_TIDY=ON .. &\
-            mkdir clang-debug-unity-odr && cd clang-debug-unity-odr &&                                   ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DCMAKE_UNITY_BUILD_BATCH_SIZE=0 .. &\
-            mkdir clang-debug-disable-precompile-headers && cd clang-debug-disable-precompile-headers && ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DCMAKE_DISABLE_PRECOMPILE_HEADERS=On .. &\
-            mkdir clang-debug-addr-ub-leak-sanitizers && cd clang-debug-addr-ub-leak-sanitizers &&       ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DENABLE_ADDR_UB_LEAK_SANITIZATION=ON .. &\
-            mkdir clang-release-addr-ub-leak-sanitizers && cd clang-release-addr-ub-leak-sanitizers &&   ${cmake} ${release}        ${clang}   ${unity}           ${ninja} -DENABLE_ADDR_UB_LEAK_SANITIZATION=ON .. &\
-            mkdir clang-relwithdebinfo-thread-sanitizer && cd clang-relwithdebinfo-thread-sanitizer &&   ${cmake} ${relwithdebinfo} ${clang}   ${unity}           ${ninja} -DENABLE_THREAD_SANITIZATION=ON .. &\
-            mkdir clang-release && cd clang-release &&                                                   ${cmake} ${release}        ${clang}   ${unity}           ${ninja} .. &\
-            mkdir gcc-debug && cd gcc-debug &&                                                           ${cmake} ${debug}          ${gcc}     ${unity}           ${ninja} .. &\
-            mkdir gcc-release && cd gcc-release &&                                                       ${cmake} ${release}        ${gcc}     ${unity} ${no_lto} ${ninja} .. &\
-            mkdir clang-16-debug && cd clang-16-debug &&                                                 ${cmake} ${debug}          ${clang16} ${unity}           ${ninja} .. &\
-            mkdir gcc-13-debug && cd gcc-13-debug &&                                                     ${cmake} ${debug}          ${gcc13}   ${unity}           ${ninja} .. &\
-            wait"
-          }
+    //         // Configure the rest in parallel. We use unity builds to decrease build times. The only exception is the
+    //         // clang-tidy build as it might otherwise miss some issues (e.g., missing includes).
+    //         sh "mkdir clang-debug-tidy && cd clang-debug-tidy &&                                         ${cmake} ${debug}          ${clang}                      ${ninja} -DENABLE_CLANG_TIDY=ON .. &\
+    //         mkdir clang-debug-unity-odr && cd clang-debug-unity-odr &&                                   ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DCMAKE_UNITY_BUILD_BATCH_SIZE=0 .. &\
+    //         mkdir clang-debug-disable-precompile-headers && cd clang-debug-disable-precompile-headers && ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DCMAKE_DISABLE_PRECOMPILE_HEADERS=On .. &\
+    //         mkdir clang-debug-addr-ub-leak-sanitizers && cd clang-debug-addr-ub-leak-sanitizers &&       ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DENABLE_ADDR_UB_LEAK_SANITIZATION=ON .. &\
+    //         mkdir clang-release-addr-ub-leak-sanitizers && cd clang-release-addr-ub-leak-sanitizers &&   ${cmake} ${release}        ${clang}   ${unity}           ${ninja} -DENABLE_ADDR_UB_LEAK_SANITIZATION=ON .. &\
+    //         mkdir clang-relwithdebinfo-thread-sanitizer && cd clang-relwithdebinfo-thread-sanitizer &&   ${cmake} ${relwithdebinfo} ${clang}   ${unity}           ${ninja} -DENABLE_THREAD_SANITIZATION=ON .. &\
+    //         mkdir clang-release && cd clang-release &&                                                   ${cmake} ${release}        ${clang}   ${unity}           ${ninja} .. &\
+    //         mkdir gcc-debug && cd gcc-debug &&                                                           ${cmake} ${debug}          ${gcc}     ${unity}           ${ninja} .. &\
+    //         mkdir gcc-release && cd gcc-release &&                                                       ${cmake} ${release}        ${gcc}     ${unity} ${no_lto} ${ninja} .. &\
+    //         mkdir clang-16-debug && cd clang-16-debug &&                                                 ${cmake} ${debug}          ${clang16} ${unity}           ${ninja} .. &\
+    //         mkdir gcc-13-debug && cd gcc-13-debug &&                                                     ${cmake} ${debug}          ${gcc13}   ${unity}           ${ninja} .. &\
+    //         wait"
+    //       }
 
-          parallel clangDebug: {
-            stage("clang-debug") {
-              // We build clang-debug using make to test make once (and clang-debug is the fastest build).
-              sh "cd clang-debug && make all -j \$(( \$(nproc) / 4))"
-              sh "./clang-debug/hyriseTest clang-debug"
-            }
-          }, clang16Debug: {
-            stage("clang-16-debug") {
-              sh "cd clang-16-debug && ninja all -j \$(( \$(nproc) / 4))"
-              sh "./clang-16-debug/hyriseTest clang-16-debug"
-            }
-          }, gccDebug: {
-            stage("gcc-debug") {
-              sh "cd gcc-debug && ninja all -j \$(( \$(nproc) / 4))"
-              sh "cd gcc-debug && ./hyriseTest"
-            }
-          }, gcc13Debug: {
-            stage("gcc-13-debug") {
-              sh "cd gcc-13-debug && ninja all -j \$(( \$(nproc) / 4))"
-              sh "cd gcc-13-debug && ./hyriseTest"
-            }
-          }, lint: {
-            stage("Linting") {
-              sh "scripts/lint.sh"
-            }
-          }
+    //       parallel clangDebug: {
+    //         stage("clang-debug") {
+    //           // We build clang-debug using make to test make once (and clang-debug is the fastest build).
+    //           sh "cd clang-debug && make all -j \$(( \$(nproc) / 4))"
+    //           sh "./clang-debug/hyriseTest clang-debug"
+    //         }
+    //       }, clang16Debug: {
+    //         stage("clang-16-debug") {
+    //           sh "cd clang-16-debug && ninja all -j \$(( \$(nproc) / 4))"
+    //           sh "./clang-16-debug/hyriseTest clang-16-debug"
+    //         }
+    //       }, gccDebug: {
+    //         stage("gcc-debug") {
+    //           sh "cd gcc-debug && ninja all -j \$(( \$(nproc) / 4))"
+    //           sh "cd gcc-debug && ./hyriseTest"
+    //         }
+    //       }, gcc13Debug: {
+    //         stage("gcc-13-debug") {
+    //           sh "cd gcc-13-debug && ninja all -j \$(( \$(nproc) / 4))"
+    //           sh "cd gcc-13-debug && ./hyriseTest"
+    //         }
+    //       }, lint: {
+    //         stage("Linting") {
+    //           sh "scripts/lint.sh"
+    //         }
+    //       }
 
-          // We distribute the cores to processes in a way to even the running times. With an even distributions,
-          // clang-tidy builds take up to 3h (galileo server). In addition to compile time, the distribution also
-          // considers the long test runtimes of clangRelWithDebInfoThreadSanitizer (~50 minutes).
-          parallel clangRelease: {
-            stage("clang-release") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "cd clang-release && ninja all -j \$(( \$(nproc) / 10))"
-                sh "./clang-release/hyriseTest clang-release"
-                sh "./clang-release/hyriseSystemTest clang-release"
-                sh "./scripts/test/hyriseConsole_test.py clang-release"
-                sh "./scripts/test/hyriseServer_test.py clang-release"
-                sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-release"
-                sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-release"
-                sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
-                sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
+    //       // We distribute the cores to processes in a way to even the running times. With an even distributions,
+    //       // clang-tidy builds take up to 3h (galileo server). In addition to compile time, the distribution also
+    //       // considers the long test runtimes of clangRelWithDebInfoThreadSanitizer (~50 minutes).
+    //       parallel clangRelease: {
+    //         stage("clang-release") {
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             sh "cd clang-release && ninja all -j \$(( \$(nproc) / 10))"
+    //             sh "./clang-release/hyriseTest clang-release"
+    //             sh "./clang-release/hyriseSystemTest clang-release"
+    //             sh "./scripts/test/hyriseConsole_test.py clang-release"
+    //             sh "./scripts/test/hyriseServer_test.py clang-release"
+    //             sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-release"
+    //             sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-release"
+    //             sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
+    //             sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
 
-              } else {
-                Utils.markStageSkippedForConditional("clangRelease")
-              }
-            }
-          }, debugSystemTests: {
-            stage("system-tests") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "mkdir clang-debug-system &&  ./clang-debug/hyriseSystemTest clang-debug-system"
-                sh "mkdir gcc-debug-system &&  ./gcc-debug/hyriseSystemTest gcc-debug-system"
-                sh "./scripts/test/hyriseConsole_test.py clang-debug"
-                sh "./scripts/test/hyriseServer_test.py clang-debug"
-                sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-debug"
-                sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-debug"
-                sh "cd clang-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
-                sh "cd clang-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate cached data
-                sh "cd clang-debug && ../scripts/test/hyriseBenchmarkStarSchema_test.py ." // Own folder to isolate cached data
-                sh "./scripts/test/hyriseConsole_test.py gcc-debug"
-                sh "./scripts/test/hyriseServer_test.py gcc-debug"
-                sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-debug"
-                sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-debug"
-                sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
-                sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate cached data
-                sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkStarSchema_test.py ." // Own folder to isolate cached data
+    //           } else {
+    //             Utils.markStageSkippedForConditional("clangRelease")
+    //           }
+    //         }
+    //       }, debugSystemTests: {
+    //         stage("system-tests") {
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             sh "mkdir clang-debug-system &&  ./clang-debug/hyriseSystemTest clang-debug-system"
+    //             sh "mkdir gcc-debug-system &&  ./gcc-debug/hyriseSystemTest gcc-debug-system"
+    //             sh "./scripts/test/hyriseConsole_test.py clang-debug"
+    //             sh "./scripts/test/hyriseServer_test.py clang-debug"
+    //             sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-debug"
+    //             sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-debug"
+    //             sh "cd clang-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
+    //             sh "cd clang-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate cached data
+    //             sh "cd clang-debug && ../scripts/test/hyriseBenchmarkStarSchema_test.py ." // Own folder to isolate cached data
+    //             sh "./scripts/test/hyriseConsole_test.py gcc-debug"
+    //             sh "./scripts/test/hyriseServer_test.py gcc-debug"
+    //             sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-debug"
+    //             sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-debug"
+    //             sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
+    //             sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate cached data
+    //             sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkStarSchema_test.py ." // Own folder to isolate cached data
 
-              } else {
-                Utils.markStageSkippedForConditional("debugSystemTests")
-              }
-            }
-          }, clangDebugRunShuffled: {
-            stage("clang-debug:test-shuffle") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "mkdir ./clang-debug/run-shuffled"
-                sh "./clang-debug/hyriseTest clang-debug/run-shuffled --gtest_repeat=5 --gtest_shuffle"
-                // We do not want to trigger SSB data generation concurrently since it is not concurrency-safe.
-                sh "./clang-debug/hyriseSystemTest clang-debug/run-shuffled --gtest_repeat=2 --gtest_shuffle --gtest_filter=\"-SSBTableGeneratorTest.*:SQLiteTestRunnerEncodings/*\""
-              } else {
-                Utils.markStageSkippedForConditional("clangDebugRunShuffled")
-              }
-            }
-          }, clangDebugUnityODR: {
-            stage("clang-debug-unity-odr") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                // Check if unity builds work even if everything is batched into a single compilation unit. This helps prevent ODR (one definition rule) issues.
-                sh "cd clang-debug-unity-odr && ninja all -j 2"
-              } else {
-                Utils.markStageSkippedForConditional("clangDebugUnityODR")
-              }
-            }
-          }, clangDebugTidy: {
-            stage("clang-debug:tidy") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                // We do not run tidy checks on the src/test folder, so there is no point in running the expensive clang-tidy for those files
-                sh "cd clang-debug-tidy && ninja hyrise_impl hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer hyriseMvccDeletePlugin hyriseUccDiscoveryPlugin -k 0 -j \$(( \$(nproc) / 5))"
-              } else {
-                Utils.markStageSkippedForConditional("clangDebugTidy")
-              }
-            }
-          }, clangDebugDisablePrecompileHeaders: {
-            stage("clang-debug:disable-precompile-headers") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                // Check if builds work even when precompile headers is turned off. Executing the binaries is unnecessary as the observed errors are missing includes.
-                sh "cd clang-debug-disable-precompile-headers && ninja hyriseTest hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer -k 0 -j 2"
-              } else {
-                Utils.markStageSkippedForConditional("clangDebugDisablePrecompileHeaders")
-              }
-            }
-          }, clangDebugAddrUBLeakSanitizers: {
-            stage("clang-debug:addr-ub-sanitizers") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "cd clang-debug-addr-ub-leak-sanitizers && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 10))"
-                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseTest clang-debug-addr-ub-leak-sanitizers"
-                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-debug-addr-ub-leak-sanitizers"
-                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 1"
-              } else {
-                Utils.markStageSkippedForConditional("clangDebugAddrUBLeakSanitizers")
-              }
-            }
-          }, gccRelease: {
-            if (env.BRANCH_NAME == 'master' || full_ci) {
-              stage("gcc-release") {
-                sh "cd gcc-release && ninja all -j \$(( \$(nproc) / 10))"
-                sh "./gcc-release/hyriseTest gcc-release"
-                sh "./gcc-release/hyriseSystemTest gcc-release"
-                sh "./scripts/test/hyriseConsole_test.py gcc-release"
-                sh "./scripts/test/hyriseServer_test.py gcc-release"
-                sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-release"
-                sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-release"
-                sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
-                sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
-              }
-            } else {
-                Utils.markStageSkippedForConditional("gccRelease")
-            }
-          }, clangReleaseAddrUBLeakSanitizers: {
-            stage("clang-release:addr-ub-sanitizers") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "cd clang-release-addr-ub-leak-sanitizers && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 5))"
-                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseTest clang-release-addr-ub-leak-sanitizers"
-                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-release-addr-ub-leak-sanitizers"
-                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
-                sh "cd clang-release-addr-ub-leak-sanitizers && LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
-              } else {
-                Utils.markStageSkippedForConditional("clangReleaseAddrUBLeakSanitizers")
-              }
-            }
-          }, clangRelWithDebInfoThreadSanitizer: {
-            stage("clang-relwithdebinfo:thread-sanitizer") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "cd clang-relwithdebinfo-thread-sanitizer && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC hyriseBenchmarkTPCDS -j \$(( \$(nproc) / 5))"
-                sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseTest clang-relwithdebinfo-thread-sanitizer"
-                sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-relwithdebinfo-thread-sanitizer"
-                sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCH -s .01 -r 100 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
-                sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCC -s 1 --time 120 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
-                sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCDS -s 1 -r 5 --scheduler --clients 5 --cores \$(( \$(nproc) / 10))"
-              } else {
-                Utils.markStageSkippedForConditional("clangRelWithDebInfoThreadSanitizer")
-              }
-            }
-          }, clangDebugCoverage: {
-            stage("clang-debug-coverage") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "./scripts/coverage.sh --generate_badge=true"
-                sh "find coverage -type d -exec chmod +rx {} \\;"
-                archive 'coverage_badge.svg'
-                archive 'coverage_percent.txt'
-                publishHTML (target: [
-                  allowMissing: false,
-                  alwaysLinkToLastBuild: false,
-                  keepAll: true,
-                  reportDir: 'coverage',
-                  reportFiles: 'index.html',
-                  reportName: "Llvm-cov_Report"
-                ])
-                script {
-                  coverageChange = sh script: "./scripts/compare_coverage.sh", returnStdout: true
-                  githubNotify context: 'Coverage', description: "$coverageChange", status: 'SUCCESS', targetUrl: "${env.BUILD_URL}/RCov_20Report/index.html"
-                }
-              } else {
-                Utils.markStageSkippedForConditional("clangDebugCoverage")
-              }
-            }
-          }
+    //           } else {
+    //             Utils.markStageSkippedForConditional("debugSystemTests")
+    //           }
+    //         }
+    //       }, clangDebugRunShuffled: {
+    //         stage("clang-debug:test-shuffle") {
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             sh "mkdir ./clang-debug/run-shuffled"
+    //             sh "./clang-debug/hyriseTest clang-debug/run-shuffled --gtest_repeat=5 --gtest_shuffle"
+    //             // We do not want to trigger SSB data generation concurrently since it is not concurrency-safe.
+    //             sh "./clang-debug/hyriseSystemTest clang-debug/run-shuffled --gtest_repeat=2 --gtest_shuffle --gtest_filter=\"-SSBTableGeneratorTest.*:SQLiteTestRunnerEncodings/*\""
+    //           } else {
+    //             Utils.markStageSkippedForConditional("clangDebugRunShuffled")
+    //           }
+    //         }
+    //       }, clangDebugUnityODR: {
+    //         stage("clang-debug-unity-odr") {
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             // Check if unity builds work even if everything is batched into a single compilation unit. This helps prevent ODR (one definition rule) issues.
+    //             sh "cd clang-debug-unity-odr && ninja all -j 2"
+    //           } else {
+    //             Utils.markStageSkippedForConditional("clangDebugUnityODR")
+    //           }
+    //         }
+    //       }, clangDebugTidy: {
+    //         stage("clang-debug:tidy") {
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             // We do not run tidy checks on the src/test folder, so there is no point in running the expensive clang-tidy for those files
+    //             sh "cd clang-debug-tidy && ninja hyrise_impl hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer hyriseMvccDeletePlugin hyriseUccDiscoveryPlugin -k 0 -j \$(( \$(nproc) / 5))"
+    //           } else {
+    //             Utils.markStageSkippedForConditional("clangDebugTidy")
+    //           }
+    //         }
+    //       }, clangDebugDisablePrecompileHeaders: {
+    //         stage("clang-debug:disable-precompile-headers") {
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             // Check if builds work even when precompile headers is turned off. Executing the binaries is unnecessary as the observed errors are missing includes.
+    //             sh "cd clang-debug-disable-precompile-headers && ninja hyriseTest hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer -k 0 -j 2"
+    //           } else {
+    //             Utils.markStageSkippedForConditional("clangDebugDisablePrecompileHeaders")
+    //           }
+    //         }
+    //       }, clangDebugAddrUBLeakSanitizers: {
+    //         stage("clang-debug:addr-ub-sanitizers") {
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             sh "cd clang-debug-addr-ub-leak-sanitizers && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 10))"
+    //             sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseTest clang-debug-addr-ub-leak-sanitizers"
+    //             sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-debug-addr-ub-leak-sanitizers"
+    //             sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 1"
+    //           } else {
+    //             Utils.markStageSkippedForConditional("clangDebugAddrUBLeakSanitizers")
+    //           }
+    //         }
+    //       }, gccRelease: {
+    //         if (env.BRANCH_NAME == 'master' || full_ci) {
+    //           stage("gcc-release") {
+    //             sh "cd gcc-release && ninja all -j \$(( \$(nproc) / 10))"
+    //             sh "./gcc-release/hyriseTest gcc-release"
+    //             sh "./gcc-release/hyriseSystemTest gcc-release"
+    //             sh "./scripts/test/hyriseConsole_test.py gcc-release"
+    //             sh "./scripts/test/hyriseServer_test.py gcc-release"
+    //             sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-release"
+    //             sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-release"
+    //             sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
+    //             sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
+    //           }
+    //         } else {
+    //             Utils.markStageSkippedForConditional("gccRelease")
+    //         }
+    //       }, clangReleaseAddrUBLeakSanitizers: {
+    //         stage("clang-release:addr-ub-sanitizers") {
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             sh "cd clang-release-addr-ub-leak-sanitizers && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 5))"
+    //             sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseTest clang-release-addr-ub-leak-sanitizers"
+    //             sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-release-addr-ub-leak-sanitizers"
+    //             sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
+    //             sh "cd clang-release-addr-ub-leak-sanitizers && LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
+    //           } else {
+    //             Utils.markStageSkippedForConditional("clangReleaseAddrUBLeakSanitizers")
+    //           }
+    //         }
+    //       }, clangRelWithDebInfoThreadSanitizer: {
+    //         stage("clang-relwithdebinfo:thread-sanitizer") {
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             sh "cd clang-relwithdebinfo-thread-sanitizer && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC hyriseBenchmarkTPCDS -j \$(( \$(nproc) / 5))"
+    //             sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseTest clang-relwithdebinfo-thread-sanitizer"
+    //             sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-relwithdebinfo-thread-sanitizer"
+    //             sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCH -s .01 -r 100 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
+    //             sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCC -s 1 --time 120 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
+    //             sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCDS -s 1 -r 5 --scheduler --clients 5 --cores \$(( \$(nproc) / 10))"
+    //           } else {
+    //             Utils.markStageSkippedForConditional("clangRelWithDebInfoThreadSanitizer")
+    //           }
+    //         }
+    //       }, clangDebugCoverage: {
+    //         stage("clang-debug-coverage") {
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             sh "./scripts/coverage.sh --generate_badge=true"
+    //             sh "find coverage -type d -exec chmod +rx {} \\;"
+    //             archive 'coverage_badge.svg'
+    //             archive 'coverage_percent.txt'
+    //             publishHTML (target: [
+    //               allowMissing: false,
+    //               alwaysLinkToLastBuild: false,
+    //               keepAll: true,
+    //               reportDir: 'coverage',
+    //               reportFiles: 'index.html',
+    //               reportName: "Llvm-cov_Report"
+    //             ])
+    //             script {
+    //               coverageChange = sh script: "./scripts/compare_coverage.sh", returnStdout: true
+    //               githubNotify context: 'Coverage', description: "$coverageChange", status: 'SUCCESS', targetUrl: "${env.BUILD_URL}/RCov_20Report/index.html"
+    //             }
+    //           } else {
+    //             Utils.markStageSkippedForConditional("clangDebugCoverage")
+    //           }
+    //         }
+    //       }
 
-          parallel memcheckReleaseTest: {
-            stage("memcheckReleaseTest") {
-              // Runs after the other sanitizers as it depends on clang-release to be built.
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "mkdir ./clang-release-memcheck-test"
-                // If this shows a leak, try --leak-check=full, which is slower but more precise. Valgrind serializes
-                // concurrent threads into a single one. Thus, we limit the cores and data preparation cores for the
-                // benchmark runs to reduce this serialization overhead. According to the Valgrind documentation,
-                // --fair-sched=yes "improves overall responsiveness if you are running an interactive multithreaded
-                // program" and "produces better reproducibility of thread scheduling for different executions of a
-                // multithreaded application" (i.e., there are no runs that are randomly faster or slower).
-                sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseTest clang-release-memcheck-test --gtest_filter=-NUMAMemoryResourceTest.BasicAllocate:SQLiteTestRunner*"
-                sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCH -s .01 -r 1 --scheduler --cores 4 --data_preparation_cores 4"
-                sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCDS -s 1 -r 1 --scheduler --cores 4 --data_preparation_cores 4"
-                sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCC -s 1 --scheduler --cores 4 --data_preparation_cores 4"
-              } else {
-                Utils.markStageSkippedForConditional("memcheckReleaseTest")
-              }
-            }
-          }, tpchVerification: {
-            stage("tpchVerification") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                // Verify both single- and multithreaded results.
-                sh "./clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 1 -s 1 --verify"
-                sh "./clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 1 -s 1 --verify --scheduler --clients 1 --cores 10"
-              } else {
-                Utils.markStageSkippedForConditional("tpchVerification")
-              }
-            }
-          }, tpchQueryPlans: {
-            stage("tpchQueryPlans") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "mkdir -p query_plans/tpch; cd query_plans/tpch && ../../clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 2 -s 10 --visualize && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
-                archiveArtifacts artifacts: 'query_plans/tpch/*.svg'
-                archiveArtifacts artifacts: 'query_plans/tpch/operator_breakdown.pdf'
-              } else {
-                Utils.markStageSkippedForConditional("tpchQueryPlans")
-              }
-            }
-          }, tpcdsQueryPlansAndVerification: {
-            stage("tpcdsQueryPlansAndVerification") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "mkdir -p query_plans/tpcds; cd query_plans/tpcds && ln -s ../../resources; ../../clang-release/hyriseBenchmarkTPCDS --dont_cache_binary_tables -r 1 -s 1 --visualize --verify && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
-                archiveArtifacts artifacts: 'query_plans/tpcds/*.svg'
-                archiveArtifacts artifacts: 'query_plans/tpcds/operator_breakdown.pdf'
-              } else {
-                Utils.markStageSkippedForConditional("tpcdsQueryPlansAndVerification")
-              }
-            }
-          }, jobQueryPlans: {
-            stage("jobQueryPlans") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                // In contrast to TPC-H and TPC-DS above, we execute the JoinOrderBenchmark from the project's root directoy because its setup script requires us to do so.
-                sh "mkdir -p query_plans/job && ./clang-release/hyriseBenchmarkJoinOrder --dont_cache_binary_tables -r 1 --visualize && ./scripts/plot_operator_breakdown.py ./clang-release/ && mv operator_breakdown.pdf query_plans/job && mv *QP.svg query_plans/job"
-                archiveArtifacts artifacts: 'query_plans/job/*.svg'
-                archiveArtifacts artifacts: 'query_plans/job/operator_breakdown.pdf'
-              } else {
-                Utils.markStageSkippedForConditional("jobQueryPlans")
-              }
-            }
-          }, ssbQueryPlans: {
-            stage("ssbQueryPlans") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "mkdir -p query_plans/ssb; cd query_plans/ssb && ../../clang-release/hyriseBenchmarkStarSchema --dont_cache_binary_tables -r 1 -s 1 --visualize && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
-                archiveArtifacts artifacts: 'query_plans/ssb/*.svg'
-                archiveArtifacts artifacts: 'query_plans/ssb/operator_breakdown.pdf'
-              } else {
-                Utils.markStageSkippedForConditional("ssbQueryPlans")
-              }
-            }
-          }, nixSetup: {
-            stage('nixSetup') {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "curl -L https://nixos.org/nix/install > nix-install.sh && chmod +x nix-install.sh && ./nix-install.sh --daemon --yes"
-                sh "/nix/var/nix/profiles/default/bin/nix-shell resources/nix --pure --run \"mkdir nix-debug && cd nix-debug && cmake ${debug} ${clang} ${unity} ${ninja} .. && ninja all -j \$(( \$(nproc) / 7)) && ./hyriseTest\""
-                // We allocate a third of all cores for the release build as several parallel stages should have already finished at this point.
-                sh "/nix/var/nix/profiles/default/bin/nix-shell resources/nix --pure --run \"mkdir nix-release && cd nix-release && cmake ${release} ${clang} ${unity} ${ninja} .. && ninja all -j \$(( \$(nproc) / 3)) && ./hyriseTest\""
-              } else {
-                Utils.markStageSkippedForConditional("nixSetup")
-              }
-            }
-          }
-        } finally {
-          sh "ls -A1 | xargs rm -rf"
-          deleteDir()
-        }
-      }
-    }
+    //       parallel memcheckReleaseTest: {
+    //         stage("memcheckReleaseTest") {
+    //           // Runs after the other sanitizers as it depends on clang-release to be built.
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             sh "mkdir ./clang-release-memcheck-test"
+    //             // If this shows a leak, try --leak-check=full, which is slower but more precise. Valgrind serializes
+    //             // concurrent threads into a single one. Thus, we limit the cores and data preparation cores for the
+    //             // benchmark runs to reduce this serialization overhead. According to the Valgrind documentation,
+    //             // --fair-sched=yes "improves overall responsiveness if you are running an interactive multithreaded
+    //             // program" and "produces better reproducibility of thread scheduling for different executions of a
+    //             // multithreaded application" (i.e., there are no runs that are randomly faster or slower).
+    //             sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseTest clang-release-memcheck-test --gtest_filter=-NUMAMemoryResourceTest.BasicAllocate:SQLiteTestRunner*"
+    //             sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCH -s .01 -r 1 --scheduler --cores 4 --data_preparation_cores 4"
+    //             sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCDS -s 1 -r 1 --scheduler --cores 4 --data_preparation_cores 4"
+    //             sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCC -s 1 --scheduler --cores 4 --data_preparation_cores 4"
+    //           } else {
+    //             Utils.markStageSkippedForConditional("memcheckReleaseTest")
+    //           }
+    //         }
+    //       }, tpchVerification: {
+    //         stage("tpchVerification") {
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             // Verify both single- and multithreaded results.
+    //             sh "./clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 1 -s 1 --verify"
+    //             sh "./clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 1 -s 1 --verify --scheduler --clients 1 --cores 10"
+    //           } else {
+    //             Utils.markStageSkippedForConditional("tpchVerification")
+    //           }
+    //         }
+    //       }, tpchQueryPlans: {
+    //         stage("tpchQueryPlans") {
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             sh "mkdir -p query_plans/tpch; cd query_plans/tpch && ../../clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 2 -s 10 --visualize && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
+    //             archiveArtifacts artifacts: 'query_plans/tpch/*.svg'
+    //             archiveArtifacts artifacts: 'query_plans/tpch/operator_breakdown.pdf'
+    //           } else {
+    //             Utils.markStageSkippedForConditional("tpchQueryPlans")
+    //           }
+    //         }
+    //       }, tpcdsQueryPlansAndVerification: {
+    //         stage("tpcdsQueryPlansAndVerification") {
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             sh "mkdir -p query_plans/tpcds; cd query_plans/tpcds && ln -s ../../resources; ../../clang-release/hyriseBenchmarkTPCDS --dont_cache_binary_tables -r 1 -s 1 --visualize --verify && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
+    //             archiveArtifacts artifacts: 'query_plans/tpcds/*.svg'
+    //             archiveArtifacts artifacts: 'query_plans/tpcds/operator_breakdown.pdf'
+    //           } else {
+    //             Utils.markStageSkippedForConditional("tpcdsQueryPlansAndVerification")
+    //           }
+    //         }
+    //       }, jobQueryPlans: {
+    //         stage("jobQueryPlans") {
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             // In contrast to TPC-H and TPC-DS above, we execute the JoinOrderBenchmark from the project's root directoy because its setup script requires us to do so.
+    //             sh "mkdir -p query_plans/job && ./clang-release/hyriseBenchmarkJoinOrder --dont_cache_binary_tables -r 1 --visualize && ./scripts/plot_operator_breakdown.py ./clang-release/ && mv operator_breakdown.pdf query_plans/job && mv *QP.svg query_plans/job"
+    //             archiveArtifacts artifacts: 'query_plans/job/*.svg'
+    //             archiveArtifacts artifacts: 'query_plans/job/operator_breakdown.pdf'
+    //           } else {
+    //             Utils.markStageSkippedForConditional("jobQueryPlans")
+    //           }
+    //         }
+    //       }, ssbQueryPlans: {
+    //         stage("ssbQueryPlans") {
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             sh "mkdir -p query_plans/ssb; cd query_plans/ssb && ../../clang-release/hyriseBenchmarkStarSchema --dont_cache_binary_tables -r 1 -s 1 --visualize && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
+    //             archiveArtifacts artifacts: 'query_plans/ssb/*.svg'
+    //             archiveArtifacts artifacts: 'query_plans/ssb/operator_breakdown.pdf'
+    //           } else {
+    //             Utils.markStageSkippedForConditional("ssbQueryPlans")
+    //           }
+    //         }
+    //       }, nixSetup: {
+    //         stage('nixSetup') {
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             sh "curl -L https://nixos.org/nix/install > nix-install.sh && chmod +x nix-install.sh && ./nix-install.sh --daemon --yes"
+    //             sh "/nix/var/nix/profiles/default/bin/nix-shell resources/nix --pure --run \"mkdir nix-debug && cd nix-debug && cmake ${debug} ${clang} ${unity} ${ninja} .. && ninja all -j \$(( \$(nproc) / 7)) && ./hyriseTest\""
+    //             // We allocate a third of all cores for the release build as several parallel stages should have already finished at this point.
+    //             sh "/nix/var/nix/profiles/default/bin/nix-shell resources/nix --pure --run \"mkdir nix-release && cd nix-release && cmake ${release} ${clang} ${unity} ${ninja} .. && ninja all -j \$(( \$(nproc) / 3)) && ./hyriseTest\""
+    //           } else {
+    //             Utils.markStageSkippedForConditional("nixSetup")
+    //           }
+    //         }
+    //       }
+    //     } finally {
+    //       sh "ls -A1 | xargs rm -rf"
+    //       deleteDir()
+    //     }
+    //   }
+    // }
   }
 
   parallel clangMacX64: {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,350 +66,350 @@ try {
     //   def hyriseCI = docker.image('hyrise/hyrise-ci:24.04');
     //   hyriseCI.pull()
 
-    //   // LSAN (executed as part of ASAN) requires elevated privileges. Therefore, we had to add --cap-add SYS_PTRACE.
-    //   // Even if the CI run sometimes succeeds without SYS_PTRACE, you should not remove it until you know what you are
-    //   // doing. See also: https://github.com/google/sanitizers/issues/764
-    //   hyriseCI.inside("--cap-add SYS_PTRACE -u 0:0") {
-    //     try {
-    //       stage("Setup") {
-    //         checkout scm
+      // LSAN (executed as part of ASAN) requires elevated privileges. Therefore, we had to add --cap-add SYS_PTRACE.
+      // Even if the CI run sometimes succeeds without SYS_PTRACE, you should not remove it until you know what you are
+      // doing. See also: https://github.com/google/sanitizers/issues/764
+      hyriseCI.inside("--cap-add SYS_PTRACE -u 0:0") {
+        try {
+          stage("Setup") {
+            checkout scm
 
-    //         // Check if ninja-build is installed. As make is sufficient to work with Hyrise, ninja-build is not
-    //         // installed via install_dependencies.sh but is part of the hyrise-ci docker image.
-    //         sh "ninja --version > /dev/null"
+            // Check if ninja-build is installed. As make is sufficient to work with Hyrise, ninja-build is not
+            // installed via install_dependencies.sh but is part of the hyrise-ci docker image.
+            sh "ninja --version > /dev/null"
 
-    //         // During CI runs, the user is different from the owner of the directories, which blocks the execution of
-    //         // git commands since the fix of the git vulnerability CVE-2022-24765. git commands can then only be
-    //         // executed if the corresponding directories are added as safe directories.
-    //         sh '''
-    //         git config --global --add safe.directory $WORKSPACE
-    //         # Get the paths of the submodules; for each path, add it as a git safe.directory
-    //         grep path .gitmodules | sed 's/.*=//' | xargs -n 1 -I '{}' git config --global --add safe.directory $WORKSPACE/'{}'
-    //         '''
+            // During CI runs, the user is different from the owner of the directories, which blocks the execution of
+            // git commands since the fix of the git vulnerability CVE-2022-24765. git commands can then only be
+            // executed if the corresponding directories are added as safe directories.
+            sh '''
+            git config --global --add safe.directory $WORKSPACE
+            # Get the paths of the submodules; for each path, add it as a git safe.directory
+            grep path .gitmodules | sed 's/.*=//' | xargs -n 1 -I '{}' git config --global --add safe.directory $WORKSPACE/'{}'
+            '''
 
-    //         sh "./install_dependencies.sh"
+            sh "./install_dependencies.sh"
 
-    //         cmake = 'cmake -DCI_BUILD=ON'
+            cmake = 'cmake -DCI_BUILD=ON'
 
-    //         // We do not use unity builds with clang-tidy (see below).
-    //         unity = '-DCMAKE_UNITY_BUILD=ON'
+            // We do not use unity builds with clang-tidy (see below).
+            unity = '-DCMAKE_UNITY_BUILD=ON'
 
-    //         // To speed compiling up, we use ninja for most builds.
-    //         ninja = '-GNinja'
+            // To speed compiling up, we use ninja for most builds.
+            ninja = '-GNinja'
 
-    //         // With Hyrise, we aim to support the most recent compiler versions and do not invest a lot of work to
-    //         // support older versions. We test LLVM 16 (older versions might work, but LLVM 15 has issues with libstdc++
-    //         // of GCC 14) and GCC 13.2 (oldest version supported by Hyrise). We execute at least debug runs for them. If
-    //         // you want to upgrade compiler versions, please update install_dependencies.sh, DEPENDENCIES.md, and the
-    //         // documentation (README, Wiki).
-    //         clang = '-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++'
-    //         clang16 = '-DCMAKE_C_COMPILER=clang-16 -DCMAKE_CXX_COMPILER=clang++-16'
-    //         gcc = '-DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14'
-    //         gcc13 = '-DCMAKE_C_COMPILER=gcc-13 -DCMAKE_CXX_COMPILER=g++-13'
+            // With Hyrise, we aim to support the most recent compiler versions and do not invest a lot of work to
+            // support older versions. We test LLVM 16 (older versions might work, but LLVM 15 has issues with libstdc++
+            // of GCC 14) and GCC 13.2 (oldest version supported by Hyrise). We execute at least debug runs for them. If
+            // you want to upgrade compiler versions, please update install_dependencies.sh, DEPENDENCIES.md, and the
+            // documentation (README, Wiki).
+            clang = '-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++'
+            clang16 = '-DCMAKE_C_COMPILER=clang-16 -DCMAKE_CXX_COMPILER=clang++-16'
+            gcc = '-DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14'
+            gcc13 = '-DCMAKE_C_COMPILER=gcc-13 -DCMAKE_CXX_COMPILER=g++-13'
 
-    //         debug = '-DCMAKE_BUILD_TYPE=Debug'
-    //         release = '-DCMAKE_BUILD_TYPE=Release'
-    //         relwithdebinfo = '-DCMAKE_BUILD_TYPE=RelWithDebInfo'
+            debug = '-DCMAKE_BUILD_TYPE=Debug'
+            release = '-DCMAKE_BUILD_TYPE=Release'
+            relwithdebinfo = '-DCMAKE_BUILD_TYPE=RelWithDebInfo'
 
-    //         // LTO is automatically disabled for debug and sanitizer builds. As LTO linking with GCC and gold (lld is
-    //         // not supported when using GCC and LTO) takes over an hour, we skip LTO for the GCC release build.
-    //         no_lto = '-DNO_LTO=TRUE'
+            // LTO is automatically disabled for debug and sanitizer builds. As LTO linking with GCC and gold (lld is
+            // not supported when using GCC and LTO) takes over an hour, we skip LTO for the GCC release build.
+            no_lto = '-DNO_LTO=TRUE'
 
-    //         // jemalloc's autoconf operates outside of the build folder (#1413). If we start two cmake instances at the
-    //         // same time, we run into conflicts. Thus, run this one (any one, really) first, so that the autoconf step
-    //         // can finish in peace.
-    //         sh "mkdir clang-debug && cd clang-debug &&                                                   ${cmake} ${debug}          ${clang}  ${unity} .. && make -j \$(nproc) libjemalloc-build"
+            // jemalloc's autoconf operates outside of the build folder (#1413). If we start two cmake instances at the
+            // same time, we run into conflicts. Thus, run this one (any one, really) first, so that the autoconf step
+            // can finish in peace.
+            sh "mkdir clang-debug && cd clang-debug &&                                                   ${cmake} ${debug}          ${clang}  ${unity} .. && make -j \$(nproc) libjemalloc-build"
 
-    //         // Configure the rest in parallel. We use unity builds to decrease build times. The only exception is the
-    //         // clang-tidy build as it might otherwise miss some issues (e.g., missing includes).
-    //         sh "mkdir clang-debug-tidy && cd clang-debug-tidy &&                                         ${cmake} ${debug}          ${clang}                      ${ninja} -DENABLE_CLANG_TIDY=ON .. &\
-    //         mkdir clang-debug-unity-odr && cd clang-debug-unity-odr &&                                   ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DCMAKE_UNITY_BUILD_BATCH_SIZE=0 .. &\
-    //         mkdir clang-debug-disable-precompile-headers && cd clang-debug-disable-precompile-headers && ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DCMAKE_DISABLE_PRECOMPILE_HEADERS=On .. &\
-    //         mkdir clang-debug-addr-ub-leak-sanitizers && cd clang-debug-addr-ub-leak-sanitizers &&       ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DENABLE_ADDR_UB_LEAK_SANITIZATION=ON .. &\
-    //         mkdir clang-release-addr-ub-leak-sanitizers && cd clang-release-addr-ub-leak-sanitizers &&   ${cmake} ${release}        ${clang}   ${unity}           ${ninja} -DENABLE_ADDR_UB_LEAK_SANITIZATION=ON .. &\
-    //         mkdir clang-relwithdebinfo-thread-sanitizer && cd clang-relwithdebinfo-thread-sanitizer &&   ${cmake} ${relwithdebinfo} ${clang}   ${unity}           ${ninja} -DENABLE_THREAD_SANITIZATION=ON .. &\
-    //         mkdir clang-release && cd clang-release &&                                                   ${cmake} ${release}        ${clang}   ${unity}           ${ninja} .. &\
-    //         mkdir gcc-debug && cd gcc-debug &&                                                           ${cmake} ${debug}          ${gcc}     ${unity}           ${ninja} .. &\
-    //         mkdir gcc-release && cd gcc-release &&                                                       ${cmake} ${release}        ${gcc}     ${unity} ${no_lto} ${ninja} .. &\
-    //         mkdir clang-16-debug && cd clang-16-debug &&                                                 ${cmake} ${debug}          ${clang16} ${unity}           ${ninja} .. &\
-    //         mkdir gcc-13-debug && cd gcc-13-debug &&                                                     ${cmake} ${debug}          ${gcc13}   ${unity}           ${ninja} .. &\
-    //         wait"
-    //       }
+            // Configure the rest in parallel. We use unity builds to decrease build times. The only exception is the
+            // clang-tidy build as it might otherwise miss some issues (e.g., missing includes).
+            sh "mkdir clang-debug-tidy && cd clang-debug-tidy &&                                         ${cmake} ${debug}          ${clang}                      ${ninja} -DENABLE_CLANG_TIDY=ON .. &\
+            mkdir clang-debug-unity-odr && cd clang-debug-unity-odr &&                                   ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DCMAKE_UNITY_BUILD_BATCH_SIZE=0 .. &\
+            mkdir clang-debug-disable-precompile-headers && cd clang-debug-disable-precompile-headers && ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DCMAKE_DISABLE_PRECOMPILE_HEADERS=On .. &\
+            mkdir clang-debug-addr-ub-leak-sanitizers && cd clang-debug-addr-ub-leak-sanitizers &&       ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DENABLE_ADDR_UB_LEAK_SANITIZATION=ON .. &\
+            mkdir clang-release-addr-ub-leak-sanitizers && cd clang-release-addr-ub-leak-sanitizers &&   ${cmake} ${release}        ${clang}   ${unity}           ${ninja} -DENABLE_ADDR_UB_LEAK_SANITIZATION=ON .. &\
+            mkdir clang-relwithdebinfo-thread-sanitizer && cd clang-relwithdebinfo-thread-sanitizer &&   ${cmake} ${relwithdebinfo} ${clang}   ${unity}           ${ninja} -DENABLE_THREAD_SANITIZATION=ON .. &\
+            mkdir clang-release && cd clang-release &&                                                   ${cmake} ${release}        ${clang}   ${unity}           ${ninja} .. &\
+            mkdir gcc-debug && cd gcc-debug &&                                                           ${cmake} ${debug}          ${gcc}     ${unity}           ${ninja} .. &\
+            mkdir gcc-release && cd gcc-release &&                                                       ${cmake} ${release}        ${gcc}     ${unity} ${no_lto} ${ninja} .. &\
+            mkdir clang-16-debug && cd clang-16-debug &&                                                 ${cmake} ${debug}          ${clang16} ${unity}           ${ninja} .. &\
+            mkdir gcc-13-debug && cd gcc-13-debug &&                                                     ${cmake} ${debug}          ${gcc13}   ${unity}           ${ninja} .. &\
+            wait"
+          }
 
-    //       parallel clangDebug: {
-    //         stage("clang-debug") {
-    //           // We build clang-debug using make to test make once (and clang-debug is the fastest build).
-    //           sh "cd clang-debug && make all -j \$(( \$(nproc) / 4))"
-    //           sh "./clang-debug/hyriseTest clang-debug"
-    //         }
-    //       }, clang16Debug: {
-    //         stage("clang-16-debug") {
-    //           sh "cd clang-16-debug && ninja all -j \$(( \$(nproc) / 4))"
-    //           sh "./clang-16-debug/hyriseTest clang-16-debug"
-    //         }
-    //       }, gccDebug: {
-    //         stage("gcc-debug") {
-    //           sh "cd gcc-debug && ninja all -j \$(( \$(nproc) / 4))"
-    //           sh "cd gcc-debug && ./hyriseTest"
-    //         }
-    //       }, gcc13Debug: {
-    //         stage("gcc-13-debug") {
-    //           sh "cd gcc-13-debug && ninja all -j \$(( \$(nproc) / 4))"
-    //           sh "cd gcc-13-debug && ./hyriseTest"
-    //         }
-    //       }, lint: {
-    //         stage("Linting") {
-    //           sh "scripts/lint.sh"
-    //         }
-    //       }
+          parallel clangDebug: {
+            stage("clang-debug") {
+              // We build clang-debug using make to test make once (and clang-debug is the fastest build).
+              sh "cd clang-debug && make all -j \$(( \$(nproc) / 4))"
+              sh "./clang-debug/hyriseTest clang-debug"
+            }
+          }, clang16Debug: {
+            stage("clang-16-debug") {
+              sh "cd clang-16-debug && ninja all -j \$(( \$(nproc) / 4))"
+              sh "./clang-16-debug/hyriseTest clang-16-debug"
+            }
+          }, gccDebug: {
+            stage("gcc-debug") {
+              sh "cd gcc-debug && ninja all -j \$(( \$(nproc) / 4))"
+              sh "cd gcc-debug && ./hyriseTest"
+            }
+          }, gcc13Debug: {
+            stage("gcc-13-debug") {
+              sh "cd gcc-13-debug && ninja all -j \$(( \$(nproc) / 4))"
+              sh "cd gcc-13-debug && ./hyriseTest"
+            }
+          }, lint: {
+            stage("Linting") {
+              sh "scripts/lint.sh"
+            }
+          }
 
-    //       // We distribute the cores to processes in a way to even the running times. With an even distributions,
-    //       // clang-tidy builds take up to 3h (galileo server). In addition to compile time, the distribution also
-    //       // considers the long test runtimes of clangRelWithDebInfoThreadSanitizer (~50 minutes).
-    //       parallel clangRelease: {
-    //         stage("clang-release") {
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             sh "cd clang-release && ninja all -j \$(( \$(nproc) / 10))"
-    //             sh "./clang-release/hyriseTest clang-release"
-    //             sh "./clang-release/hyriseSystemTest clang-release"
-    //             sh "./scripts/test/hyriseConsole_test.py clang-release"
-    //             sh "./scripts/test/hyriseServer_test.py clang-release"
-    //             sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-release"
-    //             sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-release"
-    //             sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
-    //             sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
+          // We distribute the cores to processes in a way to even the running times. With an even distributions,
+          // clang-tidy builds take up to 3h (galileo server). In addition to compile time, the distribution also
+          // considers the long test runtimes of clangRelWithDebInfoThreadSanitizer (~50 minutes).
+          // parallel clangRelease: {
+          //   stage("clang-release") {
+          //     if (env.BRANCH_NAME == 'master' || full_ci) {
+          //       sh "cd clang-release && ninja all -j \$(( \$(nproc) / 10))"
+          //       sh "./clang-release/hyriseTest clang-release"
+          //       sh "./clang-release/hyriseSystemTest clang-release"
+          //       sh "./scripts/test/hyriseConsole_test.py clang-release"
+          //       sh "./scripts/test/hyriseServer_test.py clang-release"
+          //       sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-release"
+          //       sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-release"
+          //       sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
+          //       sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
 
-    //           } else {
-    //             Utils.markStageSkippedForConditional("clangRelease")
-    //           }
-    //         }
-    //       }, debugSystemTests: {
-    //         stage("system-tests") {
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             sh "mkdir clang-debug-system &&  ./clang-debug/hyriseSystemTest clang-debug-system"
-    //             sh "mkdir gcc-debug-system &&  ./gcc-debug/hyriseSystemTest gcc-debug-system"
-    //             sh "./scripts/test/hyriseConsole_test.py clang-debug"
-    //             sh "./scripts/test/hyriseServer_test.py clang-debug"
-    //             sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-debug"
-    //             sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-debug"
-    //             sh "cd clang-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
-    //             sh "cd clang-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate cached data
-    //             sh "cd clang-debug && ../scripts/test/hyriseBenchmarkStarSchema_test.py ." // Own folder to isolate cached data
-    //             sh "./scripts/test/hyriseConsole_test.py gcc-debug"
-    //             sh "./scripts/test/hyriseServer_test.py gcc-debug"
-    //             sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-debug"
-    //             sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-debug"
-    //             sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
-    //             sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate cached data
-    //             sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkStarSchema_test.py ." // Own folder to isolate cached data
+          //     } else {
+          //       Utils.markStageSkippedForConditional("clangRelease")
+          //     }
+          //   }
+          // }, debugSystemTests: {
+          //   stage("system-tests") {
+          //     if (env.BRANCH_NAME == 'master' || full_ci) {
+          //       sh "mkdir clang-debug-system &&  ./clang-debug/hyriseSystemTest clang-debug-system"
+          //       sh "mkdir gcc-debug-system &&  ./gcc-debug/hyriseSystemTest gcc-debug-system"
+          //       sh "./scripts/test/hyriseConsole_test.py clang-debug"
+          //       sh "./scripts/test/hyriseServer_test.py clang-debug"
+          //       sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-debug"
+          //       sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-debug"
+          //       sh "cd clang-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
+          //       sh "cd clang-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate cached data
+          //       sh "cd clang-debug && ../scripts/test/hyriseBenchmarkStarSchema_test.py ." // Own folder to isolate cached data
+          //       sh "./scripts/test/hyriseConsole_test.py gcc-debug"
+          //       sh "./scripts/test/hyriseServer_test.py gcc-debug"
+          //       sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-debug"
+          //       sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-debug"
+          //       sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
+          //       sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate cached data
+          //       sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkStarSchema_test.py ." // Own folder to isolate cached data
 
-    //           } else {
-    //             Utils.markStageSkippedForConditional("debugSystemTests")
-    //           }
-    //         }
-    //       }, clangDebugRunShuffled: {
-    //         stage("clang-debug:test-shuffle") {
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             sh "mkdir ./clang-debug/run-shuffled"
-    //             sh "./clang-debug/hyriseTest clang-debug/run-shuffled --gtest_repeat=5 --gtest_shuffle"
-    //             // We do not want to trigger SSB data generation concurrently since it is not concurrency-safe.
-    //             sh "./clang-debug/hyriseSystemTest clang-debug/run-shuffled --gtest_repeat=2 --gtest_shuffle --gtest_filter=\"-SSBTableGeneratorTest.*:SQLiteTestRunnerEncodings/*\""
-    //           } else {
-    //             Utils.markStageSkippedForConditional("clangDebugRunShuffled")
-    //           }
-    //         }
-    //       }, clangDebugUnityODR: {
-    //         stage("clang-debug-unity-odr") {
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             // Check if unity builds work even if everything is batched into a single compilation unit. This helps prevent ODR (one definition rule) issues.
-    //             sh "cd clang-debug-unity-odr && ninja all -j 2"
-    //           } else {
-    //             Utils.markStageSkippedForConditional("clangDebugUnityODR")
-    //           }
-    //         }
-    //       }, clangDebugTidy: {
-    //         stage("clang-debug:tidy") {
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             // We do not run tidy checks on the src/test folder, so there is no point in running the expensive clang-tidy for those files
-    //             sh "cd clang-debug-tidy && ninja hyrise_impl hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer hyriseMvccDeletePlugin hyriseUccDiscoveryPlugin -k 0 -j \$(( \$(nproc) / 5))"
-    //           } else {
-    //             Utils.markStageSkippedForConditional("clangDebugTidy")
-    //           }
-    //         }
-    //       }, clangDebugDisablePrecompileHeaders: {
-    //         stage("clang-debug:disable-precompile-headers") {
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             // Check if builds work even when precompile headers is turned off. Executing the binaries is unnecessary as the observed errors are missing includes.
-    //             sh "cd clang-debug-disable-precompile-headers && ninja hyriseTest hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer -k 0 -j 2"
-    //           } else {
-    //             Utils.markStageSkippedForConditional("clangDebugDisablePrecompileHeaders")
-    //           }
-    //         }
-    //       }, clangDebugAddrUBLeakSanitizers: {
-    //         stage("clang-debug:addr-ub-sanitizers") {
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             sh "cd clang-debug-addr-ub-leak-sanitizers && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 10))"
-    //             sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseTest clang-debug-addr-ub-leak-sanitizers"
-    //             sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-debug-addr-ub-leak-sanitizers"
-    //             sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 1"
-    //           } else {
-    //             Utils.markStageSkippedForConditional("clangDebugAddrUBLeakSanitizers")
-    //           }
-    //         }
-    //       }, gccRelease: {
-    //         if (env.BRANCH_NAME == 'master' || full_ci) {
-    //           stage("gcc-release") {
-    //             sh "cd gcc-release && ninja all -j \$(( \$(nproc) / 10))"
-    //             sh "./gcc-release/hyriseTest gcc-release"
-    //             sh "./gcc-release/hyriseSystemTest gcc-release"
-    //             sh "./scripts/test/hyriseConsole_test.py gcc-release"
-    //             sh "./scripts/test/hyriseServer_test.py gcc-release"
-    //             sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-release"
-    //             sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-release"
-    //             sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
-    //             sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
-    //           }
-    //         } else {
-    //             Utils.markStageSkippedForConditional("gccRelease")
-    //         }
-    //       }, clangReleaseAddrUBLeakSanitizers: {
-    //         stage("clang-release:addr-ub-sanitizers") {
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             sh "cd clang-release-addr-ub-leak-sanitizers && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 5))"
-    //             sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseTest clang-release-addr-ub-leak-sanitizers"
-    //             sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-release-addr-ub-leak-sanitizers"
-    //             sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
-    //             sh "cd clang-release-addr-ub-leak-sanitizers && LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
-    //           } else {
-    //             Utils.markStageSkippedForConditional("clangReleaseAddrUBLeakSanitizers")
-    //           }
-    //         }
-    //       }, clangRelWithDebInfoThreadSanitizer: {
-    //         stage("clang-relwithdebinfo:thread-sanitizer") {
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             sh "cd clang-relwithdebinfo-thread-sanitizer && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC hyriseBenchmarkTPCDS -j \$(( \$(nproc) / 5))"
-    //             sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseTest clang-relwithdebinfo-thread-sanitizer"
-    //             sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-relwithdebinfo-thread-sanitizer"
-    //             sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCH -s .01 -r 100 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
-    //             sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCC -s 1 --time 120 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
-    //             sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCDS -s 1 -r 5 --scheduler --clients 5 --cores \$(( \$(nproc) / 10))"
-    //           } else {
-    //             Utils.markStageSkippedForConditional("clangRelWithDebInfoThreadSanitizer")
-    //           }
-    //         }
-    //       }, clangDebugCoverage: {
-    //         stage("clang-debug-coverage") {
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             sh "./scripts/coverage.sh --generate_badge=true"
-    //             sh "find coverage -type d -exec chmod +rx {} \\;"
-    //             archive 'coverage_badge.svg'
-    //             archive 'coverage_percent.txt'
-    //             publishHTML (target: [
-    //               allowMissing: false,
-    //               alwaysLinkToLastBuild: false,
-    //               keepAll: true,
-    //               reportDir: 'coverage',
-    //               reportFiles: 'index.html',
-    //               reportName: "Llvm-cov_Report"
-    //             ])
-    //             script {
-    //               coverageChange = sh script: "./scripts/compare_coverage.sh", returnStdout: true
-    //               githubNotify context: 'Coverage', description: "$coverageChange", status: 'SUCCESS', targetUrl: "${env.BUILD_URL}/RCov_20Report/index.html"
-    //             }
-    //           } else {
-    //             Utils.markStageSkippedForConditional("clangDebugCoverage")
-    //           }
-    //         }
-    //       }
+          //     } else {
+          //       Utils.markStageSkippedForConditional("debugSystemTests")
+          //     }
+          //   }
+          // }, clangDebugRunShuffled: {
+          //   stage("clang-debug:test-shuffle") {
+          //     if (env.BRANCH_NAME == 'master' || full_ci) {
+          //       sh "mkdir ./clang-debug/run-shuffled"
+          //       sh "./clang-debug/hyriseTest clang-debug/run-shuffled --gtest_repeat=5 --gtest_shuffle"
+          //       // We do not want to trigger SSB data generation concurrently since it is not concurrency-safe.
+          //       sh "./clang-debug/hyriseSystemTest clang-debug/run-shuffled --gtest_repeat=2 --gtest_shuffle --gtest_filter=\"-SSBTableGeneratorTest.*:SQLiteTestRunnerEncodings/*\""
+          //     } else {
+          //       Utils.markStageSkippedForConditional("clangDebugRunShuffled")
+          //     }
+          //   }
+          // }, clangDebugUnityODR: {
+          //   stage("clang-debug-unity-odr") {
+          //     if (env.BRANCH_NAME == 'master' || full_ci) {
+          //       // Check if unity builds work even if everything is batched into a single compilation unit. This helps prevent ODR (one definition rule) issues.
+          //       sh "cd clang-debug-unity-odr && ninja all -j 2"
+          //     } else {
+          //       Utils.markStageSkippedForConditional("clangDebugUnityODR")
+          //     }
+          //   }
+          // }, clangDebugTidy: {
+          //   stage("clang-debug:tidy") {
+          //     if (env.BRANCH_NAME == 'master' || full_ci) {
+          //       // We do not run tidy checks on the src/test folder, so there is no point in running the expensive clang-tidy for those files
+          //       sh "cd clang-debug-tidy && ninja hyrise_impl hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer hyriseMvccDeletePlugin hyriseUccDiscoveryPlugin -k 0 -j \$(( \$(nproc) / 5))"
+          //     } else {
+          //       Utils.markStageSkippedForConditional("clangDebugTidy")
+          //     }
+          //   }
+          // }, clangDebugDisablePrecompileHeaders: {
+          //   stage("clang-debug:disable-precompile-headers") {
+          //     if (env.BRANCH_NAME == 'master' || full_ci) {
+          //       // Check if builds work even when precompile headers is turned off. Executing the binaries is unnecessary as the observed errors are missing includes.
+          //       sh "cd clang-debug-disable-precompile-headers && ninja hyriseTest hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer -k 0 -j 2"
+          //     } else {
+          //       Utils.markStageSkippedForConditional("clangDebugDisablePrecompileHeaders")
+          //     }
+          //   }
+          // }, clangDebugAddrUBLeakSanitizers: {
+          //   stage("clang-debug:addr-ub-sanitizers") {
+          //     if (env.BRANCH_NAME == 'master' || full_ci) {
+          //       sh "cd clang-debug-addr-ub-leak-sanitizers && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 10))"
+          //       sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseTest clang-debug-addr-ub-leak-sanitizers"
+          //       sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-debug-addr-ub-leak-sanitizers"
+          //       sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 1"
+          //     } else {
+          //       Utils.markStageSkippedForConditional("clangDebugAddrUBLeakSanitizers")
+          //     }
+          //   }
+          // }, gccRelease: {
+          //   if (env.BRANCH_NAME == 'master' || full_ci) {
+          //     stage("gcc-release") {
+          //       sh "cd gcc-release && ninja all -j \$(( \$(nproc) / 10))"
+          //       sh "./gcc-release/hyriseTest gcc-release"
+          //       sh "./gcc-release/hyriseSystemTest gcc-release"
+          //       sh "./scripts/test/hyriseConsole_test.py gcc-release"
+          //       sh "./scripts/test/hyriseServer_test.py gcc-release"
+          //       sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-release"
+          //       sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-release"
+          //       sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
+          //       sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
+          //     }
+          //   } else {
+          //       Utils.markStageSkippedForConditional("gccRelease")
+          //   }
+          // }, clangReleaseAddrUBLeakSanitizers: {
+          //   stage("clang-release:addr-ub-sanitizers") {
+          //     if (env.BRANCH_NAME == 'master' || full_ci) {
+          //       sh "cd clang-release-addr-ub-leak-sanitizers && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 5))"
+          //       sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseTest clang-release-addr-ub-leak-sanitizers"
+          //       sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-release-addr-ub-leak-sanitizers"
+          //       sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
+          //       sh "cd clang-release-addr-ub-leak-sanitizers && LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
+          //     } else {
+          //       Utils.markStageSkippedForConditional("clangReleaseAddrUBLeakSanitizers")
+          //     }
+          //   }
+          // }, clangRelWithDebInfoThreadSanitizer: {
+          //   stage("clang-relwithdebinfo:thread-sanitizer") {
+          //     if (env.BRANCH_NAME == 'master' || full_ci) {
+          //       sh "cd clang-relwithdebinfo-thread-sanitizer && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC hyriseBenchmarkTPCDS -j \$(( \$(nproc) / 5))"
+          //       sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseTest clang-relwithdebinfo-thread-sanitizer"
+          //       sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-relwithdebinfo-thread-sanitizer"
+          //       sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCH -s .01 -r 100 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
+          //       sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCC -s 1 --time 120 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
+          //       sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCDS -s 1 -r 5 --scheduler --clients 5 --cores \$(( \$(nproc) / 10))"
+          //     } else {
+          //       Utils.markStageSkippedForConditional("clangRelWithDebInfoThreadSanitizer")
+          //     }
+          //   }
+          // }, clangDebugCoverage: {
+          //   stage("clang-debug-coverage") {
+          //     if (env.BRANCH_NAME == 'master' || full_ci) {
+          //       sh "./scripts/coverage.sh --generate_badge=true"
+          //       sh "find coverage -type d -exec chmod +rx {} \\;"
+          //       archive 'coverage_badge.svg'
+          //       archive 'coverage_percent.txt'
+          //       publishHTML (target: [
+          //         allowMissing: false,
+          //         alwaysLinkToLastBuild: false,
+          //         keepAll: true,
+          //         reportDir: 'coverage',
+          //         reportFiles: 'index.html',
+          //         reportName: "Llvm-cov_Report"
+          //       ])
+          //       script {
+          //         coverageChange = sh script: "./scripts/compare_coverage.sh", returnStdout: true
+          //         githubNotify context: 'Coverage', description: "$coverageChange", status: 'SUCCESS', targetUrl: "${env.BUILD_URL}/RCov_20Report/index.html"
+          //       }
+          //     } else {
+          //       Utils.markStageSkippedForConditional("clangDebugCoverage")
+          //     }
+          //   }
+          // }
 
-    //       parallel memcheckReleaseTest: {
-    //         stage("memcheckReleaseTest") {
-    //           // Runs after the other sanitizers as it depends on clang-release to be built.
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             sh "mkdir ./clang-release-memcheck-test"
-    //             // If this shows a leak, try --leak-check=full, which is slower but more precise. Valgrind serializes
-    //             // concurrent threads into a single one. Thus, we limit the cores and data preparation cores for the
-    //             // benchmark runs to reduce this serialization overhead. According to the Valgrind documentation,
-    //             // --fair-sched=yes "improves overall responsiveness if you are running an interactive multithreaded
-    //             // program" and "produces better reproducibility of thread scheduling for different executions of a
-    //             // multithreaded application" (i.e., there are no runs that are randomly faster or slower).
-    //             sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseTest clang-release-memcheck-test --gtest_filter=-NUMAMemoryResourceTest.BasicAllocate:SQLiteTestRunner*"
-    //             sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCH -s .01 -r 1 --scheduler --cores 4 --data_preparation_cores 4"
-    //             sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCDS -s 1 -r 1 --scheduler --cores 4 --data_preparation_cores 4"
-    //             sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCC -s 1 --scheduler --cores 4 --data_preparation_cores 4"
-    //           } else {
-    //             Utils.markStageSkippedForConditional("memcheckReleaseTest")
-    //           }
-    //         }
-    //       }, tpchVerification: {
-    //         stage("tpchVerification") {
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             // Verify both single- and multithreaded results.
-    //             sh "./clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 1 -s 1 --verify"
-    //             sh "./clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 1 -s 1 --verify --scheduler --clients 1 --cores 10"
-    //           } else {
-    //             Utils.markStageSkippedForConditional("tpchVerification")
-    //           }
-    //         }
-    //       }, tpchQueryPlans: {
-    //         stage("tpchQueryPlans") {
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             sh "mkdir -p query_plans/tpch; cd query_plans/tpch && ../../clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 2 -s 10 --visualize && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
-    //             archiveArtifacts artifacts: 'query_plans/tpch/*.svg'
-    //             archiveArtifacts artifacts: 'query_plans/tpch/operator_breakdown.pdf'
-    //           } else {
-    //             Utils.markStageSkippedForConditional("tpchQueryPlans")
-    //           }
-    //         }
-    //       }, tpcdsQueryPlansAndVerification: {
-    //         stage("tpcdsQueryPlansAndVerification") {
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             sh "mkdir -p query_plans/tpcds; cd query_plans/tpcds && ln -s ../../resources; ../../clang-release/hyriseBenchmarkTPCDS --dont_cache_binary_tables -r 1 -s 1 --visualize --verify && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
-    //             archiveArtifacts artifacts: 'query_plans/tpcds/*.svg'
-    //             archiveArtifacts artifacts: 'query_plans/tpcds/operator_breakdown.pdf'
-    //           } else {
-    //             Utils.markStageSkippedForConditional("tpcdsQueryPlansAndVerification")
-    //           }
-    //         }
-    //       }, jobQueryPlans: {
-    //         stage("jobQueryPlans") {
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             // In contrast to TPC-H and TPC-DS above, we execute the JoinOrderBenchmark from the project's root directoy because its setup script requires us to do so.
-    //             sh "mkdir -p query_plans/job && ./clang-release/hyriseBenchmarkJoinOrder --dont_cache_binary_tables -r 1 --visualize && ./scripts/plot_operator_breakdown.py ./clang-release/ && mv operator_breakdown.pdf query_plans/job && mv *QP.svg query_plans/job"
-    //             archiveArtifacts artifacts: 'query_plans/job/*.svg'
-    //             archiveArtifacts artifacts: 'query_plans/job/operator_breakdown.pdf'
-    //           } else {
-    //             Utils.markStageSkippedForConditional("jobQueryPlans")
-    //           }
-    //         }
-    //       }, ssbQueryPlans: {
-    //         stage("ssbQueryPlans") {
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             sh "mkdir -p query_plans/ssb; cd query_plans/ssb && ../../clang-release/hyriseBenchmarkStarSchema --dont_cache_binary_tables -r 1 -s 1 --visualize && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
-    //             archiveArtifacts artifacts: 'query_plans/ssb/*.svg'
-    //             archiveArtifacts artifacts: 'query_plans/ssb/operator_breakdown.pdf'
-    //           } else {
-    //             Utils.markStageSkippedForConditional("ssbQueryPlans")
-    //           }
-    //         }
-    //       }, nixSetup: {
-    //         stage('nixSetup') {
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             sh "curl -L https://nixos.org/nix/install > nix-install.sh && chmod +x nix-install.sh && ./nix-install.sh --daemon --yes"
-    //             sh "/nix/var/nix/profiles/default/bin/nix-shell resources/nix --pure --run \"mkdir nix-debug && cd nix-debug && cmake ${debug} ${clang} ${unity} ${ninja} .. && ninja all -j \$(( \$(nproc) / 7)) && ./hyriseTest\""
-    //             // We allocate a third of all cores for the release build as several parallel stages should have already finished at this point.
-    //             sh "/nix/var/nix/profiles/default/bin/nix-shell resources/nix --pure --run \"mkdir nix-release && cd nix-release && cmake ${release} ${clang} ${unity} ${ninja} .. && ninja all -j \$(( \$(nproc) / 3)) && ./hyriseTest\""
-    //           } else {
-    //             Utils.markStageSkippedForConditional("nixSetup")
-    //           }
-    //         }
-    //       }
-    //     } finally {
-    //       sh "ls -A1 | xargs rm -rf"
-    //       deleteDir()
-    //     }
-    //   }
-    // }
+          // parallel memcheckReleaseTest: {
+          //   stage("memcheckReleaseTest") {
+          //     // Runs after the other sanitizers as it depends on clang-release to be built.
+          //     if (env.BRANCH_NAME == 'master' || full_ci) {
+          //       sh "mkdir ./clang-release-memcheck-test"
+          //       // If this shows a leak, try --leak-check=full, which is slower but more precise. Valgrind serializes
+          //       // concurrent threads into a single one. Thus, we limit the cores and data preparation cores for the
+          //       // benchmark runs to reduce this serialization overhead. According to the Valgrind documentation,
+          //       // --fair-sched=yes "improves overall responsiveness if you are running an interactive multithreaded
+          //       // program" and "produces better reproducibility of thread scheduling for different executions of a
+          //       // multithreaded application" (i.e., there are no runs that are randomly faster or slower).
+          //       sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseTest clang-release-memcheck-test --gtest_filter=-NUMAMemoryResourceTest.BasicAllocate:SQLiteTestRunner*"
+          //       sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCH -s .01 -r 1 --scheduler --cores 4 --data_preparation_cores 4"
+          //       sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCDS -s 1 -r 1 --scheduler --cores 4 --data_preparation_cores 4"
+          //       sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCC -s 1 --scheduler --cores 4 --data_preparation_cores 4"
+          //     } else {
+          //       Utils.markStageSkippedForConditional("memcheckReleaseTest")
+          //     }
+          //   }
+          // }, tpchVerification: {
+          //   stage("tpchVerification") {
+          //     if (env.BRANCH_NAME == 'master' || full_ci) {
+          //       // Verify both single- and multithreaded results.
+          //       sh "./clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 1 -s 1 --verify"
+          //       sh "./clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 1 -s 1 --verify --scheduler --clients 1 --cores 10"
+          //     } else {
+          //       Utils.markStageSkippedForConditional("tpchVerification")
+          //     }
+          //   }
+          // }, tpchQueryPlans: {
+          //   stage("tpchQueryPlans") {
+          //     if (env.BRANCH_NAME == 'master' || full_ci) {
+          //       sh "mkdir -p query_plans/tpch; cd query_plans/tpch && ../../clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 2 -s 10 --visualize && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
+          //       archiveArtifacts artifacts: 'query_plans/tpch/*.svg'
+          //       archiveArtifacts artifacts: 'query_plans/tpch/operator_breakdown.pdf'
+          //     } else {
+          //       Utils.markStageSkippedForConditional("tpchQueryPlans")
+          //     }
+          //   }
+          // }, tpcdsQueryPlansAndVerification: {
+          //   stage("tpcdsQueryPlansAndVerification") {
+          //     if (env.BRANCH_NAME == 'master' || full_ci) {
+          //       sh "mkdir -p query_plans/tpcds; cd query_plans/tpcds && ln -s ../../resources; ../../clang-release/hyriseBenchmarkTPCDS --dont_cache_binary_tables -r 1 -s 1 --visualize --verify && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
+          //       archiveArtifacts artifacts: 'query_plans/tpcds/*.svg'
+          //       archiveArtifacts artifacts: 'query_plans/tpcds/operator_breakdown.pdf'
+          //     } else {
+          //       Utils.markStageSkippedForConditional("tpcdsQueryPlansAndVerification")
+          //     }
+          //   }
+          // }, jobQueryPlans: {
+          //   stage("jobQueryPlans") {
+          //     if (env.BRANCH_NAME == 'master' || full_ci) {
+          //       // In contrast to TPC-H and TPC-DS above, we execute the JoinOrderBenchmark from the project's root directoy because its setup script requires us to do so.
+          //       sh "mkdir -p query_plans/job && ./clang-release/hyriseBenchmarkJoinOrder --dont_cache_binary_tables -r 1 --visualize && ./scripts/plot_operator_breakdown.py ./clang-release/ && mv operator_breakdown.pdf query_plans/job && mv *QP.svg query_plans/job"
+          //       archiveArtifacts artifacts: 'query_plans/job/*.svg'
+          //       archiveArtifacts artifacts: 'query_plans/job/operator_breakdown.pdf'
+          //     } else {
+          //       Utils.markStageSkippedForConditional("jobQueryPlans")
+          //     }
+          //   }
+          // }, ssbQueryPlans: {
+          //   stage("ssbQueryPlans") {
+          //     if (env.BRANCH_NAME == 'master' || full_ci) {
+          //       sh "mkdir -p query_plans/ssb; cd query_plans/ssb && ../../clang-release/hyriseBenchmarkStarSchema --dont_cache_binary_tables -r 1 -s 1 --visualize && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
+          //       archiveArtifacts artifacts: 'query_plans/ssb/*.svg'
+          //       archiveArtifacts artifacts: 'query_plans/ssb/operator_breakdown.pdf'
+          //     } else {
+          //       Utils.markStageSkippedForConditional("ssbQueryPlans")
+          //     }
+          //   }
+          // }, nixSetup: {
+          //   stage('nixSetup') {
+          //     if (env.BRANCH_NAME == 'master' || full_ci) {
+          //       sh "curl -L https://nixos.org/nix/install > nix-install.sh && chmod +x nix-install.sh && ./nix-install.sh --daemon --yes"
+          //       sh "/nix/var/nix/profiles/default/bin/nix-shell resources/nix --pure --run \"mkdir nix-debug && cd nix-debug && cmake ${debug} ${clang} ${unity} ${ninja} .. && ninja all -j \$(( \$(nproc) / 7)) && ./hyriseTest\""
+          //       // We allocate a third of all cores for the release build as several parallel stages should have already finished at this point.
+          //       sh "/nix/var/nix/profiles/default/bin/nix-shell resources/nix --pure --run \"mkdir nix-release && cd nix-release && cmake ${release} ${clang} ${unity} ${ninja} .. && ninja all -j \$(( \$(nproc) / 3)) && ./hyriseTest\""
+          //     } else {
+          //       Utils.markStageSkippedForConditional("nixSetup")
+          //     }
+          //   }
+          // }
+        } finally {
+          sh "ls -A1 | xargs rm -rf"
+          deleteDir()
+        }
+      }
+    }
   }
 
   parallel clangMacX64: {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,362 +55,362 @@ try {
     }
   }
 
-  // node('linux') {
-  //   stage("Hostname") {
-  //     // Print the hostname to let us know on which node the docker image was executed for reproducibility.
-  //     sh "hostname"
-  //   }
+  node('linux') {
+    stage("Hostname") {
+      // Print the hostname to let us know on which node the docker image was executed for reproducibility.
+      sh "hostname"
+    }
 
-  //   // The empty '' results in using the default registry: https://index.docker.io/v1/
-  //   docker.withRegistry('', 'docker') {
-  //     def hyriseCI = docker.image('hyrise/hyrise-ci:24.04');
-  //     hyriseCI.pull()
+    // The empty '' results in using the default registry: https://index.docker.io/v1/
+    // docker.withRegistry('', 'docker') {
+    //   def hyriseCI = docker.image('hyrise/hyrise-ci:24.04');
+    //   hyriseCI.pull()
 
-  //     // LSAN (executed as part of ASAN) requires elevated privileges. Therefore, we had to add --cap-add SYS_PTRACE.
-  //     // Even if the CI run sometimes succeeds without SYS_PTRACE, you should not remove it until you know what you are
-  //     // doing. See also: https://github.com/google/sanitizers/issues/764
-  //     hyriseCI.inside("--cap-add SYS_PTRACE -u 0:0") {
-  //       try {
-  //         stage("Setup") {
-  //           checkout scm
+    //   // LSAN (executed as part of ASAN) requires elevated privileges. Therefore, we had to add --cap-add SYS_PTRACE.
+    //   // Even if the CI run sometimes succeeds without SYS_PTRACE, you should not remove it until you know what you are
+    //   // doing. See also: https://github.com/google/sanitizers/issues/764
+    //   hyriseCI.inside("--cap-add SYS_PTRACE -u 0:0") {
+    //     try {
+    //       stage("Setup") {
+    //         checkout scm
 
-  //           // Check if ninja-build is installed. As make is sufficient to work with Hyrise, ninja-build is not
-  //           // installed via install_dependencies.sh but is part of the hyrise-ci docker image.
-  //           sh "ninja --version > /dev/null"
+    //         // Check if ninja-build is installed. As make is sufficient to work with Hyrise, ninja-build is not
+    //         // installed via install_dependencies.sh but is part of the hyrise-ci docker image.
+    //         sh "ninja --version > /dev/null"
 
-  //           // During CI runs, the user is different from the owner of the directories, which blocks the execution of
-  //           // git commands since the fix of the git vulnerability CVE-2022-24765. git commands can then only be
-  //           // executed if the corresponding directories are added as safe directories.
-  //           sh '''
-  //           git config --global --add safe.directory $WORKSPACE
-  //           # Get the paths of the submodules; for each path, add it as a git safe.directory
-  //           grep path .gitmodules | sed 's/.*=//' | xargs -n 1 -I '{}' git config --global --add safe.directory $WORKSPACE/'{}'
-  //           '''
+    //         // During CI runs, the user is different from the owner of the directories, which blocks the execution of
+    //         // git commands since the fix of the git vulnerability CVE-2022-24765. git commands can then only be
+    //         // executed if the corresponding directories are added as safe directories.
+    //         sh '''
+    //         git config --global --add safe.directory $WORKSPACE
+    //         # Get the paths of the submodules; for each path, add it as a git safe.directory
+    //         grep path .gitmodules | sed 's/.*=//' | xargs -n 1 -I '{}' git config --global --add safe.directory $WORKSPACE/'{}'
+    //         '''
 
-  //           sh "./install_dependencies.sh"
+    //         sh "./install_dependencies.sh"
 
-  //           cmake = 'cmake -DCI_BUILD=ON'
+    //         cmake = 'cmake -DCI_BUILD=ON'
 
-  //           // We do not use unity builds with clang-tidy (see below).
-  //           unity = '-DCMAKE_UNITY_BUILD=ON'
+    //         // We do not use unity builds with clang-tidy (see below).
+    //         unity = '-DCMAKE_UNITY_BUILD=ON'
 
-  //           // To speed compiling up, we use ninja for most builds.
-  //           ninja = '-GNinja'
+    //         // To speed compiling up, we use ninja for most builds.
+    //         ninja = '-GNinja'
 
-  //           // With Hyrise, we aim to support the most recent compiler versions and do not invest a lot of work to
-  //           // support older versions. We test LLVM 16 (older versions might work, but LLVM 15 has issues with libstdc++
-  //           // of GCC 14) and GCC 13.2 (oldest version supported by Hyrise). We execute at least debug runs for them. If
-  //           // you want to upgrade compiler versions, please update install_dependencies.sh, DEPENDENCIES.md, and the
-  //           // documentation (README, Wiki).
-  //           clang = '-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++'
-  //           clang16 = '-DCMAKE_C_COMPILER=clang-16 -DCMAKE_CXX_COMPILER=clang++-16'
-  //           gcc = '-DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14'
-  //           gcc13 = '-DCMAKE_C_COMPILER=gcc-13 -DCMAKE_CXX_COMPILER=g++-13'
+    //         // With Hyrise, we aim to support the most recent compiler versions and do not invest a lot of work to
+    //         // support older versions. We test LLVM 16 (older versions might work, but LLVM 15 has issues with libstdc++
+    //         // of GCC 14) and GCC 13.2 (oldest version supported by Hyrise). We execute at least debug runs for them. If
+    //         // you want to upgrade compiler versions, please update install_dependencies.sh, DEPENDENCIES.md, and the
+    //         // documentation (README, Wiki).
+    //         clang = '-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++'
+    //         clang16 = '-DCMAKE_C_COMPILER=clang-16 -DCMAKE_CXX_COMPILER=clang++-16'
+    //         gcc = '-DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14'
+    //         gcc13 = '-DCMAKE_C_COMPILER=gcc-13 -DCMAKE_CXX_COMPILER=g++-13'
 
-  //           debug = '-DCMAKE_BUILD_TYPE=Debug'
-  //           release = '-DCMAKE_BUILD_TYPE=Release'
-  //           relwithdebinfo = '-DCMAKE_BUILD_TYPE=RelWithDebInfo'
+    //         debug = '-DCMAKE_BUILD_TYPE=Debug'
+    //         release = '-DCMAKE_BUILD_TYPE=Release'
+    //         relwithdebinfo = '-DCMAKE_BUILD_TYPE=RelWithDebInfo'
 
-  //           // LTO is automatically disabled for debug and sanitizer builds. As LTO linking with GCC and gold (lld is
-  //           // not supported when using GCC and LTO) takes over an hour, we skip LTO for the GCC release build.
-  //           no_lto = '-DNO_LTO=TRUE'
+    //         // LTO is automatically disabled for debug and sanitizer builds. As LTO linking with GCC and gold (lld is
+    //         // not supported when using GCC and LTO) takes over an hour, we skip LTO for the GCC release build.
+    //         no_lto = '-DNO_LTO=TRUE'
 
-  //           // jemalloc's autoconf operates outside of the build folder (#1413). If we start two cmake instances at the
-  //           // same time, we run into conflicts. Thus, run this one (any one, really) first, so that the autoconf step
-  //           // can finish in peace.
-  //           sh "mkdir clang-debug && cd clang-debug &&                                                   ${cmake} ${debug}          ${clang}  ${unity} .. && make -j \$(nproc) libjemalloc-build"
+    //         // jemalloc's autoconf operates outside of the build folder (#1413). If we start two cmake instances at the
+    //         // same time, we run into conflicts. Thus, run this one (any one, really) first, so that the autoconf step
+    //         // can finish in peace.
+    //         sh "mkdir clang-debug && cd clang-debug &&                                                   ${cmake} ${debug}          ${clang}  ${unity} .. && make -j \$(nproc) libjemalloc-build"
 
-  //           // Configure the rest in parallel. We use unity builds to decrease build times. The only exception is the
-  //           // clang-tidy build as it might otherwise miss some issues (e.g., missing includes).
-  //           sh "mkdir clang-debug-tidy && cd clang-debug-tidy &&                                         ${cmake} ${debug}          ${clang}                      ${ninja} -DENABLE_CLANG_TIDY=ON .. &\
-  //           mkdir clang-debug-unity-odr && cd clang-debug-unity-odr &&                                   ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DCMAKE_UNITY_BUILD_BATCH_SIZE=0 .. &\
-  //           mkdir clang-debug-disable-precompile-headers && cd clang-debug-disable-precompile-headers && ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DCMAKE_DISABLE_PRECOMPILE_HEADERS=On .. &\
-  //           mkdir clang-debug-addr-ub-leak-sanitizers && cd clang-debug-addr-ub-leak-sanitizers &&       ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DENABLE_ADDR_UB_LEAK_SANITIZATION=ON .. &\
-  //           mkdir clang-release-addr-ub-leak-sanitizers && cd clang-release-addr-ub-leak-sanitizers &&   ${cmake} ${release}        ${clang}   ${unity}           ${ninja} -DENABLE_ADDR_UB_LEAK_SANITIZATION=ON .. &\
-  //           mkdir clang-relwithdebinfo-thread-sanitizer && cd clang-relwithdebinfo-thread-sanitizer &&   ${cmake} ${relwithdebinfo} ${clang}   ${unity}           ${ninja} -DENABLE_THREAD_SANITIZATION=ON .. &\
-  //           mkdir clang-release && cd clang-release &&                                                   ${cmake} ${release}        ${clang}   ${unity}           ${ninja} .. &\
-  //           mkdir gcc-debug && cd gcc-debug &&                                                           ${cmake} ${debug}          ${gcc}     ${unity}           ${ninja} .. &\
-  //           mkdir gcc-release && cd gcc-release &&                                                       ${cmake} ${release}        ${gcc}     ${unity} ${no_lto} ${ninja} .. &\
-  //           mkdir clang-16-debug && cd clang-16-debug &&                                                 ${cmake} ${debug}          ${clang16} ${unity}           ${ninja} .. &\
-  //           mkdir gcc-13-debug && cd gcc-13-debug &&                                                     ${cmake} ${debug}          ${gcc13}   ${unity}           ${ninja} .. &\
-  //           wait"
-  //         }
+    //         // Configure the rest in parallel. We use unity builds to decrease build times. The only exception is the
+    //         // clang-tidy build as it might otherwise miss some issues (e.g., missing includes).
+    //         sh "mkdir clang-debug-tidy && cd clang-debug-tidy &&                                         ${cmake} ${debug}          ${clang}                      ${ninja} -DENABLE_CLANG_TIDY=ON .. &\
+    //         mkdir clang-debug-unity-odr && cd clang-debug-unity-odr &&                                   ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DCMAKE_UNITY_BUILD_BATCH_SIZE=0 .. &\
+    //         mkdir clang-debug-disable-precompile-headers && cd clang-debug-disable-precompile-headers && ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DCMAKE_DISABLE_PRECOMPILE_HEADERS=On .. &\
+    //         mkdir clang-debug-addr-ub-leak-sanitizers && cd clang-debug-addr-ub-leak-sanitizers &&       ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DENABLE_ADDR_UB_LEAK_SANITIZATION=ON .. &\
+    //         mkdir clang-release-addr-ub-leak-sanitizers && cd clang-release-addr-ub-leak-sanitizers &&   ${cmake} ${release}        ${clang}   ${unity}           ${ninja} -DENABLE_ADDR_UB_LEAK_SANITIZATION=ON .. &\
+    //         mkdir clang-relwithdebinfo-thread-sanitizer && cd clang-relwithdebinfo-thread-sanitizer &&   ${cmake} ${relwithdebinfo} ${clang}   ${unity}           ${ninja} -DENABLE_THREAD_SANITIZATION=ON .. &\
+    //         mkdir clang-release && cd clang-release &&                                                   ${cmake} ${release}        ${clang}   ${unity}           ${ninja} .. &\
+    //         mkdir gcc-debug && cd gcc-debug &&                                                           ${cmake} ${debug}          ${gcc}     ${unity}           ${ninja} .. &\
+    //         mkdir gcc-release && cd gcc-release &&                                                       ${cmake} ${release}        ${gcc}     ${unity} ${no_lto} ${ninja} .. &\
+    //         mkdir clang-16-debug && cd clang-16-debug &&                                                 ${cmake} ${debug}          ${clang16} ${unity}           ${ninja} .. &\
+    //         mkdir gcc-13-debug && cd gcc-13-debug &&                                                     ${cmake} ${debug}          ${gcc13}   ${unity}           ${ninja} .. &\
+    //         wait"
+    //       }
 
-  //         parallel clangDebug: {
-  //           stage("clang-debug") {
-  //             // We build clang-debug using make to test make once (and clang-debug is the fastest build).
-  //             sh "cd clang-debug && make all -j \$(( \$(nproc) / 4))"
-  //             sh "./clang-debug/hyriseTest clang-debug"
-  //           }
-  //         }, clang16Debug: {
-  //           stage("clang-16-debug") {
-  //             sh "cd clang-16-debug && ninja all -j \$(( \$(nproc) / 4))"
-  //             sh "./clang-16-debug/hyriseTest clang-16-debug"
-  //           }
-  //         }, gccDebug: {
-  //           stage("gcc-debug") {
-  //             sh "cd gcc-debug && ninja all -j \$(( \$(nproc) / 4))"
-  //             sh "cd gcc-debug && ./hyriseTest"
-  //           }
-  //         }, gcc13Debug: {
-  //           stage("gcc-13-debug") {
-  //             sh "cd gcc-13-debug && ninja all -j \$(( \$(nproc) / 4))"
-  //             sh "cd gcc-13-debug && ./hyriseTest"
-  //           }
-  //         }, lint: {
-  //           stage("Linting") {
-  //             sh "scripts/lint.sh"
-  //           }
-  //         }
+    //       parallel clangDebug: {
+    //         stage("clang-debug") {
+    //           // We build clang-debug using make to test make once (and clang-debug is the fastest build).
+    //           sh "cd clang-debug && make all -j \$(( \$(nproc) / 4))"
+    //           sh "./clang-debug/hyriseTest clang-debug"
+    //         }
+    //       }, clang16Debug: {
+    //         stage("clang-16-debug") {
+    //           sh "cd clang-16-debug && ninja all -j \$(( \$(nproc) / 4))"
+    //           sh "./clang-16-debug/hyriseTest clang-16-debug"
+    //         }
+    //       }, gccDebug: {
+    //         stage("gcc-debug") {
+    //           sh "cd gcc-debug && ninja all -j \$(( \$(nproc) / 4))"
+    //           sh "cd gcc-debug && ./hyriseTest"
+    //         }
+    //       }, gcc13Debug: {
+    //         stage("gcc-13-debug") {
+    //           sh "cd gcc-13-debug && ninja all -j \$(( \$(nproc) / 4))"
+    //           sh "cd gcc-13-debug && ./hyriseTest"
+    //         }
+    //       }, lint: {
+    //         stage("Linting") {
+    //           sh "scripts/lint.sh"
+    //         }
+    //       }
 
-  //         // We distribute the cores to processes in a way to even the running times. With an even distributions,
-  //         // clang-tidy builds take up to 3h (galileo server). In addition to compile time, the distribution also
-  //         // considers the long test runtimes of clangRelWithDebInfoThreadSanitizer (~50 minutes).
-  //         parallel clangRelease: {
-  //           stage("clang-release") {
-  //             if (env.BRANCH_NAME == 'master' || full_ci) {
-  //               sh "cd clang-release && ninja all -j \$(( \$(nproc) / 10))"
-  //               sh "./clang-release/hyriseTest clang-release"
-  //               sh "./clang-release/hyriseSystemTest clang-release"
-  //               sh "./scripts/test/hyriseConsole_test.py clang-release"
-  //               sh "./scripts/test/hyriseServer_test.py clang-release"
-  //               sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-release"
-  //               sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-release"
-  //               sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
-  //               sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
+    //       // We distribute the cores to processes in a way to even the running times. With an even distributions,
+    //       // clang-tidy builds take up to 3h (galileo server). In addition to compile time, the distribution also
+    //       // considers the long test runtimes of clangRelWithDebInfoThreadSanitizer (~50 minutes).
+    //       parallel clangRelease: {
+    //         stage("clang-release") {
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             sh "cd clang-release && ninja all -j \$(( \$(nproc) / 10))"
+    //             sh "./clang-release/hyriseTest clang-release"
+    //             sh "./clang-release/hyriseSystemTest clang-release"
+    //             sh "./scripts/test/hyriseConsole_test.py clang-release"
+    //             sh "./scripts/test/hyriseServer_test.py clang-release"
+    //             sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-release"
+    //             sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-release"
+    //             sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
+    //             sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
 
-  //             } else {
-  //               Utils.markStageSkippedForConditional("clangRelease")
-  //             }
-  //           }
-  //         }, debugSystemTests: {
-  //           stage("system-tests") {
-  //             if (env.BRANCH_NAME == 'master' || full_ci) {
-  //               sh "mkdir clang-debug-system &&  ./clang-debug/hyriseSystemTest clang-debug-system"
-  //               sh "mkdir gcc-debug-system &&  ./gcc-debug/hyriseSystemTest gcc-debug-system"
-  //               sh "./scripts/test/hyriseConsole_test.py clang-debug"
-  //               sh "./scripts/test/hyriseServer_test.py clang-debug"
-  //               sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-debug"
-  //               sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-debug"
-  //               sh "cd clang-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
-  //               sh "cd clang-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate cached data
-  //               sh "cd clang-debug && ../scripts/test/hyriseBenchmarkStarSchema_test.py ." // Own folder to isolate cached data
-  //               sh "./scripts/test/hyriseConsole_test.py gcc-debug"
-  //               sh "./scripts/test/hyriseServer_test.py gcc-debug"
-  //               sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-debug"
-  //               sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-debug"
-  //               sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
-  //               sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate cached data
-  //               sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkStarSchema_test.py ." // Own folder to isolate cached data
+    //           } else {
+    //             Utils.markStageSkippedForConditional("clangRelease")
+    //           }
+    //         }
+    //       }, debugSystemTests: {
+    //         stage("system-tests") {
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             sh "mkdir clang-debug-system &&  ./clang-debug/hyriseSystemTest clang-debug-system"
+    //             sh "mkdir gcc-debug-system &&  ./gcc-debug/hyriseSystemTest gcc-debug-system"
+    //             sh "./scripts/test/hyriseConsole_test.py clang-debug"
+    //             sh "./scripts/test/hyriseServer_test.py clang-debug"
+    //             sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-debug"
+    //             sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-debug"
+    //             sh "cd clang-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
+    //             sh "cd clang-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate cached data
+    //             sh "cd clang-debug && ../scripts/test/hyriseBenchmarkStarSchema_test.py ." // Own folder to isolate cached data
+    //             sh "./scripts/test/hyriseConsole_test.py gcc-debug"
+    //             sh "./scripts/test/hyriseServer_test.py gcc-debug"
+    //             sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-debug"
+    //             sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-debug"
+    //             sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
+    //             sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate cached data
+    //             sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkStarSchema_test.py ." // Own folder to isolate cached data
 
-  //             } else {
-  //               Utils.markStageSkippedForConditional("debugSystemTests")
-  //             }
-  //           }
-  //         }, clangDebugRunShuffled: {
-  //           stage("clang-debug:test-shuffle") {
-  //             if (env.BRANCH_NAME == 'master' || full_ci) {
-  //               sh "mkdir ./clang-debug/run-shuffled"
-  //               sh "./clang-debug/hyriseTest clang-debug/run-shuffled --gtest_repeat=5 --gtest_shuffle"
-  //               // We do not want to trigger SSB data generation concurrently since it is not concurrency-safe.
-  //               sh "./clang-debug/hyriseSystemTest clang-debug/run-shuffled --gtest_repeat=2 --gtest_shuffle --gtest_filter=\"-SSBTableGeneratorTest.*:SQLiteTestRunnerEncodings/*\""
-  //             } else {
-  //               Utils.markStageSkippedForConditional("clangDebugRunShuffled")
-  //             }
-  //           }
-  //         }, clangDebugUnityODR: {
-  //           stage("clang-debug-unity-odr") {
-  //             if (env.BRANCH_NAME == 'master' || full_ci) {
-  //               // Check if unity builds work even if everything is batched into a single compilation unit. This helps prevent ODR (one definition rule) issues.
-  //               sh "cd clang-debug-unity-odr && ninja all -j 2"
-  //             } else {
-  //               Utils.markStageSkippedForConditional("clangDebugUnityODR")
-  //             }
-  //           }
-  //         }, clangDebugTidy: {
-  //           stage("clang-debug:tidy") {
-  //             if (env.BRANCH_NAME == 'master' || full_ci) {
-  //               // We do not run tidy checks on the src/test folder, so there is no point in running the expensive clang-tidy for those files
-  //               sh "cd clang-debug-tidy && ninja hyrise_impl hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer hyriseMvccDeletePlugin hyriseUccDiscoveryPlugin -k 0 -j \$(( \$(nproc) / 5))"
-  //             } else {
-  //               Utils.markStageSkippedForConditional("clangDebugTidy")
-  //             }
-  //           }
-  //         }, clangDebugDisablePrecompileHeaders: {
-  //           stage("clang-debug:disable-precompile-headers") {
-  //             if (env.BRANCH_NAME == 'master' || full_ci) {
-  //               // Check if builds work even when precompile headers is turned off. Executing the binaries is unnecessary as the observed errors are missing includes.
-  //               sh "cd clang-debug-disable-precompile-headers && ninja hyriseTest hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer -k 0 -j 2"
-  //             } else {
-  //               Utils.markStageSkippedForConditional("clangDebugDisablePrecompileHeaders")
-  //             }
-  //           }
-  //         }, clangDebugAddrUBLeakSanitizers: {
-  //           stage("clang-debug:addr-ub-sanitizers") {
-  //             if (env.BRANCH_NAME == 'master' || full_ci) {
-  //               sh "cd clang-debug-addr-ub-leak-sanitizers && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 10))"
-  //               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseTest clang-debug-addr-ub-leak-sanitizers"
-  //               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-debug-addr-ub-leak-sanitizers"
-  //               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 1"
-  //             } else {
-  //               Utils.markStageSkippedForConditional("clangDebugAddrUBLeakSanitizers")
-  //             }
-  //           }
-  //         }, gccRelease: {
-  //           if (env.BRANCH_NAME == 'master' || full_ci) {
-  //             stage("gcc-release") {
-  //               sh "cd gcc-release && ninja all -j \$(( \$(nproc) / 10))"
-  //               sh "./gcc-release/hyriseTest gcc-release"
-  //               sh "./gcc-release/hyriseSystemTest gcc-release"
-  //               sh "./scripts/test/hyriseConsole_test.py gcc-release"
-  //               sh "./scripts/test/hyriseServer_test.py gcc-release"
-  //               sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-release"
-  //               sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-release"
-  //               sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
-  //               sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
-  //             }
-  //           } else {
-  //               Utils.markStageSkippedForConditional("gccRelease")
-  //           }
-  //         }, clangReleaseAddrUBLeakSanitizers: {
-  //           stage("clang-release:addr-ub-sanitizers") {
-  //             if (env.BRANCH_NAME == 'master' || full_ci) {
-  //               sh "cd clang-release-addr-ub-leak-sanitizers && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 5))"
-  //               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseTest clang-release-addr-ub-leak-sanitizers"
-  //               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-release-addr-ub-leak-sanitizers"
-  //               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
-  //               sh "cd clang-release-addr-ub-leak-sanitizers && LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
-  //             } else {
-  //               Utils.markStageSkippedForConditional("clangReleaseAddrUBLeakSanitizers")
-  //             }
-  //           }
-  //         }, clangRelWithDebInfoThreadSanitizer: {
-  //           stage("clang-relwithdebinfo:thread-sanitizer") {
-  //             if (env.BRANCH_NAME == 'master' || full_ci) {
-  //               sh "cd clang-relwithdebinfo-thread-sanitizer && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC hyriseBenchmarkTPCDS -j \$(( \$(nproc) / 5))"
-  //               sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseTest clang-relwithdebinfo-thread-sanitizer"
-  //               sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-relwithdebinfo-thread-sanitizer"
-  //               sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCH -s .01 -r 100 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
-  //               sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCC -s 1 --time 120 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
-  //               sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCDS -s 1 -r 5 --scheduler --clients 5 --cores \$(( \$(nproc) / 10))"
-  //             } else {
-  //               Utils.markStageSkippedForConditional("clangRelWithDebInfoThreadSanitizer")
-  //             }
-  //           }
-  //         }, clangDebugCoverage: {
-  //           stage("clang-debug-coverage") {
-  //             if (env.BRANCH_NAME == 'master' || full_ci) {
-  //               sh "./scripts/coverage.sh --generate_badge=true"
-  //               sh "find coverage -type d -exec chmod +rx {} \\;"
-  //               archive 'coverage_badge.svg'
-  //               archive 'coverage_percent.txt'
-  //               publishHTML (target: [
-  //                 allowMissing: false,
-  //                 alwaysLinkToLastBuild: false,
-  //                 keepAll: true,
-  //                 reportDir: 'coverage',
-  //                 reportFiles: 'index.html',
-  //                 reportName: "Llvm-cov_Report"
-  //               ])
-  //               script {
-  //                 coverageChange = sh script: "./scripts/compare_coverage.sh", returnStdout: true
-  //                 githubNotify context: 'Coverage', description: "$coverageChange", status: 'SUCCESS', targetUrl: "${env.BUILD_URL}/RCov_20Report/index.html"
-  //               }
-  //             } else {
-  //               Utils.markStageSkippedForConditional("clangDebugCoverage")
-  //             }
-  //           }
-  //         }
+    //           } else {
+    //             Utils.markStageSkippedForConditional("debugSystemTests")
+    //           }
+    //         }
+    //       }, clangDebugRunShuffled: {
+    //         stage("clang-debug:test-shuffle") {
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             sh "mkdir ./clang-debug/run-shuffled"
+    //             sh "./clang-debug/hyriseTest clang-debug/run-shuffled --gtest_repeat=5 --gtest_shuffle"
+    //             // We do not want to trigger SSB data generation concurrently since it is not concurrency-safe.
+    //             sh "./clang-debug/hyriseSystemTest clang-debug/run-shuffled --gtest_repeat=2 --gtest_shuffle --gtest_filter=\"-SSBTableGeneratorTest.*:SQLiteTestRunnerEncodings/*\""
+    //           } else {
+    //             Utils.markStageSkippedForConditional("clangDebugRunShuffled")
+    //           }
+    //         }
+    //       }, clangDebugUnityODR: {
+    //         stage("clang-debug-unity-odr") {
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             // Check if unity builds work even if everything is batched into a single compilation unit. This helps prevent ODR (one definition rule) issues.
+    //             sh "cd clang-debug-unity-odr && ninja all -j 2"
+    //           } else {
+    //             Utils.markStageSkippedForConditional("clangDebugUnityODR")
+    //           }
+    //         }
+    //       }, clangDebugTidy: {
+    //         stage("clang-debug:tidy") {
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             // We do not run tidy checks on the src/test folder, so there is no point in running the expensive clang-tidy for those files
+    //             sh "cd clang-debug-tidy && ninja hyrise_impl hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer hyriseMvccDeletePlugin hyriseUccDiscoveryPlugin -k 0 -j \$(( \$(nproc) / 5))"
+    //           } else {
+    //             Utils.markStageSkippedForConditional("clangDebugTidy")
+    //           }
+    //         }
+    //       }, clangDebugDisablePrecompileHeaders: {
+    //         stage("clang-debug:disable-precompile-headers") {
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             // Check if builds work even when precompile headers is turned off. Executing the binaries is unnecessary as the observed errors are missing includes.
+    //             sh "cd clang-debug-disable-precompile-headers && ninja hyriseTest hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer -k 0 -j 2"
+    //           } else {
+    //             Utils.markStageSkippedForConditional("clangDebugDisablePrecompileHeaders")
+    //           }
+    //         }
+    //       }, clangDebugAddrUBLeakSanitizers: {
+    //         stage("clang-debug:addr-ub-sanitizers") {
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             sh "cd clang-debug-addr-ub-leak-sanitizers && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 10))"
+    //             sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseTest clang-debug-addr-ub-leak-sanitizers"
+    //             sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-debug-addr-ub-leak-sanitizers"
+    //             sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 1"
+    //           } else {
+    //             Utils.markStageSkippedForConditional("clangDebugAddrUBLeakSanitizers")
+    //           }
+    //         }
+    //       }, gccRelease: {
+    //         if (env.BRANCH_NAME == 'master' || full_ci) {
+    //           stage("gcc-release") {
+    //             sh "cd gcc-release && ninja all -j \$(( \$(nproc) / 10))"
+    //             sh "./gcc-release/hyriseTest gcc-release"
+    //             sh "./gcc-release/hyriseSystemTest gcc-release"
+    //             sh "./scripts/test/hyriseConsole_test.py gcc-release"
+    //             sh "./scripts/test/hyriseServer_test.py gcc-release"
+    //             sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-release"
+    //             sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-release"
+    //             sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
+    //             sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
+    //           }
+    //         } else {
+    //             Utils.markStageSkippedForConditional("gccRelease")
+    //         }
+    //       }, clangReleaseAddrUBLeakSanitizers: {
+    //         stage("clang-release:addr-ub-sanitizers") {
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             sh "cd clang-release-addr-ub-leak-sanitizers && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 5))"
+    //             sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseTest clang-release-addr-ub-leak-sanitizers"
+    //             sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-release-addr-ub-leak-sanitizers"
+    //             sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
+    //             sh "cd clang-release-addr-ub-leak-sanitizers && LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
+    //           } else {
+    //             Utils.markStageSkippedForConditional("clangReleaseAddrUBLeakSanitizers")
+    //           }
+    //         }
+    //       }, clangRelWithDebInfoThreadSanitizer: {
+    //         stage("clang-relwithdebinfo:thread-sanitizer") {
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             sh "cd clang-relwithdebinfo-thread-sanitizer && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC hyriseBenchmarkTPCDS -j \$(( \$(nproc) / 5))"
+    //             sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseTest clang-relwithdebinfo-thread-sanitizer"
+    //             sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-relwithdebinfo-thread-sanitizer"
+    //             sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCH -s .01 -r 100 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
+    //             sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCC -s 1 --time 120 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
+    //             sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCDS -s 1 -r 5 --scheduler --clients 5 --cores \$(( \$(nproc) / 10))"
+    //           } else {
+    //             Utils.markStageSkippedForConditional("clangRelWithDebInfoThreadSanitizer")
+    //           }
+    //         }
+    //       }, clangDebugCoverage: {
+    //         stage("clang-debug-coverage") {
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             sh "./scripts/coverage.sh --generate_badge=true"
+    //             sh "find coverage -type d -exec chmod +rx {} \\;"
+    //             archive 'coverage_badge.svg'
+    //             archive 'coverage_percent.txt'
+    //             publishHTML (target: [
+    //               allowMissing: false,
+    //               alwaysLinkToLastBuild: false,
+    //               keepAll: true,
+    //               reportDir: 'coverage',
+    //               reportFiles: 'index.html',
+    //               reportName: "Llvm-cov_Report"
+    //             ])
+    //             script {
+    //               coverageChange = sh script: "./scripts/compare_coverage.sh", returnStdout: true
+    //               githubNotify context: 'Coverage', description: "$coverageChange", status: 'SUCCESS', targetUrl: "${env.BUILD_URL}/RCov_20Report/index.html"
+    //             }
+    //           } else {
+    //             Utils.markStageSkippedForConditional("clangDebugCoverage")
+    //           }
+    //         }
+    //       }
 
-  //         parallel memcheckReleaseTest: {
-  //           stage("memcheckReleaseTest") {
-  //             // Runs after the other sanitizers as it depends on clang-release to be built.
-  //             if (env.BRANCH_NAME == 'master' || full_ci) {
-  //               sh "mkdir ./clang-release-memcheck-test"
-  //               // If this shows a leak, try --leak-check=full, which is slower but more precise. Valgrind serializes
-  //               // concurrent threads into a single one. Thus, we limit the cores and data preparation cores for the
-  //               // benchmark runs to reduce this serialization overhead. According to the Valgrind documentation,
-  //               // --fair-sched=yes "improves overall responsiveness if you are running an interactive multithreaded
-  //               // program" and "produces better reproducibility of thread scheduling for different executions of a
-  //               // multithreaded application" (i.e., there are no runs that are randomly faster or slower).
-  //               sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseTest clang-release-memcheck-test --gtest_filter=-NUMAMemoryResourceTest.BasicAllocate:SQLiteTestRunner*"
-  //               sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCH -s .01 -r 1 --scheduler --cores 4 --data_preparation_cores 4"
-  //               sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCDS -s 1 -r 1 --scheduler --cores 4 --data_preparation_cores 4"
-  //               sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCC -s 1 --scheduler --cores 4 --data_preparation_cores 4"
-  //             } else {
-  //               Utils.markStageSkippedForConditional("memcheckReleaseTest")
-  //             }
-  //           }
-  //         }, tpchVerification: {
-  //           stage("tpchVerification") {
-  //             if (env.BRANCH_NAME == 'master' || full_ci) {
-  //               // Verify both single- and multithreaded results.
-  //               sh "./clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 1 -s 1 --verify"
-  //               sh "./clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 1 -s 1 --verify --scheduler --clients 1 --cores 10"
-  //             } else {
-  //               Utils.markStageSkippedForConditional("tpchVerification")
-  //             }
-  //           }
-  //         }, tpchQueryPlans: {
-  //           stage("tpchQueryPlans") {
-  //             if (env.BRANCH_NAME == 'master' || full_ci) {
-  //               sh "mkdir -p query_plans/tpch; cd query_plans/tpch && ../../clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 2 -s 10 --visualize && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
-  //               archiveArtifacts artifacts: 'query_plans/tpch/*.svg'
-  //               archiveArtifacts artifacts: 'query_plans/tpch/operator_breakdown.pdf'
-  //             } else {
-  //               Utils.markStageSkippedForConditional("tpchQueryPlans")
-  //             }
-  //           }
-  //         }, tpcdsQueryPlansAndVerification: {
-  //           stage("tpcdsQueryPlansAndVerification") {
-  //             if (env.BRANCH_NAME == 'master' || full_ci) {
-  //               sh "mkdir -p query_plans/tpcds; cd query_plans/tpcds && ln -s ../../resources; ../../clang-release/hyriseBenchmarkTPCDS --dont_cache_binary_tables -r 1 -s 1 --visualize --verify && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
-  //               archiveArtifacts artifacts: 'query_plans/tpcds/*.svg'
-  //               archiveArtifacts artifacts: 'query_plans/tpcds/operator_breakdown.pdf'
-  //             } else {
-  //               Utils.markStageSkippedForConditional("tpcdsQueryPlansAndVerification")
-  //             }
-  //           }
-  //         }, jobQueryPlans: {
-  //           stage("jobQueryPlans") {
-  //             if (env.BRANCH_NAME == 'master' || full_ci) {
-  //               // In contrast to TPC-H and TPC-DS above, we execute the JoinOrderBenchmark from the project's root directoy because its setup script requires us to do so.
-  //               sh "mkdir -p query_plans/job && ./clang-release/hyriseBenchmarkJoinOrder --dont_cache_binary_tables -r 1 --visualize && ./scripts/plot_operator_breakdown.py ./clang-release/ && mv operator_breakdown.pdf query_plans/job && mv *QP.svg query_plans/job"
-  //               archiveArtifacts artifacts: 'query_plans/job/*.svg'
-  //               archiveArtifacts artifacts: 'query_plans/job/operator_breakdown.pdf'
-  //             } else {
-  //               Utils.markStageSkippedForConditional("jobQueryPlans")
-  //             }
-  //           }
-  //         }, ssbQueryPlans: {
-  //           stage("ssbQueryPlans") {
-  //             if (env.BRANCH_NAME == 'master' || full_ci) {
-  //               sh "mkdir -p query_plans/ssb; cd query_plans/ssb && ../../clang-release/hyriseBenchmarkStarSchema --dont_cache_binary_tables -r 1 -s 1 --visualize && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
-  //               archiveArtifacts artifacts: 'query_plans/ssb/*.svg'
-  //               archiveArtifacts artifacts: 'query_plans/ssb/operator_breakdown.pdf'
-  //             } else {
-  //               Utils.markStageSkippedForConditional("ssbQueryPlans")
-  //             }
-  //           }
-  //         }, nixSetup: {
-  //           stage('nixSetup') {
-  //             if (env.BRANCH_NAME == 'master' || full_ci) {
-  //               sh "curl -L https://nixos.org/nix/install > nix-install.sh && chmod +x nix-install.sh && ./nix-install.sh --daemon --yes"
-  //               sh "/nix/var/nix/profiles/default/bin/nix-shell resources/nix --pure --run \"mkdir nix-debug && cd nix-debug && cmake ${debug} ${clang} ${unity} ${ninja} .. && ninja all -j \$(( \$(nproc) / 7)) && ./hyriseTest\""
-  //               // We allocate a third of all cores for the release build as several parallel stages should have already finished at this point.
-  //               sh "/nix/var/nix/profiles/default/bin/nix-shell resources/nix --pure --run \"mkdir nix-release && cd nix-release && cmake ${release} ${clang} ${unity} ${ninja} .. && ninja all -j \$(( \$(nproc) / 3)) && ./hyriseTest\""
-  //             } else {
-  //               Utils.markStageSkippedForConditional("nixSetup")
-  //             }
-  //           }
-  //         }
-  //       } finally {
-  //         sh "ls -A1 | xargs rm -rf"
-  //         deleteDir()
-  //       }
-  //     }
-  //   }
-  // }
+    //       parallel memcheckReleaseTest: {
+    //         stage("memcheckReleaseTest") {
+    //           // Runs after the other sanitizers as it depends on clang-release to be built.
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             sh "mkdir ./clang-release-memcheck-test"
+    //             // If this shows a leak, try --leak-check=full, which is slower but more precise. Valgrind serializes
+    //             // concurrent threads into a single one. Thus, we limit the cores and data preparation cores for the
+    //             // benchmark runs to reduce this serialization overhead. According to the Valgrind documentation,
+    //             // --fair-sched=yes "improves overall responsiveness if you are running an interactive multithreaded
+    //             // program" and "produces better reproducibility of thread scheduling for different executions of a
+    //             // multithreaded application" (i.e., there are no runs that are randomly faster or slower).
+    //             sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseTest clang-release-memcheck-test --gtest_filter=-NUMAMemoryResourceTest.BasicAllocate:SQLiteTestRunner*"
+    //             sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCH -s .01 -r 1 --scheduler --cores 4 --data_preparation_cores 4"
+    //             sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCDS -s 1 -r 1 --scheduler --cores 4 --data_preparation_cores 4"
+    //             sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCC -s 1 --scheduler --cores 4 --data_preparation_cores 4"
+    //           } else {
+    //             Utils.markStageSkippedForConditional("memcheckReleaseTest")
+    //           }
+    //         }
+    //       }, tpchVerification: {
+    //         stage("tpchVerification") {
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             // Verify both single- and multithreaded results.
+    //             sh "./clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 1 -s 1 --verify"
+    //             sh "./clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 1 -s 1 --verify --scheduler --clients 1 --cores 10"
+    //           } else {
+    //             Utils.markStageSkippedForConditional("tpchVerification")
+    //           }
+    //         }
+    //       }, tpchQueryPlans: {
+    //         stage("tpchQueryPlans") {
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             sh "mkdir -p query_plans/tpch; cd query_plans/tpch && ../../clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 2 -s 10 --visualize && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
+    //             archiveArtifacts artifacts: 'query_plans/tpch/*.svg'
+    //             archiveArtifacts artifacts: 'query_plans/tpch/operator_breakdown.pdf'
+    //           } else {
+    //             Utils.markStageSkippedForConditional("tpchQueryPlans")
+    //           }
+    //         }
+    //       }, tpcdsQueryPlansAndVerification: {
+    //         stage("tpcdsQueryPlansAndVerification") {
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             sh "mkdir -p query_plans/tpcds; cd query_plans/tpcds && ln -s ../../resources; ../../clang-release/hyriseBenchmarkTPCDS --dont_cache_binary_tables -r 1 -s 1 --visualize --verify && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
+    //             archiveArtifacts artifacts: 'query_plans/tpcds/*.svg'
+    //             archiveArtifacts artifacts: 'query_plans/tpcds/operator_breakdown.pdf'
+    //           } else {
+    //             Utils.markStageSkippedForConditional("tpcdsQueryPlansAndVerification")
+    //           }
+    //         }
+    //       }, jobQueryPlans: {
+    //         stage("jobQueryPlans") {
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             // In contrast to TPC-H and TPC-DS above, we execute the JoinOrderBenchmark from the project's root directoy because its setup script requires us to do so.
+    //             sh "mkdir -p query_plans/job && ./clang-release/hyriseBenchmarkJoinOrder --dont_cache_binary_tables -r 1 --visualize && ./scripts/plot_operator_breakdown.py ./clang-release/ && mv operator_breakdown.pdf query_plans/job && mv *QP.svg query_plans/job"
+    //             archiveArtifacts artifacts: 'query_plans/job/*.svg'
+    //             archiveArtifacts artifacts: 'query_plans/job/operator_breakdown.pdf'
+    //           } else {
+    //             Utils.markStageSkippedForConditional("jobQueryPlans")
+    //           }
+    //         }
+    //       }, ssbQueryPlans: {
+    //         stage("ssbQueryPlans") {
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             sh "mkdir -p query_plans/ssb; cd query_plans/ssb && ../../clang-release/hyriseBenchmarkStarSchema --dont_cache_binary_tables -r 1 -s 1 --visualize && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
+    //             archiveArtifacts artifacts: 'query_plans/ssb/*.svg'
+    //             archiveArtifacts artifacts: 'query_plans/ssb/operator_breakdown.pdf'
+    //           } else {
+    //             Utils.markStageSkippedForConditional("ssbQueryPlans")
+    //           }
+    //         }
+    //       }, nixSetup: {
+    //         stage('nixSetup') {
+    //           if (env.BRANCH_NAME == 'master' || full_ci) {
+    //             sh "curl -L https://nixos.org/nix/install > nix-install.sh && chmod +x nix-install.sh && ./nix-install.sh --daemon --yes"
+    //             sh "/nix/var/nix/profiles/default/bin/nix-shell resources/nix --pure --run \"mkdir nix-debug && cd nix-debug && cmake ${debug} ${clang} ${unity} ${ninja} .. && ninja all -j \$(( \$(nproc) / 7)) && ./hyriseTest\""
+    //             // We allocate a third of all cores for the release build as several parallel stages should have already finished at this point.
+    //             sh "/nix/var/nix/profiles/default/bin/nix-shell resources/nix --pure --run \"mkdir nix-release && cd nix-release && cmake ${release} ${clang} ${unity} ${ninja} .. && ninja all -j \$(( \$(nproc) / 3)) && ./hyriseTest\""
+    //           } else {
+    //             Utils.markStageSkippedForConditional("nixSetup")
+    //           }
+    //         }
+    //       }
+    //     } finally {
+    //       sh "ls -A1 | xargs rm -rf"
+    //       deleteDir()
+    //     }
+    //   }
+    // }
+  }
 
   parallel clangMacX64: {
     node('mac') {
@@ -443,7 +443,7 @@ try {
             // Build Hyrise (Release) with a recent clang compiler version (as recommended for Hyrise on macOS) and run
             // various tests. As the release build already takes quite a while on the Intel machine, we disable LTO and
             // only build release with LTO on the ARM machine.
-            sh "mkdir clang-debug && cd clang-debug && cmake ${debug} ${ninja} ${no_lto} -DCMAKE_C_COMPILER=/usr/local/opt/llvm@19/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm@19/bin/clang++ .."
+            sh "mkdir clang-debug && cd clang-debug && cmake ${debug} ${ninja} ${no_lto} ${unity} -DCMAKE_C_COMPILER=/usr/local/opt/llvm@19/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm@19/bin/clang++ .."
             sh "cd clang-debug && ninja"
             sh "./clang-debug/hyriseTest"
             sh "./clang-debug/hyriseSystemTest --gtest_filter=-${tests_excluded_in_mac_builds}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -368,7 +368,7 @@ try {
                 archiveArtifacts artifacts: 'query_plans/tpcds/*.svg'
                 archiveArtifacts artifacts: 'query_plans/tpcds/operator_breakdown.pdf'
               } else {
-                Utils.markStageSkippedForConditional("tpcdsQueryPlans")
+                Utils.markStageSkippedForConditional("tpcdsQueryPlansAndVerification")
               }
             }
           }, jobQueryPlans: {
@@ -443,7 +443,7 @@ try {
             // Build Hyrise (Release) with a recent clang compiler version (as recommended for Hyrise on macOS) and run
             // various tests. As the release build already takes quite a while on the Intel machine, we disable LTO and
             // only build release with LTO on the ARM machine.
-            sh "mkdir clang-release && cd clang-release && cmake ${release} ${ninja} ${unity} -DCMAKE_C_COMPILER=/usr/local/opt/llvm@19/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm@19/bin/clang++ .."
+            sh "mkdir clang-release && cd clang-release && cmake ${release} ${ninja} ${unity} ${no_lto} -DCMAKE_C_COMPILER=/usr/local/opt/llvm@19/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm@19/bin/clang++ .."
             sh "cd clang-release && ninja"
             sh "./clang-release/hyriseTest"
             sh "./clang-release/hyriseSystemTest --gtest_filter=-${tests_excluded_in_mac_builds}"
@@ -479,7 +479,7 @@ try {
             // Build Hyrise (Debug) with a recent clang compiler version (as recommended for Hyrise on macOS) and run
             // various tests.
             // NOTE: These paths differ from x64 - brew on ARM uses /opt (https://docs.brew.sh/Installation)
-            sh "mkdir clang-debug && cd clang-debug && cmake ${debug} ${unity} ${no_lto} ${ninja} -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm@19/bin/clang -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm@19/bin/clang++ .."
+            sh "mkdir clang-debug && cd clang-debug && cmake ${debug} ${unity} ${ninja} -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm@19/bin/clang -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm@19/bin/clang++ .."
             sh "cd clang-debug && ninja"
 
             // Check whether arm64 binaries are built to ensure that we are not accidentally running rosetta that

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -248,7 +248,7 @@ try {
           }, clangDebugAddrUBLeakSanitizers: {
             stage("clang-debug:addr-ub-sanitizers") {
               if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "cd clang-debug-addr-ub-leak-sanitizers && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 10))"
+                sh "cd clang-debug-addr-ub-leak-sanitizers && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 20))"
                 sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseTest clang-debug-addr-ub-leak-sanitizers"
                 sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-debug-addr-ub-leak-sanitizers"
                 sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 1"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -166,244 +166,244 @@ try {
           // We distribute the cores to processes in a way to even the running times. With an even distributions,
           // clang-tidy builds take up to 3h (galileo server). In addition to compile time, the distribution also
           // considers the long test runtimes of clangRelWithDebInfoThreadSanitizer (~50 minutes).
-          // parallel clangRelease: {
-          //   stage("clang-release") {
-          //     if (env.BRANCH_NAME == 'master' || full_ci) {
-          //       sh "cd clang-release && ninja all -j \$(( \$(nproc) / 10))"
-          //       sh "./clang-release/hyriseTest clang-release"
-          //       sh "./clang-release/hyriseSystemTest clang-release"
-          //       sh "./scripts/test/hyriseConsole_test.py clang-release"
-          //       sh "./scripts/test/hyriseServer_test.py clang-release"
-          //       sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-release"
-          //       sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-release"
-          //       sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
-          //       sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
+          parallel clangRelease: {
+            stage("clang-release") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "cd clang-release && ninja all -j \$(( \$(nproc) / 10))"
+                sh "./clang-release/hyriseTest clang-release"
+                sh "./clang-release/hyriseSystemTest clang-release"
+                sh "./scripts/test/hyriseConsole_test.py clang-release"
+                sh "./scripts/test/hyriseServer_test.py clang-release"
+                sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-release"
+                sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-release"
+                sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
+                sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
 
-          //     } else {
-          //       Utils.markStageSkippedForConditional("clangRelease")
-          //     }
-          //   }
-          // }, debugSystemTests: {
-          //   stage("system-tests") {
-          //     if (env.BRANCH_NAME == 'master' || full_ci) {
-          //       sh "mkdir clang-debug-system &&  ./clang-debug/hyriseSystemTest clang-debug-system"
-          //       sh "mkdir gcc-debug-system &&  ./gcc-debug/hyriseSystemTest gcc-debug-system"
-          //       sh "./scripts/test/hyriseConsole_test.py clang-debug"
-          //       sh "./scripts/test/hyriseServer_test.py clang-debug"
-          //       sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-debug"
-          //       sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-debug"
-          //       sh "cd clang-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
-          //       sh "cd clang-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate cached data
-          //       sh "cd clang-debug && ../scripts/test/hyriseBenchmarkStarSchema_test.py ." // Own folder to isolate cached data
-          //       sh "./scripts/test/hyriseConsole_test.py gcc-debug"
-          //       sh "./scripts/test/hyriseServer_test.py gcc-debug"
-          //       sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-debug"
-          //       sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-debug"
-          //       sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
-          //       sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate cached data
-          //       sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkStarSchema_test.py ." // Own folder to isolate cached data
+              } else {
+                Utils.markStageSkippedForConditional("clangRelease")
+              }
+            }
+          }, debugSystemTests: {
+            stage("system-tests") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "mkdir clang-debug-system &&  ./clang-debug/hyriseSystemTest clang-debug-system"
+                sh "mkdir gcc-debug-system &&  ./gcc-debug/hyriseSystemTest gcc-debug-system"
+                sh "./scripts/test/hyriseConsole_test.py clang-debug"
+                sh "./scripts/test/hyriseServer_test.py clang-debug"
+                sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-debug"
+                sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-debug"
+                sh "cd clang-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
+                sh "cd clang-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate cached data
+                sh "cd clang-debug && ../scripts/test/hyriseBenchmarkStarSchema_test.py ." // Own folder to isolate cached data
+                sh "./scripts/test/hyriseConsole_test.py gcc-debug"
+                sh "./scripts/test/hyriseServer_test.py gcc-debug"
+                sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-debug"
+                sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-debug"
+                sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
+                sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate cached data
+                sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkStarSchema_test.py ." // Own folder to isolate cached data
 
-          //     } else {
-          //       Utils.markStageSkippedForConditional("debugSystemTests")
-          //     }
-          //   }
-          // }, clangDebugRunShuffled: {
-          //   stage("clang-debug:test-shuffle") {
-          //     if (env.BRANCH_NAME == 'master' || full_ci) {
-          //       sh "mkdir ./clang-debug/run-shuffled"
-          //       sh "./clang-debug/hyriseTest clang-debug/run-shuffled --gtest_repeat=5 --gtest_shuffle"
-          //       // We do not want to trigger SSB data generation concurrently since it is not concurrency-safe.
-          //       sh "./clang-debug/hyriseSystemTest clang-debug/run-shuffled --gtest_repeat=2 --gtest_shuffle --gtest_filter=\"-SSBTableGeneratorTest.*:SQLiteTestRunnerEncodings/*\""
-          //     } else {
-          //       Utils.markStageSkippedForConditional("clangDebugRunShuffled")
-          //     }
-          //   }
-          // }, clangDebugUnityODR: {
-          //   stage("clang-debug-unity-odr") {
-          //     if (env.BRANCH_NAME == 'master' || full_ci) {
-          //       // Check if unity builds work even if everything is batched into a single compilation unit. This helps prevent ODR (one definition rule) issues.
-          //       sh "cd clang-debug-unity-odr && ninja all -j 2"
-          //     } else {
-          //       Utils.markStageSkippedForConditional("clangDebugUnityODR")
-          //     }
-          //   }
-          // }, clangDebugTidy: {
-          //   stage("clang-debug:tidy") {
-          //     if (env.BRANCH_NAME == 'master' || full_ci) {
-          //       // We do not run tidy checks on the src/test folder, so there is no point in running the expensive clang-tidy for those files
-          //       sh "cd clang-debug-tidy && ninja hyrise_impl hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer hyriseMvccDeletePlugin hyriseUccDiscoveryPlugin -k 0 -j \$(( \$(nproc) / 5))"
-          //     } else {
-          //       Utils.markStageSkippedForConditional("clangDebugTidy")
-          //     }
-          //   }
-          // }, clangDebugDisablePrecompileHeaders: {
-          //   stage("clang-debug:disable-precompile-headers") {
-          //     if (env.BRANCH_NAME == 'master' || full_ci) {
-          //       // Check if builds work even when precompile headers is turned off. Executing the binaries is unnecessary as the observed errors are missing includes.
-          //       sh "cd clang-debug-disable-precompile-headers && ninja hyriseTest hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer -k 0 -j 2"
-          //     } else {
-          //       Utils.markStageSkippedForConditional("clangDebugDisablePrecompileHeaders")
-          //     }
-          //   }
-          // }, clangDebugAddrUBLeakSanitizers: {
-          //   stage("clang-debug:addr-ub-sanitizers") {
-          //     if (env.BRANCH_NAME == 'master' || full_ci) {
-          //       sh "cd clang-debug-addr-ub-leak-sanitizers && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 10))"
-          //       sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseTest clang-debug-addr-ub-leak-sanitizers"
-          //       sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-debug-addr-ub-leak-sanitizers"
-          //       sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 1"
-          //     } else {
-          //       Utils.markStageSkippedForConditional("clangDebugAddrUBLeakSanitizers")
-          //     }
-          //   }
-          // }, gccRelease: {
-          //   if (env.BRANCH_NAME == 'master' || full_ci) {
-          //     stage("gcc-release") {
-          //       sh "cd gcc-release && ninja all -j \$(( \$(nproc) / 10))"
-          //       sh "./gcc-release/hyriseTest gcc-release"
-          //       sh "./gcc-release/hyriseSystemTest gcc-release"
-          //       sh "./scripts/test/hyriseConsole_test.py gcc-release"
-          //       sh "./scripts/test/hyriseServer_test.py gcc-release"
-          //       sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-release"
-          //       sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-release"
-          //       sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
-          //       sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
-          //     }
-          //   } else {
-          //       Utils.markStageSkippedForConditional("gccRelease")
-          //   }
-          // }, clangReleaseAddrUBLeakSanitizers: {
-          //   stage("clang-release:addr-ub-sanitizers") {
-          //     if (env.BRANCH_NAME == 'master' || full_ci) {
-          //       sh "cd clang-release-addr-ub-leak-sanitizers && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 5))"
-          //       sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseTest clang-release-addr-ub-leak-sanitizers"
-          //       sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-release-addr-ub-leak-sanitizers"
-          //       sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
-          //       sh "cd clang-release-addr-ub-leak-sanitizers && LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
-          //     } else {
-          //       Utils.markStageSkippedForConditional("clangReleaseAddrUBLeakSanitizers")
-          //     }
-          //   }
-          // }, clangRelWithDebInfoThreadSanitizer: {
-          //   stage("clang-relwithdebinfo:thread-sanitizer") {
-          //     if (env.BRANCH_NAME == 'master' || full_ci) {
-          //       sh "cd clang-relwithdebinfo-thread-sanitizer && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC hyriseBenchmarkTPCDS -j \$(( \$(nproc) / 5))"
-          //       sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseTest clang-relwithdebinfo-thread-sanitizer"
-          //       sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-relwithdebinfo-thread-sanitizer"
-          //       sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCH -s .01 -r 100 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
-          //       sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCC -s 1 --time 120 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
-          //       sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCDS -s 1 -r 5 --scheduler --clients 5 --cores \$(( \$(nproc) / 10))"
-          //     } else {
-          //       Utils.markStageSkippedForConditional("clangRelWithDebInfoThreadSanitizer")
-          //     }
-          //   }
-          // }, clangDebugCoverage: {
-          //   stage("clang-debug-coverage") {
-          //     if (env.BRANCH_NAME == 'master' || full_ci) {
-          //       sh "./scripts/coverage.sh --generate_badge=true"
-          //       sh "find coverage -type d -exec chmod +rx {} \\;"
-          //       archive 'coverage_badge.svg'
-          //       archive 'coverage_percent.txt'
-          //       publishHTML (target: [
-          //         allowMissing: false,
-          //         alwaysLinkToLastBuild: false,
-          //         keepAll: true,
-          //         reportDir: 'coverage',
-          //         reportFiles: 'index.html',
-          //         reportName: "Llvm-cov_Report"
-          //       ])
-          //       script {
-          //         coverageChange = sh script: "./scripts/compare_coverage.sh", returnStdout: true
-          //         githubNotify context: 'Coverage', description: "$coverageChange", status: 'SUCCESS', targetUrl: "${env.BUILD_URL}/RCov_20Report/index.html"
-          //       }
-          //     } else {
-          //       Utils.markStageSkippedForConditional("clangDebugCoverage")
-          //     }
-          //   }
-          // }
+              } else {
+                Utils.markStageSkippedForConditional("debugSystemTests")
+              }
+            }
+          }, clangDebugRunShuffled: {
+            stage("clang-debug:test-shuffle") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "mkdir ./clang-debug/run-shuffled"
+                sh "./clang-debug/hyriseTest clang-debug/run-shuffled --gtest_repeat=5 --gtest_shuffle"
+                // We do not want to trigger SSB data generation concurrently since it is not concurrency-safe.
+                sh "./clang-debug/hyriseSystemTest clang-debug/run-shuffled --gtest_repeat=2 --gtest_shuffle --gtest_filter=\"-SSBTableGeneratorTest.*:SQLiteTestRunnerEncodings/*\""
+              } else {
+                Utils.markStageSkippedForConditional("clangDebugRunShuffled")
+              }
+            }
+          }, clangDebugUnityODR: {
+            stage("clang-debug-unity-odr") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                // Check if unity builds work even if everything is batched into a single compilation unit. This helps prevent ODR (one definition rule) issues.
+                sh "cd clang-debug-unity-odr && ninja all -j 2"
+              } else {
+                Utils.markStageSkippedForConditional("clangDebugUnityODR")
+              }
+            }
+          }, clangDebugTidy: {
+            stage("clang-debug:tidy") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                // We do not run tidy checks on the src/test folder, so there is no point in running the expensive clang-tidy for those files
+                sh "cd clang-debug-tidy && ninja hyrise_impl hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer hyriseMvccDeletePlugin hyriseUccDiscoveryPlugin -k 0 -j \$(( \$(nproc) / 5))"
+              } else {
+                Utils.markStageSkippedForConditional("clangDebugTidy")
+              }
+            }
+          }, clangDebugDisablePrecompileHeaders: {
+            stage("clang-debug:disable-precompile-headers") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                // Check if builds work even when precompile headers is turned off. Executing the binaries is unnecessary as the observed errors are missing includes.
+                sh "cd clang-debug-disable-precompile-headers && ninja hyriseTest hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer -k 0 -j 2"
+              } else {
+                Utils.markStageSkippedForConditional("clangDebugDisablePrecompileHeaders")
+              }
+            }
+          }, clangDebugAddrUBLeakSanitizers: {
+            stage("clang-debug:addr-ub-sanitizers") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "cd clang-debug-addr-ub-leak-sanitizers && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 10))"
+                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseTest clang-debug-addr-ub-leak-sanitizers"
+                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-debug-addr-ub-leak-sanitizers"
+                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 1"
+              } else {
+                Utils.markStageSkippedForConditional("clangDebugAddrUBLeakSanitizers")
+              }
+            }
+          }, gccRelease: {
+            if (env.BRANCH_NAME == 'master' || full_ci) {
+              stage("gcc-release") {
+                sh "cd gcc-release && ninja all -j \$(( \$(nproc) / 10))"
+                sh "./gcc-release/hyriseTest gcc-release"
+                sh "./gcc-release/hyriseSystemTest gcc-release"
+                sh "./scripts/test/hyriseConsole_test.py gcc-release"
+                sh "./scripts/test/hyriseServer_test.py gcc-release"
+                sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-release"
+                sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-release"
+                sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
+                sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
+              }
+            } else {
+                Utils.markStageSkippedForConditional("gccRelease")
+            }
+          }, clangReleaseAddrUBLeakSanitizers: {
+            stage("clang-release:addr-ub-sanitizers") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "cd clang-release-addr-ub-leak-sanitizers && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 5))"
+                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseTest clang-release-addr-ub-leak-sanitizers"
+                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-release-addr-ub-leak-sanitizers"
+                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
+                sh "cd clang-release-addr-ub-leak-sanitizers && LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
+              } else {
+                Utils.markStageSkippedForConditional("clangReleaseAddrUBLeakSanitizers")
+              }
+            }
+          }, clangRelWithDebInfoThreadSanitizer: {
+            stage("clang-relwithdebinfo:thread-sanitizer") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "cd clang-relwithdebinfo-thread-sanitizer && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC hyriseBenchmarkTPCDS -j \$(( \$(nproc) / 5))"
+                sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseTest clang-relwithdebinfo-thread-sanitizer"
+                sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-relwithdebinfo-thread-sanitizer"
+                sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCH -s .01 -r 100 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
+                sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCC -s 1 --time 120 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
+                sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCDS -s 1 -r 5 --scheduler --clients 5 --cores \$(( \$(nproc) / 10))"
+              } else {
+                Utils.markStageSkippedForConditional("clangRelWithDebInfoThreadSanitizer")
+              }
+            }
+          }, clangDebugCoverage: {
+            stage("clang-debug-coverage") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "./scripts/coverage.sh --generate_badge=true"
+                sh "find coverage -type d -exec chmod +rx {} \\;"
+                archive 'coverage_badge.svg'
+                archive 'coverage_percent.txt'
+                publishHTML (target: [
+                  allowMissing: false,
+                  alwaysLinkToLastBuild: false,
+                  keepAll: true,
+                  reportDir: 'coverage',
+                  reportFiles: 'index.html',
+                  reportName: "Llvm-cov_Report"
+                ])
+                script {
+                  coverageChange = sh script: "./scripts/compare_coverage.sh", returnStdout: true
+                  githubNotify context: 'Coverage', description: "$coverageChange", status: 'SUCCESS', targetUrl: "${env.BUILD_URL}/RCov_20Report/index.html"
+                }
+              } else {
+                Utils.markStageSkippedForConditional("clangDebugCoverage")
+              }
+            }
+          }
 
-          // parallel memcheckReleaseTest: {
-          //   stage("memcheckReleaseTest") {
-          //     // Runs after the other sanitizers as it depends on clang-release to be built.
-          //     if (env.BRANCH_NAME == 'master' || full_ci) {
-          //       sh "mkdir ./clang-release-memcheck-test"
-          //       // If this shows a leak, try --leak-check=full, which is slower but more precise. Valgrind serializes
-          //       // concurrent threads into a single one. Thus, we limit the cores and data preparation cores for the
-          //       // benchmark runs to reduce this serialization overhead. According to the Valgrind documentation,
-          //       // --fair-sched=yes "improves overall responsiveness if you are running an interactive multithreaded
-          //       // program" and "produces better reproducibility of thread scheduling for different executions of a
-          //       // multithreaded application" (i.e., there are no runs that are randomly faster or slower).
-          //       sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseTest clang-release-memcheck-test --gtest_filter=-NUMAMemoryResourceTest.BasicAllocate:SQLiteTestRunner*"
-          //       sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCH -s .01 -r 1 --scheduler --cores 4 --data_preparation_cores 4"
-          //       sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCDS -s 1 -r 1 --scheduler --cores 4 --data_preparation_cores 4"
-          //       sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCC -s 1 --scheduler --cores 4 --data_preparation_cores 4"
-          //     } else {
-          //       Utils.markStageSkippedForConditional("memcheckReleaseTest")
-          //     }
-          //   }
-          // }, tpchVerification: {
-          //   stage("tpchVerification") {
-          //     if (env.BRANCH_NAME == 'master' || full_ci) {
-          //       // Verify both single- and multithreaded results.
-          //       sh "./clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 1 -s 1 --verify"
-          //       sh "./clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 1 -s 1 --verify --scheduler --clients 1 --cores 10"
-          //     } else {
-          //       Utils.markStageSkippedForConditional("tpchVerification")
-          //     }
-          //   }
-          // }, tpchQueryPlans: {
-          //   stage("tpchQueryPlans") {
-          //     if (env.BRANCH_NAME == 'master' || full_ci) {
-          //       sh "mkdir -p query_plans/tpch; cd query_plans/tpch && ../../clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 2 -s 10 --visualize && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
-          //       archiveArtifacts artifacts: 'query_plans/tpch/*.svg'
-          //       archiveArtifacts artifacts: 'query_plans/tpch/operator_breakdown.pdf'
-          //     } else {
-          //       Utils.markStageSkippedForConditional("tpchQueryPlans")
-          //     }
-          //   }
-          // }, tpcdsQueryPlansAndVerification: {
-          //   stage("tpcdsQueryPlansAndVerification") {
-          //     if (env.BRANCH_NAME == 'master' || full_ci) {
-          //       sh "mkdir -p query_plans/tpcds; cd query_plans/tpcds && ln -s ../../resources; ../../clang-release/hyriseBenchmarkTPCDS --dont_cache_binary_tables -r 1 -s 1 --visualize --verify && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
-          //       archiveArtifacts artifacts: 'query_plans/tpcds/*.svg'
-          //       archiveArtifacts artifacts: 'query_plans/tpcds/operator_breakdown.pdf'
-          //     } else {
-          //       Utils.markStageSkippedForConditional("tpcdsQueryPlansAndVerification")
-          //     }
-          //   }
-          // }, jobQueryPlans: {
-          //   stage("jobQueryPlans") {
-          //     if (env.BRANCH_NAME == 'master' || full_ci) {
-          //       // In contrast to TPC-H and TPC-DS above, we execute the JoinOrderBenchmark from the project's root directoy because its setup script requires us to do so.
-          //       sh "mkdir -p query_plans/job && ./clang-release/hyriseBenchmarkJoinOrder --dont_cache_binary_tables -r 1 --visualize && ./scripts/plot_operator_breakdown.py ./clang-release/ && mv operator_breakdown.pdf query_plans/job && mv *QP.svg query_plans/job"
-          //       archiveArtifacts artifacts: 'query_plans/job/*.svg'
-          //       archiveArtifacts artifacts: 'query_plans/job/operator_breakdown.pdf'
-          //     } else {
-          //       Utils.markStageSkippedForConditional("jobQueryPlans")
-          //     }
-          //   }
-          // }, ssbQueryPlans: {
-          //   stage("ssbQueryPlans") {
-          //     if (env.BRANCH_NAME == 'master' || full_ci) {
-          //       sh "mkdir -p query_plans/ssb; cd query_plans/ssb && ../../clang-release/hyriseBenchmarkStarSchema --dont_cache_binary_tables -r 1 -s 1 --visualize && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
-          //       archiveArtifacts artifacts: 'query_plans/ssb/*.svg'
-          //       archiveArtifacts artifacts: 'query_plans/ssb/operator_breakdown.pdf'
-          //     } else {
-          //       Utils.markStageSkippedForConditional("ssbQueryPlans")
-          //     }
-          //   }
-          // }, nixSetup: {
-          //   stage('nixSetup') {
-          //     if (env.BRANCH_NAME == 'master' || full_ci) {
-          //       sh "curl -L https://nixos.org/nix/install > nix-install.sh && chmod +x nix-install.sh && ./nix-install.sh --daemon --yes"
-          //       sh "/nix/var/nix/profiles/default/bin/nix-shell resources/nix --pure --run \"mkdir nix-debug && cd nix-debug && cmake ${debug} ${clang} ${unity} ${ninja} .. && ninja all -j \$(( \$(nproc) / 7)) && ./hyriseTest\""
-          //       // We allocate a third of all cores for the release build as several parallel stages should have already finished at this point.
-          //       sh "/nix/var/nix/profiles/default/bin/nix-shell resources/nix --pure --run \"mkdir nix-release && cd nix-release && cmake ${release} ${clang} ${unity} ${ninja} .. && ninja all -j \$(( \$(nproc) / 3)) && ./hyriseTest\""
-          //     } else {
-          //       Utils.markStageSkippedForConditional("nixSetup")
-          //     }
-          //   }
-          // }
+          parallel memcheckReleaseTest: {
+            stage("memcheckReleaseTest") {
+              // Runs after the other sanitizers as it depends on clang-release to be built.
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "mkdir ./clang-release-memcheck-test"
+                // If this shows a leak, try --leak-check=full, which is slower but more precise. Valgrind serializes
+                // concurrent threads into a single one. Thus, we limit the cores and data preparation cores for the
+                // benchmark runs to reduce this serialization overhead. According to the Valgrind documentation,
+                // --fair-sched=yes "improves overall responsiveness if you are running an interactive multithreaded
+                // program" and "produces better reproducibility of thread scheduling for different executions of a
+                // multithreaded application" (i.e., there are no runs that are randomly faster or slower).
+                sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseTest clang-release-memcheck-test --gtest_filter=-NUMAMemoryResourceTest.BasicAllocate:SQLiteTestRunner*"
+                sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCH -s .01 -r 1 --scheduler --cores 4 --data_preparation_cores 4"
+                sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCDS -s 1 -r 1 --scheduler --cores 4 --data_preparation_cores 4"
+                sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCC -s 1 --scheduler --cores 4 --data_preparation_cores 4"
+              } else {
+                Utils.markStageSkippedForConditional("memcheckReleaseTest")
+              }
+            }
+          }, tpchVerification: {
+            stage("tpchVerification") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                // Verify both single- and multithreaded results.
+                sh "./clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 1 -s 1 --verify"
+                sh "./clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 1 -s 1 --verify --scheduler --clients 1 --cores 10"
+              } else {
+                Utils.markStageSkippedForConditional("tpchVerification")
+              }
+            }
+          }, tpchQueryPlans: {
+            stage("tpchQueryPlans") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "mkdir -p query_plans/tpch; cd query_plans/tpch && ../../clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 2 -s 10 --visualize && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
+                archiveArtifacts artifacts: 'query_plans/tpch/*.svg'
+                archiveArtifacts artifacts: 'query_plans/tpch/operator_breakdown.pdf'
+              } else {
+                Utils.markStageSkippedForConditional("tpchQueryPlans")
+              }
+            }
+          }, tpcdsQueryPlansAndVerification: {
+            stage("tpcdsQueryPlansAndVerification") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "mkdir -p query_plans/tpcds; cd query_plans/tpcds && ln -s ../../resources; ../../clang-release/hyriseBenchmarkTPCDS --dont_cache_binary_tables -r 1 -s 1 --visualize --verify && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
+                archiveArtifacts artifacts: 'query_plans/tpcds/*.svg'
+                archiveArtifacts artifacts: 'query_plans/tpcds/operator_breakdown.pdf'
+              } else {
+                Utils.markStageSkippedForConditional("tpcdsQueryPlansAndVerification")
+              }
+            }
+          }, jobQueryPlans: {
+            stage("jobQueryPlans") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                // In contrast to TPC-H and TPC-DS above, we execute the JoinOrderBenchmark from the project's root directoy because its setup script requires us to do so.
+                sh "mkdir -p query_plans/job && ./clang-release/hyriseBenchmarkJoinOrder --dont_cache_binary_tables -r 1 --visualize && ./scripts/plot_operator_breakdown.py ./clang-release/ && mv operator_breakdown.pdf query_plans/job && mv *QP.svg query_plans/job"
+                archiveArtifacts artifacts: 'query_plans/job/*.svg'
+                archiveArtifacts artifacts: 'query_plans/job/operator_breakdown.pdf'
+              } else {
+                Utils.markStageSkippedForConditional("jobQueryPlans")
+              }
+            }
+          }, ssbQueryPlans: {
+            stage("ssbQueryPlans") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "mkdir -p query_plans/ssb; cd query_plans/ssb && ../../clang-release/hyriseBenchmarkStarSchema --dont_cache_binary_tables -r 1 -s 1 --visualize && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
+                archiveArtifacts artifacts: 'query_plans/ssb/*.svg'
+                archiveArtifacts artifacts: 'query_plans/ssb/operator_breakdown.pdf'
+              } else {
+                Utils.markStageSkippedForConditional("ssbQueryPlans")
+              }
+            }
+          }, nixSetup: {
+            stage('nixSetup') {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "curl -L https://nixos.org/nix/install > nix-install.sh && chmod +x nix-install.sh && ./nix-install.sh --daemon --yes"
+                sh "/nix/var/nix/profiles/default/bin/nix-shell resources/nix --pure --run \"mkdir nix-debug && cd nix-debug && cmake ${debug} ${clang} ${unity} ${ninja} .. && ninja all -j \$(( \$(nproc) / 7)) && ./hyriseTest\""
+                // We allocate a third of all cores for the release build as several parallel stages should have already finished at this point.
+                sh "/nix/var/nix/profiles/default/bin/nix-shell resources/nix --pure --run \"mkdir nix-release && cd nix-release && cmake ${release} ${clang} ${unity} ${ninja} .. && ninja all -j \$(( \$(nproc) / 3)) && ./hyriseTest\""
+              } else {
+                Utils.markStageSkippedForConditional("nixSetup")
+              }
+            }
+          }
         } finally {
           sh "ls -A1 | xargs rm -rf"
           deleteDir()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,362 +55,362 @@ try {
     }
   }
 
-  node('linux') {
-    stage("Hostname") {
-      // Print the hostname to let us know on which node the docker image was executed for reproducibility.
-      sh "hostname"
-    }
+  // node('linux') {
+  //   stage("Hostname") {
+  //     // Print the hostname to let us know on which node the docker image was executed for reproducibility.
+  //     sh "hostname"
+  //   }
 
-    // The empty '' results in using the default registry: https://index.docker.io/v1/
-    docker.withRegistry('', 'docker') {
-      def hyriseCI = docker.image('hyrise/hyrise-ci:24.04');
-      hyriseCI.pull()
+  //   // The empty '' results in using the default registry: https://index.docker.io/v1/
+  //   docker.withRegistry('', 'docker') {
+  //     def hyriseCI = docker.image('hyrise/hyrise-ci:24.04');
+  //     hyriseCI.pull()
 
-      // LSAN (executed as part of ASAN) requires elevated privileges. Therefore, we had to add --cap-add SYS_PTRACE.
-      // Even if the CI run sometimes succeeds without SYS_PTRACE, you should not remove it until you know what you are
-      // doing. See also: https://github.com/google/sanitizers/issues/764
-      hyriseCI.inside("--cap-add SYS_PTRACE -u 0:0") {
-        try {
-          stage("Setup") {
-            checkout scm
+  //     // LSAN (executed as part of ASAN) requires elevated privileges. Therefore, we had to add --cap-add SYS_PTRACE.
+  //     // Even if the CI run sometimes succeeds without SYS_PTRACE, you should not remove it until you know what you are
+  //     // doing. See also: https://github.com/google/sanitizers/issues/764
+  //     hyriseCI.inside("--cap-add SYS_PTRACE -u 0:0") {
+  //       try {
+  //         stage("Setup") {
+  //           checkout scm
 
-            // Check if ninja-build is installed. As make is sufficient to work with Hyrise, ninja-build is not
-            // installed via install_dependencies.sh but is part of the hyrise-ci docker image.
-            sh "ninja --version > /dev/null"
+  //           // Check if ninja-build is installed. As make is sufficient to work with Hyrise, ninja-build is not
+  //           // installed via install_dependencies.sh but is part of the hyrise-ci docker image.
+  //           sh "ninja --version > /dev/null"
 
-            // During CI runs, the user is different from the owner of the directories, which blocks the execution of
-            // git commands since the fix of the git vulnerability CVE-2022-24765. git commands can then only be
-            // executed if the corresponding directories are added as safe directories.
-            sh '''
-            git config --global --add safe.directory $WORKSPACE
-            # Get the paths of the submodules; for each path, add it as a git safe.directory
-            grep path .gitmodules | sed 's/.*=//' | xargs -n 1 -I '{}' git config --global --add safe.directory $WORKSPACE/'{}'
-            '''
+  //           // During CI runs, the user is different from the owner of the directories, which blocks the execution of
+  //           // git commands since the fix of the git vulnerability CVE-2022-24765. git commands can then only be
+  //           // executed if the corresponding directories are added as safe directories.
+  //           sh '''
+  //           git config --global --add safe.directory $WORKSPACE
+  //           # Get the paths of the submodules; for each path, add it as a git safe.directory
+  //           grep path .gitmodules | sed 's/.*=//' | xargs -n 1 -I '{}' git config --global --add safe.directory $WORKSPACE/'{}'
+  //           '''
 
-            sh "./install_dependencies.sh"
+  //           sh "./install_dependencies.sh"
 
-            cmake = 'cmake -DCI_BUILD=ON'
+  //           cmake = 'cmake -DCI_BUILD=ON'
 
-            // We do not use unity builds with clang-tidy (see below).
-            unity = '-DCMAKE_UNITY_BUILD=ON'
+  //           // We do not use unity builds with clang-tidy (see below).
+  //           unity = '-DCMAKE_UNITY_BUILD=ON'
 
-            // To speed compiling up, we use ninja for most builds.
-            ninja = '-GNinja'
+  //           // To speed compiling up, we use ninja for most builds.
+  //           ninja = '-GNinja'
 
-            // With Hyrise, we aim to support the most recent compiler versions and do not invest a lot of work to
-            // support older versions. We test LLVM 16 (older versions might work, but LLVM 15 has issues with libstdc++
-            // of GCC 14) and GCC 13.2 (oldest version supported by Hyrise). We execute at least debug runs for them. If
-            // you want to upgrade compiler versions, please update install_dependencies.sh, DEPENDENCIES.md, and the
-            // documentation (README, Wiki).
-            clang = '-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++'
-            clang16 = '-DCMAKE_C_COMPILER=clang-16 -DCMAKE_CXX_COMPILER=clang++-16'
-            gcc = '-DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14'
-            gcc13 = '-DCMAKE_C_COMPILER=gcc-13 -DCMAKE_CXX_COMPILER=g++-13'
+  //           // With Hyrise, we aim to support the most recent compiler versions and do not invest a lot of work to
+  //           // support older versions. We test LLVM 16 (older versions might work, but LLVM 15 has issues with libstdc++
+  //           // of GCC 14) and GCC 13.2 (oldest version supported by Hyrise). We execute at least debug runs for them. If
+  //           // you want to upgrade compiler versions, please update install_dependencies.sh, DEPENDENCIES.md, and the
+  //           // documentation (README, Wiki).
+  //           clang = '-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++'
+  //           clang16 = '-DCMAKE_C_COMPILER=clang-16 -DCMAKE_CXX_COMPILER=clang++-16'
+  //           gcc = '-DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14'
+  //           gcc13 = '-DCMAKE_C_COMPILER=gcc-13 -DCMAKE_CXX_COMPILER=g++-13'
 
-            debug = '-DCMAKE_BUILD_TYPE=Debug'
-            release = '-DCMAKE_BUILD_TYPE=Release'
-            relwithdebinfo = '-DCMAKE_BUILD_TYPE=RelWithDebInfo'
+  //           debug = '-DCMAKE_BUILD_TYPE=Debug'
+  //           release = '-DCMAKE_BUILD_TYPE=Release'
+  //           relwithdebinfo = '-DCMAKE_BUILD_TYPE=RelWithDebInfo'
 
-            // LTO is automatically disabled for debug and sanitizer builds. As LTO linking with GCC and gold (lld is
-            // not supported when using GCC and LTO) takes over an hour, we skip LTO for the GCC release build.
-            no_lto = '-DNO_LTO=TRUE'
+  //           // LTO is automatically disabled for debug and sanitizer builds. As LTO linking with GCC and gold (lld is
+  //           // not supported when using GCC and LTO) takes over an hour, we skip LTO for the GCC release build.
+  //           no_lto = '-DNO_LTO=TRUE'
 
-            // jemalloc's autoconf operates outside of the build folder (#1413). If we start two cmake instances at the
-            // same time, we run into conflicts. Thus, run this one (any one, really) first, so that the autoconf step
-            // can finish in peace.
-            sh "mkdir clang-debug && cd clang-debug &&                                                   ${cmake} ${debug}          ${clang}  ${unity} .. && make -j \$(nproc) libjemalloc-build"
+  //           // jemalloc's autoconf operates outside of the build folder (#1413). If we start two cmake instances at the
+  //           // same time, we run into conflicts. Thus, run this one (any one, really) first, so that the autoconf step
+  //           // can finish in peace.
+  //           sh "mkdir clang-debug && cd clang-debug &&                                                   ${cmake} ${debug}          ${clang}  ${unity} .. && make -j \$(nproc) libjemalloc-build"
 
-            // Configure the rest in parallel. We use unity builds to decrease build times. The only exception is the
-            // clang-tidy build as it might otherwise miss some issues (e.g., missing includes).
-            sh "mkdir clang-debug-tidy && cd clang-debug-tidy &&                                         ${cmake} ${debug}          ${clang}                      ${ninja} -DENABLE_CLANG_TIDY=ON .. &\
-            mkdir clang-debug-unity-odr && cd clang-debug-unity-odr &&                                   ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DCMAKE_UNITY_BUILD_BATCH_SIZE=0 .. &\
-            mkdir clang-debug-disable-precompile-headers && cd clang-debug-disable-precompile-headers && ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DCMAKE_DISABLE_PRECOMPILE_HEADERS=On .. &\
-            mkdir clang-debug-addr-ub-leak-sanitizers && cd clang-debug-addr-ub-leak-sanitizers &&       ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DENABLE_ADDR_UB_LEAK_SANITIZATION=ON .. &\
-            mkdir clang-release-addr-ub-leak-sanitizers && cd clang-release-addr-ub-leak-sanitizers &&   ${cmake} ${release}        ${clang}   ${unity}           ${ninja} -DENABLE_ADDR_UB_LEAK_SANITIZATION=ON .. &\
-            mkdir clang-relwithdebinfo-thread-sanitizer && cd clang-relwithdebinfo-thread-sanitizer &&   ${cmake} ${relwithdebinfo} ${clang}   ${unity}           ${ninja} -DENABLE_THREAD_SANITIZATION=ON .. &\
-            mkdir clang-release && cd clang-release &&                                                   ${cmake} ${release}        ${clang}   ${unity}           ${ninja} .. &\
-            mkdir gcc-debug && cd gcc-debug &&                                                           ${cmake} ${debug}          ${gcc}     ${unity}           ${ninja} .. &\
-            mkdir gcc-release && cd gcc-release &&                                                       ${cmake} ${release}        ${gcc}     ${unity} ${no_lto} ${ninja} .. &\
-            mkdir clang-16-debug && cd clang-16-debug &&                                                 ${cmake} ${debug}          ${clang16} ${unity}           ${ninja} .. &\
-            mkdir gcc-13-debug && cd gcc-13-debug &&                                                     ${cmake} ${debug}          ${gcc13}   ${unity}           ${ninja} .. &\
-            wait"
-          }
+  //           // Configure the rest in parallel. We use unity builds to decrease build times. The only exception is the
+  //           // clang-tidy build as it might otherwise miss some issues (e.g., missing includes).
+  //           sh "mkdir clang-debug-tidy && cd clang-debug-tidy &&                                         ${cmake} ${debug}          ${clang}                      ${ninja} -DENABLE_CLANG_TIDY=ON .. &\
+  //           mkdir clang-debug-unity-odr && cd clang-debug-unity-odr &&                                   ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DCMAKE_UNITY_BUILD_BATCH_SIZE=0 .. &\
+  //           mkdir clang-debug-disable-precompile-headers && cd clang-debug-disable-precompile-headers && ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DCMAKE_DISABLE_PRECOMPILE_HEADERS=On .. &\
+  //           mkdir clang-debug-addr-ub-leak-sanitizers && cd clang-debug-addr-ub-leak-sanitizers &&       ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DENABLE_ADDR_UB_LEAK_SANITIZATION=ON .. &\
+  //           mkdir clang-release-addr-ub-leak-sanitizers && cd clang-release-addr-ub-leak-sanitizers &&   ${cmake} ${release}        ${clang}   ${unity}           ${ninja} -DENABLE_ADDR_UB_LEAK_SANITIZATION=ON .. &\
+  //           mkdir clang-relwithdebinfo-thread-sanitizer && cd clang-relwithdebinfo-thread-sanitizer &&   ${cmake} ${relwithdebinfo} ${clang}   ${unity}           ${ninja} -DENABLE_THREAD_SANITIZATION=ON .. &\
+  //           mkdir clang-release && cd clang-release &&                                                   ${cmake} ${release}        ${clang}   ${unity}           ${ninja} .. &\
+  //           mkdir gcc-debug && cd gcc-debug &&                                                           ${cmake} ${debug}          ${gcc}     ${unity}           ${ninja} .. &\
+  //           mkdir gcc-release && cd gcc-release &&                                                       ${cmake} ${release}        ${gcc}     ${unity} ${no_lto} ${ninja} .. &\
+  //           mkdir clang-16-debug && cd clang-16-debug &&                                                 ${cmake} ${debug}          ${clang16} ${unity}           ${ninja} .. &\
+  //           mkdir gcc-13-debug && cd gcc-13-debug &&                                                     ${cmake} ${debug}          ${gcc13}   ${unity}           ${ninja} .. &\
+  //           wait"
+  //         }
 
-          parallel clangDebug: {
-            stage("clang-debug") {
-              // We build clang-debug using make to test make once (and clang-debug is the fastest build).
-              sh "cd clang-debug && make all -j \$(( \$(nproc) / 4))"
-              sh "./clang-debug/hyriseTest clang-debug"
-            }
-          }, clang16Debug: {
-            stage("clang-16-debug") {
-              sh "cd clang-16-debug && ninja all -j \$(( \$(nproc) / 4))"
-              sh "./clang-16-debug/hyriseTest clang-16-debug"
-            }
-          }, gccDebug: {
-            stage("gcc-debug") {
-              sh "cd gcc-debug && ninja all -j \$(( \$(nproc) / 4))"
-              sh "cd gcc-debug && ./hyriseTest"
-            }
-          }, gcc13Debug: {
-            stage("gcc-13-debug") {
-              sh "cd gcc-13-debug && ninja all -j \$(( \$(nproc) / 4))"
-              sh "cd gcc-13-debug && ./hyriseTest"
-            }
-          }, lint: {
-            stage("Linting") {
-              sh "scripts/lint.sh"
-            }
-          }
+  //         parallel clangDebug: {
+  //           stage("clang-debug") {
+  //             // We build clang-debug using make to test make once (and clang-debug is the fastest build).
+  //             sh "cd clang-debug && make all -j \$(( \$(nproc) / 4))"
+  //             sh "./clang-debug/hyriseTest clang-debug"
+  //           }
+  //         }, clang16Debug: {
+  //           stage("clang-16-debug") {
+  //             sh "cd clang-16-debug && ninja all -j \$(( \$(nproc) / 4))"
+  //             sh "./clang-16-debug/hyriseTest clang-16-debug"
+  //           }
+  //         }, gccDebug: {
+  //           stage("gcc-debug") {
+  //             sh "cd gcc-debug && ninja all -j \$(( \$(nproc) / 4))"
+  //             sh "cd gcc-debug && ./hyriseTest"
+  //           }
+  //         }, gcc13Debug: {
+  //           stage("gcc-13-debug") {
+  //             sh "cd gcc-13-debug && ninja all -j \$(( \$(nproc) / 4))"
+  //             sh "cd gcc-13-debug && ./hyriseTest"
+  //           }
+  //         }, lint: {
+  //           stage("Linting") {
+  //             sh "scripts/lint.sh"
+  //           }
+  //         }
 
-          // We distribute the cores to processes in a way to even the running times. With an even distributions,
-          // clang-tidy builds take up to 3h (galileo server). In addition to compile time, the distribution also
-          // considers the long test runtimes of clangRelWithDebInfoThreadSanitizer (~50 minutes).
-          parallel clangRelease: {
-            stage("clang-release") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "cd clang-release && ninja all -j \$(( \$(nproc) / 10))"
-                sh "./clang-release/hyriseTest clang-release"
-                sh "./clang-release/hyriseSystemTest clang-release"
-                sh "./scripts/test/hyriseConsole_test.py clang-release"
-                sh "./scripts/test/hyriseServer_test.py clang-release"
-                sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-release"
-                sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-release"
-                sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
-                sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
+  //         // We distribute the cores to processes in a way to even the running times. With an even distributions,
+  //         // clang-tidy builds take up to 3h (galileo server). In addition to compile time, the distribution also
+  //         // considers the long test runtimes of clangRelWithDebInfoThreadSanitizer (~50 minutes).
+  //         parallel clangRelease: {
+  //           stage("clang-release") {
+  //             if (env.BRANCH_NAME == 'master' || full_ci) {
+  //               sh "cd clang-release && ninja all -j \$(( \$(nproc) / 10))"
+  //               sh "./clang-release/hyriseTest clang-release"
+  //               sh "./clang-release/hyriseSystemTest clang-release"
+  //               sh "./scripts/test/hyriseConsole_test.py clang-release"
+  //               sh "./scripts/test/hyriseServer_test.py clang-release"
+  //               sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-release"
+  //               sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-release"
+  //               sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
+  //               sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
 
-              } else {
-                Utils.markStageSkippedForConditional("clangRelease")
-              }
-            }
-          }, debugSystemTests: {
-            stage("system-tests") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "mkdir clang-debug-system &&  ./clang-debug/hyriseSystemTest clang-debug-system"
-                sh "mkdir gcc-debug-system &&  ./gcc-debug/hyriseSystemTest gcc-debug-system"
-                sh "./scripts/test/hyriseConsole_test.py clang-debug"
-                sh "./scripts/test/hyriseServer_test.py clang-debug"
-                sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-debug"
-                sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-debug"
-                sh "cd clang-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
-                sh "cd clang-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate cached data
-                sh "cd clang-debug && ../scripts/test/hyriseBenchmarkStarSchema_test.py ." // Own folder to isolate cached data
-                sh "./scripts/test/hyriseConsole_test.py gcc-debug"
-                sh "./scripts/test/hyriseServer_test.py gcc-debug"
-                sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-debug"
-                sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-debug"
-                sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
-                sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate cached data
-                sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkStarSchema_test.py ." // Own folder to isolate cached data
+  //             } else {
+  //               Utils.markStageSkippedForConditional("clangRelease")
+  //             }
+  //           }
+  //         }, debugSystemTests: {
+  //           stage("system-tests") {
+  //             if (env.BRANCH_NAME == 'master' || full_ci) {
+  //               sh "mkdir clang-debug-system &&  ./clang-debug/hyriseSystemTest clang-debug-system"
+  //               sh "mkdir gcc-debug-system &&  ./gcc-debug/hyriseSystemTest gcc-debug-system"
+  //               sh "./scripts/test/hyriseConsole_test.py clang-debug"
+  //               sh "./scripts/test/hyriseServer_test.py clang-debug"
+  //               sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-debug"
+  //               sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-debug"
+  //               sh "cd clang-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
+  //               sh "cd clang-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate cached data
+  //               sh "cd clang-debug && ../scripts/test/hyriseBenchmarkStarSchema_test.py ." // Own folder to isolate cached data
+  //               sh "./scripts/test/hyriseConsole_test.py gcc-debug"
+  //               sh "./scripts/test/hyriseServer_test.py gcc-debug"
+  //               sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-debug"
+  //               sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-debug"
+  //               sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
+  //               sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate cached data
+  //               sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkStarSchema_test.py ." // Own folder to isolate cached data
 
-              } else {
-                Utils.markStageSkippedForConditional("debugSystemTests")
-              }
-            }
-          }, clangDebugRunShuffled: {
-            stage("clang-debug:test-shuffle") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "mkdir ./clang-debug/run-shuffled"
-                sh "./clang-debug/hyriseTest clang-debug/run-shuffled --gtest_repeat=5 --gtest_shuffle"
-                // We do not want to trigger SSB data generation concurrently since it is not concurrency-safe.
-                sh "./clang-debug/hyriseSystemTest clang-debug/run-shuffled --gtest_repeat=2 --gtest_shuffle --gtest_filter=\"-SSBTableGeneratorTest.*:SQLiteTestRunnerEncodings/*\""
-              } else {
-                Utils.markStageSkippedForConditional("clangDebugRunShuffled")
-              }
-            }
-          }, clangDebugUnityODR: {
-            stage("clang-debug-unity-odr") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                // Check if unity builds work even if everything is batched into a single compilation unit. This helps prevent ODR (one definition rule) issues.
-                sh "cd clang-debug-unity-odr && ninja all -j 2"
-              } else {
-                Utils.markStageSkippedForConditional("clangDebugUnityODR")
-              }
-            }
-          }, clangDebugTidy: {
-            stage("clang-debug:tidy") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                // We do not run tidy checks on the src/test folder, so there is no point in running the expensive clang-tidy for those files
-                sh "cd clang-debug-tidy && ninja hyrise_impl hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer hyriseMvccDeletePlugin hyriseUccDiscoveryPlugin -k 0 -j \$(( \$(nproc) / 5))"
-              } else {
-                Utils.markStageSkippedForConditional("clangDebugTidy")
-              }
-            }
-          }, clangDebugDisablePrecompileHeaders: {
-            stage("clang-debug:disable-precompile-headers") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                // Check if builds work even when precompile headers is turned off. Executing the binaries is unnecessary as the observed errors are missing includes.
-                sh "cd clang-debug-disable-precompile-headers && ninja hyriseTest hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer -k 0 -j 2"
-              } else {
-                Utils.markStageSkippedForConditional("clangDebugDisablePrecompileHeaders")
-              }
-            }
-          }, clangDebugAddrUBLeakSanitizers: {
-            stage("clang-debug:addr-ub-sanitizers") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "cd clang-debug-addr-ub-leak-sanitizers && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 10))"
-                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseTest clang-debug-addr-ub-leak-sanitizers"
-                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-debug-addr-ub-leak-sanitizers"
-                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 1"
-              } else {
-                Utils.markStageSkippedForConditional("clangDebugAddrUBLeakSanitizers")
-              }
-            }
-          }, gccRelease: {
-            if (env.BRANCH_NAME == 'master' || full_ci) {
-              stage("gcc-release") {
-                sh "cd gcc-release && ninja all -j \$(( \$(nproc) / 10))"
-                sh "./gcc-release/hyriseTest gcc-release"
-                sh "./gcc-release/hyriseSystemTest gcc-release"
-                sh "./scripts/test/hyriseConsole_test.py gcc-release"
-                sh "./scripts/test/hyriseServer_test.py gcc-release"
-                sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-release"
-                sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-release"
-                sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
-                sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
-              }
-            } else {
-                Utils.markStageSkippedForConditional("gccRelease")
-            }
-          }, clangReleaseAddrUBLeakSanitizers: {
-            stage("clang-release:addr-ub-sanitizers") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "cd clang-release-addr-ub-leak-sanitizers && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 5))"
-                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseTest clang-release-addr-ub-leak-sanitizers"
-                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-release-addr-ub-leak-sanitizers"
-                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
-                sh "cd clang-release-addr-ub-leak-sanitizers && LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
-              } else {
-                Utils.markStageSkippedForConditional("clangReleaseAddrUBLeakSanitizers")
-              }
-            }
-          }, clangRelWithDebInfoThreadSanitizer: {
-            stage("clang-relwithdebinfo:thread-sanitizer") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "cd clang-relwithdebinfo-thread-sanitizer && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC hyriseBenchmarkTPCDS -j \$(( \$(nproc) / 5))"
-                sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseTest clang-relwithdebinfo-thread-sanitizer"
-                sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-relwithdebinfo-thread-sanitizer"
-                sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCH -s .01 -r 100 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
-                sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCC -s 1 --time 120 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
-                sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCDS -s 1 -r 5 --scheduler --clients 5 --cores \$(( \$(nproc) / 10))"
-              } else {
-                Utils.markStageSkippedForConditional("clangRelWithDebInfoThreadSanitizer")
-              }
-            }
-          }, clangDebugCoverage: {
-            stage("clang-debug-coverage") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "./scripts/coverage.sh --generate_badge=true"
-                sh "find coverage -type d -exec chmod +rx {} \\;"
-                archive 'coverage_badge.svg'
-                archive 'coverage_percent.txt'
-                publishHTML (target: [
-                  allowMissing: false,
-                  alwaysLinkToLastBuild: false,
-                  keepAll: true,
-                  reportDir: 'coverage',
-                  reportFiles: 'index.html',
-                  reportName: "Llvm-cov_Report"
-                ])
-                script {
-                  coverageChange = sh script: "./scripts/compare_coverage.sh", returnStdout: true
-                  githubNotify context: 'Coverage', description: "$coverageChange", status: 'SUCCESS', targetUrl: "${env.BUILD_URL}/RCov_20Report/index.html"
-                }
-              } else {
-                Utils.markStageSkippedForConditional("clangDebugCoverage")
-              }
-            }
-          }
+  //             } else {
+  //               Utils.markStageSkippedForConditional("debugSystemTests")
+  //             }
+  //           }
+  //         }, clangDebugRunShuffled: {
+  //           stage("clang-debug:test-shuffle") {
+  //             if (env.BRANCH_NAME == 'master' || full_ci) {
+  //               sh "mkdir ./clang-debug/run-shuffled"
+  //               sh "./clang-debug/hyriseTest clang-debug/run-shuffled --gtest_repeat=5 --gtest_shuffle"
+  //               // We do not want to trigger SSB data generation concurrently since it is not concurrency-safe.
+  //               sh "./clang-debug/hyriseSystemTest clang-debug/run-shuffled --gtest_repeat=2 --gtest_shuffle --gtest_filter=\"-SSBTableGeneratorTest.*:SQLiteTestRunnerEncodings/*\""
+  //             } else {
+  //               Utils.markStageSkippedForConditional("clangDebugRunShuffled")
+  //             }
+  //           }
+  //         }, clangDebugUnityODR: {
+  //           stage("clang-debug-unity-odr") {
+  //             if (env.BRANCH_NAME == 'master' || full_ci) {
+  //               // Check if unity builds work even if everything is batched into a single compilation unit. This helps prevent ODR (one definition rule) issues.
+  //               sh "cd clang-debug-unity-odr && ninja all -j 2"
+  //             } else {
+  //               Utils.markStageSkippedForConditional("clangDebugUnityODR")
+  //             }
+  //           }
+  //         }, clangDebugTidy: {
+  //           stage("clang-debug:tidy") {
+  //             if (env.BRANCH_NAME == 'master' || full_ci) {
+  //               // We do not run tidy checks on the src/test folder, so there is no point in running the expensive clang-tidy for those files
+  //               sh "cd clang-debug-tidy && ninja hyrise_impl hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer hyriseMvccDeletePlugin hyriseUccDiscoveryPlugin -k 0 -j \$(( \$(nproc) / 5))"
+  //             } else {
+  //               Utils.markStageSkippedForConditional("clangDebugTidy")
+  //             }
+  //           }
+  //         }, clangDebugDisablePrecompileHeaders: {
+  //           stage("clang-debug:disable-precompile-headers") {
+  //             if (env.BRANCH_NAME == 'master' || full_ci) {
+  //               // Check if builds work even when precompile headers is turned off. Executing the binaries is unnecessary as the observed errors are missing includes.
+  //               sh "cd clang-debug-disable-precompile-headers && ninja hyriseTest hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer -k 0 -j 2"
+  //             } else {
+  //               Utils.markStageSkippedForConditional("clangDebugDisablePrecompileHeaders")
+  //             }
+  //           }
+  //         }, clangDebugAddrUBLeakSanitizers: {
+  //           stage("clang-debug:addr-ub-sanitizers") {
+  //             if (env.BRANCH_NAME == 'master' || full_ci) {
+  //               sh "cd clang-debug-addr-ub-leak-sanitizers && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 10))"
+  //               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseTest clang-debug-addr-ub-leak-sanitizers"
+  //               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-debug-addr-ub-leak-sanitizers"
+  //               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 1"
+  //             } else {
+  //               Utils.markStageSkippedForConditional("clangDebugAddrUBLeakSanitizers")
+  //             }
+  //           }
+  //         }, gccRelease: {
+  //           if (env.BRANCH_NAME == 'master' || full_ci) {
+  //             stage("gcc-release") {
+  //               sh "cd gcc-release && ninja all -j \$(( \$(nproc) / 10))"
+  //               sh "./gcc-release/hyriseTest gcc-release"
+  //               sh "./gcc-release/hyriseSystemTest gcc-release"
+  //               sh "./scripts/test/hyriseConsole_test.py gcc-release"
+  //               sh "./scripts/test/hyriseServer_test.py gcc-release"
+  //               sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-release"
+  //               sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-release"
+  //               sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
+  //               sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
+  //             }
+  //           } else {
+  //               Utils.markStageSkippedForConditional("gccRelease")
+  //           }
+  //         }, clangReleaseAddrUBLeakSanitizers: {
+  //           stage("clang-release:addr-ub-sanitizers") {
+  //             if (env.BRANCH_NAME == 'master' || full_ci) {
+  //               sh "cd clang-release-addr-ub-leak-sanitizers && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 5))"
+  //               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseTest clang-release-addr-ub-leak-sanitizers"
+  //               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-release-addr-ub-leak-sanitizers"
+  //               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
+  //               sh "cd clang-release-addr-ub-leak-sanitizers && LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
+  //             } else {
+  //               Utils.markStageSkippedForConditional("clangReleaseAddrUBLeakSanitizers")
+  //             }
+  //           }
+  //         }, clangRelWithDebInfoThreadSanitizer: {
+  //           stage("clang-relwithdebinfo:thread-sanitizer") {
+  //             if (env.BRANCH_NAME == 'master' || full_ci) {
+  //               sh "cd clang-relwithdebinfo-thread-sanitizer && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC hyriseBenchmarkTPCDS -j \$(( \$(nproc) / 5))"
+  //               sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseTest clang-relwithdebinfo-thread-sanitizer"
+  //               sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-relwithdebinfo-thread-sanitizer"
+  //               sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCH -s .01 -r 100 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
+  //               sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCC -s 1 --time 120 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
+  //               sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCDS -s 1 -r 5 --scheduler --clients 5 --cores \$(( \$(nproc) / 10))"
+  //             } else {
+  //               Utils.markStageSkippedForConditional("clangRelWithDebInfoThreadSanitizer")
+  //             }
+  //           }
+  //         }, clangDebugCoverage: {
+  //           stage("clang-debug-coverage") {
+  //             if (env.BRANCH_NAME == 'master' || full_ci) {
+  //               sh "./scripts/coverage.sh --generate_badge=true"
+  //               sh "find coverage -type d -exec chmod +rx {} \\;"
+  //               archive 'coverage_badge.svg'
+  //               archive 'coverage_percent.txt'
+  //               publishHTML (target: [
+  //                 allowMissing: false,
+  //                 alwaysLinkToLastBuild: false,
+  //                 keepAll: true,
+  //                 reportDir: 'coverage',
+  //                 reportFiles: 'index.html',
+  //                 reportName: "Llvm-cov_Report"
+  //               ])
+  //               script {
+  //                 coverageChange = sh script: "./scripts/compare_coverage.sh", returnStdout: true
+  //                 githubNotify context: 'Coverage', description: "$coverageChange", status: 'SUCCESS', targetUrl: "${env.BUILD_URL}/RCov_20Report/index.html"
+  //               }
+  //             } else {
+  //               Utils.markStageSkippedForConditional("clangDebugCoverage")
+  //             }
+  //           }
+  //         }
 
-          parallel memcheckReleaseTest: {
-            stage("memcheckReleaseTest") {
-              // Runs after the other sanitizers as it depends on clang-release to be built.
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "mkdir ./clang-release-memcheck-test"
-                // If this shows a leak, try --leak-check=full, which is slower but more precise. Valgrind serializes
-                // concurrent threads into a single one. Thus, we limit the cores and data preparation cores for the
-                // benchmark runs to reduce this serialization overhead. According to the Valgrind documentation,
-                // --fair-sched=yes "improves overall responsiveness if you are running an interactive multithreaded
-                // program" and "produces better reproducibility of thread scheduling for different executions of a
-                // multithreaded application" (i.e., there are no runs that are randomly faster or slower).
-                sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseTest clang-release-memcheck-test --gtest_filter=-NUMAMemoryResourceTest.BasicAllocate:SQLiteTestRunner*"
-                sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCH -s .01 -r 1 --scheduler --cores 4 --data_preparation_cores 4"
-                sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCDS -s 1 -r 1 --scheduler --cores 4 --data_preparation_cores 4"
-                sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCC -s 1 --scheduler --cores 4 --data_preparation_cores 4"
-              } else {
-                Utils.markStageSkippedForConditional("memcheckReleaseTest")
-              }
-            }
-          }, tpchVerification: {
-            stage("tpchVerification") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                // Verify both single- and multithreaded results.
-                sh "./clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 1 -s 1 --verify"
-                sh "./clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 1 -s 1 --verify --scheduler --clients 1 --cores 10"
-              } else {
-                Utils.markStageSkippedForConditional("tpchVerification")
-              }
-            }
-          }, tpchQueryPlans: {
-            stage("tpchQueryPlans") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "mkdir -p query_plans/tpch; cd query_plans/tpch && ../../clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 2 -s 10 --visualize && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
-                archiveArtifacts artifacts: 'query_plans/tpch/*.svg'
-                archiveArtifacts artifacts: 'query_plans/tpch/operator_breakdown.pdf'
-              } else {
-                Utils.markStageSkippedForConditional("tpchQueryPlans")
-              }
-            }
-          }, tpcdsQueryPlansAndVerification: {
-            stage("tpcdsQueryPlansAndVerification") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "mkdir -p query_plans/tpcds; cd query_plans/tpcds && ln -s ../../resources; ../../clang-release/hyriseBenchmarkTPCDS --dont_cache_binary_tables -r 1 -s 1 --visualize --verify && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
-                archiveArtifacts artifacts: 'query_plans/tpcds/*.svg'
-                archiveArtifacts artifacts: 'query_plans/tpcds/operator_breakdown.pdf'
-              } else {
-                Utils.markStageSkippedForConditional("tpcdsQueryPlansAndVerification")
-              }
-            }
-          }, jobQueryPlans: {
-            stage("jobQueryPlans") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                // In contrast to TPC-H and TPC-DS above, we execute the JoinOrderBenchmark from the project's root directoy because its setup script requires us to do so.
-                sh "mkdir -p query_plans/job && ./clang-release/hyriseBenchmarkJoinOrder --dont_cache_binary_tables -r 1 --visualize && ./scripts/plot_operator_breakdown.py ./clang-release/ && mv operator_breakdown.pdf query_plans/job && mv *QP.svg query_plans/job"
-                archiveArtifacts artifacts: 'query_plans/job/*.svg'
-                archiveArtifacts artifacts: 'query_plans/job/operator_breakdown.pdf'
-              } else {
-                Utils.markStageSkippedForConditional("jobQueryPlans")
-              }
-            }
-          }, ssbQueryPlans: {
-            stage("ssbQueryPlans") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "mkdir -p query_plans/ssb; cd query_plans/ssb && ../../clang-release/hyriseBenchmarkStarSchema --dont_cache_binary_tables -r 1 -s 1 --visualize && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
-                archiveArtifacts artifacts: 'query_plans/ssb/*.svg'
-                archiveArtifacts artifacts: 'query_plans/ssb/operator_breakdown.pdf'
-              } else {
-                Utils.markStageSkippedForConditional("ssbQueryPlans")
-              }
-            }
-          }, nixSetup: {
-            stage('nixSetup') {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "curl -L https://nixos.org/nix/install > nix-install.sh && chmod +x nix-install.sh && ./nix-install.sh --daemon --yes"
-                sh "/nix/var/nix/profiles/default/bin/nix-shell resources/nix --pure --run \"mkdir nix-debug && cd nix-debug && cmake ${debug} ${clang} ${unity} ${ninja} .. && ninja all -j \$(( \$(nproc) / 7)) && ./hyriseTest\""
-                // We allocate a third of all cores for the release build as several parallel stages should have already finished at this point.
-                sh "/nix/var/nix/profiles/default/bin/nix-shell resources/nix --pure --run \"mkdir nix-release && cd nix-release && cmake ${release} ${clang} ${unity} ${ninja} .. && ninja all -j \$(( \$(nproc) / 3)) && ./hyriseTest\""
-              } else {
-                Utils.markStageSkippedForConditional("nixSetup")
-              }
-            }
-          }
-        } finally {
-          sh "ls -A1 | xargs rm -rf"
-          deleteDir()
-        }
-      }
-    }
-  }
+  //         parallel memcheckReleaseTest: {
+  //           stage("memcheckReleaseTest") {
+  //             // Runs after the other sanitizers as it depends on clang-release to be built.
+  //             if (env.BRANCH_NAME == 'master' || full_ci) {
+  //               sh "mkdir ./clang-release-memcheck-test"
+  //               // If this shows a leak, try --leak-check=full, which is slower but more precise. Valgrind serializes
+  //               // concurrent threads into a single one. Thus, we limit the cores and data preparation cores for the
+  //               // benchmark runs to reduce this serialization overhead. According to the Valgrind documentation,
+  //               // --fair-sched=yes "improves overall responsiveness if you are running an interactive multithreaded
+  //               // program" and "produces better reproducibility of thread scheduling for different executions of a
+  //               // multithreaded application" (i.e., there are no runs that are randomly faster or slower).
+  //               sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseTest clang-release-memcheck-test --gtest_filter=-NUMAMemoryResourceTest.BasicAllocate:SQLiteTestRunner*"
+  //               sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCH -s .01 -r 1 --scheduler --cores 4 --data_preparation_cores 4"
+  //               sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCDS -s 1 -r 1 --scheduler --cores 4 --data_preparation_cores 4"
+  //               sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCC -s 1 --scheduler --cores 4 --data_preparation_cores 4"
+  //             } else {
+  //               Utils.markStageSkippedForConditional("memcheckReleaseTest")
+  //             }
+  //           }
+  //         }, tpchVerification: {
+  //           stage("tpchVerification") {
+  //             if (env.BRANCH_NAME == 'master' || full_ci) {
+  //               // Verify both single- and multithreaded results.
+  //               sh "./clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 1 -s 1 --verify"
+  //               sh "./clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 1 -s 1 --verify --scheduler --clients 1 --cores 10"
+  //             } else {
+  //               Utils.markStageSkippedForConditional("tpchVerification")
+  //             }
+  //           }
+  //         }, tpchQueryPlans: {
+  //           stage("tpchQueryPlans") {
+  //             if (env.BRANCH_NAME == 'master' || full_ci) {
+  //               sh "mkdir -p query_plans/tpch; cd query_plans/tpch && ../../clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 2 -s 10 --visualize && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
+  //               archiveArtifacts artifacts: 'query_plans/tpch/*.svg'
+  //               archiveArtifacts artifacts: 'query_plans/tpch/operator_breakdown.pdf'
+  //             } else {
+  //               Utils.markStageSkippedForConditional("tpchQueryPlans")
+  //             }
+  //           }
+  //         }, tpcdsQueryPlansAndVerification: {
+  //           stage("tpcdsQueryPlansAndVerification") {
+  //             if (env.BRANCH_NAME == 'master' || full_ci) {
+  //               sh "mkdir -p query_plans/tpcds; cd query_plans/tpcds && ln -s ../../resources; ../../clang-release/hyriseBenchmarkTPCDS --dont_cache_binary_tables -r 1 -s 1 --visualize --verify && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
+  //               archiveArtifacts artifacts: 'query_plans/tpcds/*.svg'
+  //               archiveArtifacts artifacts: 'query_plans/tpcds/operator_breakdown.pdf'
+  //             } else {
+  //               Utils.markStageSkippedForConditional("tpcdsQueryPlansAndVerification")
+  //             }
+  //           }
+  //         }, jobQueryPlans: {
+  //           stage("jobQueryPlans") {
+  //             if (env.BRANCH_NAME == 'master' || full_ci) {
+  //               // In contrast to TPC-H and TPC-DS above, we execute the JoinOrderBenchmark from the project's root directoy because its setup script requires us to do so.
+  //               sh "mkdir -p query_plans/job && ./clang-release/hyriseBenchmarkJoinOrder --dont_cache_binary_tables -r 1 --visualize && ./scripts/plot_operator_breakdown.py ./clang-release/ && mv operator_breakdown.pdf query_plans/job && mv *QP.svg query_plans/job"
+  //               archiveArtifacts artifacts: 'query_plans/job/*.svg'
+  //               archiveArtifacts artifacts: 'query_plans/job/operator_breakdown.pdf'
+  //             } else {
+  //               Utils.markStageSkippedForConditional("jobQueryPlans")
+  //             }
+  //           }
+  //         }, ssbQueryPlans: {
+  //           stage("ssbQueryPlans") {
+  //             if (env.BRANCH_NAME == 'master' || full_ci) {
+  //               sh "mkdir -p query_plans/ssb; cd query_plans/ssb && ../../clang-release/hyriseBenchmarkStarSchema --dont_cache_binary_tables -r 1 -s 1 --visualize && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
+  //               archiveArtifacts artifacts: 'query_plans/ssb/*.svg'
+  //               archiveArtifacts artifacts: 'query_plans/ssb/operator_breakdown.pdf'
+  //             } else {
+  //               Utils.markStageSkippedForConditional("ssbQueryPlans")
+  //             }
+  //           }
+  //         }, nixSetup: {
+  //           stage('nixSetup') {
+  //             if (env.BRANCH_NAME == 'master' || full_ci) {
+  //               sh "curl -L https://nixos.org/nix/install > nix-install.sh && chmod +x nix-install.sh && ./nix-install.sh --daemon --yes"
+  //               sh "/nix/var/nix/profiles/default/bin/nix-shell resources/nix --pure --run \"mkdir nix-debug && cd nix-debug && cmake ${debug} ${clang} ${unity} ${ninja} .. && ninja all -j \$(( \$(nproc) / 7)) && ./hyriseTest\""
+  //               // We allocate a third of all cores for the release build as several parallel stages should have already finished at this point.
+  //               sh "/nix/var/nix/profiles/default/bin/nix-shell resources/nix --pure --run \"mkdir nix-release && cd nix-release && cmake ${release} ${clang} ${unity} ${ninja} .. && ninja all -j \$(( \$(nproc) / 3)) && ./hyriseTest\""
+  //             } else {
+  //               Utils.markStageSkippedForConditional("nixSetup")
+  //             }
+  //           }
+  //         }
+  //       } finally {
+  //         sh "ls -A1 | xargs rm -rf"
+  //         deleteDir()
+  //       }
+  //     }
+  //   }
+  // }
 
   parallel clangMacX64: {
     node('mac') {
@@ -443,13 +443,13 @@ try {
             // Build Hyrise (Release) with a recent clang compiler version (as recommended for Hyrise on macOS) and run
             // various tests. As the release build already takes quite a while on the Intel machine, we disable LTO and
             // only build release with LTO on the ARM machine.
-            sh "mkdir clang-release && cd clang-release && cmake ${release} ${ninja} ${no_lto} -DCMAKE_C_COMPILER=/usr/local/opt/llvm@19/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm@19/bin/clang++ .."
-            sh "cd clang-release && ninja"
-            sh "./clang-release/hyriseTest"
-            sh "./clang-release/hyriseSystemTest --gtest_filter=-${tests_excluded_in_mac_builds}"
-            sh "./scripts/test/hyriseConsole_test.py clang-release"
-            sh "./scripts/test/hyriseServer_test.py clang-release"
-            sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-release"
+            sh "mkdir clang-debug && cd clang-debug && cmake ${debug} ${ninja} ${no_lto} -DCMAKE_C_COMPILER=/usr/local/opt/llvm@19/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm@19/bin/clang++ .."
+            sh "cd clang-debug && ninja"
+            sh "./clang-debug/hyriseTest"
+            sh "./clang-debug/hyriseSystemTest --gtest_filter=-${tests_excluded_in_mac_builds}"
+            sh "./scripts/test/hyriseConsole_test.py clang-debug"
+            sh "./scripts/test/hyriseServer_test.py clang-debug"
+            sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-debug"
           } finally {
             sh "ls -A1 | xargs rm -rf"
           }
@@ -479,18 +479,18 @@ try {
             // Build Hyrise (Debug) with a recent clang compiler version (as recommended for Hyrise on macOS) and run
             // various tests.
             // NOTE: These paths differ from x64 - brew on ARM uses /opt (https://docs.brew.sh/Installation)
-            sh "mkdir clang-debug && cd clang-debug && cmake ${debug} ${unity} ${ninja} -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm@19/bin/clang -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm@19/bin/clang++ .."
-            sh "cd clang-debug && ninja"
+            sh "mkdir clang-release && cd clang-release && cmake ${release} ${unity} ${ninja} -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm@19/bin/clang -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm@19/bin/clang++ .."
+            sh "cd clang-release && ninja"
 
             // Check whether arm64 binaries are built to ensure that we are not accidentally running rosetta that
             // executes x86 binaries on arm.
-            sh "file ./clang-debug/hyriseTest | grep arm64"
+            sh "file ./clang-release/hyriseTest | grep arm64"
 
-            sh "./clang-debug/hyriseTest"
-            sh "./clang-debug/hyriseSystemTest --gtest_filter=-${tests_excluded_in_mac_builds}"
-            sh "./scripts/test/hyriseConsole_test.py clang-debug"
-            sh "./scripts/test/hyriseServer_test.py clang-debug"
-            sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-debug"
+            sh "./clang-release/hyriseTest"
+            sh "./clang-release/hyriseSystemTest --gtest_filter=-${tests_excluded_in_mac_builds}"
+            sh "./scripts/test/hyriseConsole_test.py clang-release"
+            sh "./scripts/test/hyriseServer_test.py clang-release"
+            sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-release"
           } finally {
             sh "ls -A1 | xargs rm -rf"
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -451,7 +451,7 @@ try {
             // Build Hyrise (Release) with a recent clang compiler version (as recommended for Hyrise on macOS) and run
             // various tests. As the release build already takes quite a while on the Intel machine, we disable LTO and
             // only build release with LTO on the ARM machine.
-            sh "mkdir clang-debug && cd clang-debug && cmake ${debug} ${ninja} ${no_lto} ${unity} -DCMAKE_C_COMPILER=/usr/local/opt/llvm@19/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm@19/bin/clang++ .."
+            sh "mkdir clang-debug && cd clang-debug && cmake ${debug} ${ninja} ${unity} -DCMAKE_C_COMPILER=/usr/local/opt/llvm@19/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm@19/bin/clang++ .."
             sh "cd clang-debug && ninja"
             sh "./clang-debug/hyriseTest"
             sh "./clang-debug/hyriseSystemTest --gtest_filter=-${tests_excluded_in_mac_builds}"
@@ -480,14 +480,14 @@ try {
             // Build hyriseTest (Release) with macOS's default compiler (Apple clang) and run it. Passing clang
             // explicitly seems to make the compiler find C system headers (required for SSB and JCC-H data generators)
             // that are not found otherwise.
-            sh "mkdir clang-apple-release && cd clang-apple-release && cmake ${release} ${ninja} -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ .."
+            sh "mkdir clang-apple-release && cd clang-apple-release && cmake ${release} ${no_lto} ${ninja} -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ .."
             sh "cd clang-apple-release && ninja"
             sh "./clang-apple-release/hyriseTest"
 
             // Build Hyrise (Debug) with a recent clang compiler version (as recommended for Hyrise on macOS) and run
             // various tests.
             // NOTE: These paths differ from x64 - brew on ARM uses /opt (https://docs.brew.sh/Installation)
-            sh "mkdir clang-release && cd clang-release && cmake ${release} ${unity} ${ninja} -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm@19/bin/clang -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm@19/bin/clang++ .."
+            sh "mkdir clang-release && cd clang-release && cmake ${release} ${unity} ${no_lto} ${ninja} -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm@19/bin/clang -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm@19/bin/clang++ .."
             sh "cd clang-release && ninja"
 
             // Check whether arm64 binaries are built to ensure that we are not accidentally running rosetta that

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,354 +62,354 @@ try {
     }
 
     // The empty '' results in using the default registry: https://index.docker.io/v1/
-    // docker.withRegistry('', 'docker') {
-    //   def hyriseCI = docker.image('hyrise/hyrise-ci:24.04');
-    //   hyriseCI.pull()
+    docker.withRegistry('', 'docker') {
+      def hyriseCI = docker.image('hyrise/hyrise-ci:24.04');
+      hyriseCI.pull()
 
-    //   // LSAN (executed as part of ASAN) requires elevated privileges. Therefore, we had to add --cap-add SYS_PTRACE.
-    //   // Even if the CI run sometimes succeeds without SYS_PTRACE, you should not remove it until you know what you are
-    //   // doing. See also: https://github.com/google/sanitizers/issues/764
-    //   hyriseCI.inside("--cap-add SYS_PTRACE -u 0:0") {
-    //     try {
-    //       stage("Setup") {
-    //         checkout scm
+      // LSAN (executed as part of ASAN) requires elevated privileges. Therefore, we had to add --cap-add SYS_PTRACE.
+      // Even if the CI run sometimes succeeds without SYS_PTRACE, you should not remove it until you know what you are
+      // doing. See also: https://github.com/google/sanitizers/issues/764
+      hyriseCI.inside("--cap-add SYS_PTRACE -u 0:0") {
+        try {
+          stage("Setup") {
+            checkout scm
 
-    //         // Check if ninja-build is installed. As make is sufficient to work with Hyrise, ninja-build is not
-    //         // installed via install_dependencies.sh but is part of the hyrise-ci docker image.
-    //         sh "ninja --version > /dev/null"
+            // Check if ninja-build is installed. As make is sufficient to work with Hyrise, ninja-build is not
+            // installed via install_dependencies.sh but is part of the hyrise-ci docker image.
+            sh "ninja --version > /dev/null"
 
-    //         // During CI runs, the user is different from the owner of the directories, which blocks the execution of
-    //         // git commands since the fix of the git vulnerability CVE-2022-24765. git commands can then only be
-    //         // executed if the corresponding directories are added as safe directories.
-    //         sh '''
-    //         git config --global --add safe.directory $WORKSPACE
-    //         # Get the paths of the submodules; for each path, add it as a git safe.directory
-    //         grep path .gitmodules | sed 's/.*=//' | xargs -n 1 -I '{}' git config --global --add safe.directory $WORKSPACE/'{}'
-    //         '''
+            // During CI runs, the user is different from the owner of the directories, which blocks the execution of
+            // git commands since the fix of the git vulnerability CVE-2022-24765. git commands can then only be
+            // executed if the corresponding directories are added as safe directories.
+            sh '''
+            git config --global --add safe.directory $WORKSPACE
+            # Get the paths of the submodules; for each path, add it as a git safe.directory
+            grep path .gitmodules | sed 's/.*=//' | xargs -n 1 -I '{}' git config --global --add safe.directory $WORKSPACE/'{}'
+            '''
 
-    //         sh "./install_dependencies.sh"
+            sh "./install_dependencies.sh"
 
-    //         cmake = 'cmake -DCI_BUILD=ON'
+            cmake = 'cmake -DCI_BUILD=ON'
 
-    //         // We do not use unity builds with clang-tidy (see below).
-    //         unity = '-DCMAKE_UNITY_BUILD=ON'
+            // We do not use unity builds with clang-tidy (see below).
+            unity = '-DCMAKE_UNITY_BUILD=ON'
 
-    //         // To speed compiling up, we use ninja for most builds.
-    //         ninja = '-GNinja'
+            // To speed compiling up, we use ninja for most builds.
+            ninja = '-GNinja'
 
-    //         // With Hyrise, we aim to support the most recent compiler versions and do not invest a lot of work to
-    //         // support older versions. We test LLVM 16 (older versions might work, but LLVM 15 has issues with libstdc++
-    //         // of GCC 14) and GCC 13.2 (oldest version supported by Hyrise). We execute at least debug runs for them. If
-    //         // you want to upgrade compiler versions, please update install_dependencies.sh, DEPENDENCIES.md, and the
-    //         // documentation (README, Wiki).
-    //         clang = '-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++'
-    //         clang16 = '-DCMAKE_C_COMPILER=clang-16 -DCMAKE_CXX_COMPILER=clang++-16'
-    //         gcc = '-DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14'
-    //         gcc13 = '-DCMAKE_C_COMPILER=gcc-13 -DCMAKE_CXX_COMPILER=g++-13'
+            // With Hyrise, we aim to support the most recent compiler versions and do not invest a lot of work to
+            // support older versions. We test LLVM 16 (older versions might work, but LLVM 15 has issues with libstdc++
+            // of GCC 14) and GCC 13.2 (oldest version supported by Hyrise). We execute at least debug runs for them. If
+            // you want to upgrade compiler versions, please update install_dependencies.sh, DEPENDENCIES.md, and the
+            // documentation (README, Wiki).
+            clang = '-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++'
+            clang16 = '-DCMAKE_C_COMPILER=clang-16 -DCMAKE_CXX_COMPILER=clang++-16'
+            gcc = '-DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14'
+            gcc13 = '-DCMAKE_C_COMPILER=gcc-13 -DCMAKE_CXX_COMPILER=g++-13'
 
-    //         debug = '-DCMAKE_BUILD_TYPE=Debug'
-    //         release = '-DCMAKE_BUILD_TYPE=Release'
-    //         relwithdebinfo = '-DCMAKE_BUILD_TYPE=RelWithDebInfo'
+            debug = '-DCMAKE_BUILD_TYPE=Debug'
+            release = '-DCMAKE_BUILD_TYPE=Release'
+            relwithdebinfo = '-DCMAKE_BUILD_TYPE=RelWithDebInfo'
 
-    //         // LTO is automatically disabled for debug and sanitizer builds. As LTO linking with GCC and gold (lld is
-    //         // not supported when using GCC and LTO) takes over an hour, we skip LTO for the GCC release build.
-    //         no_lto = '-DNO_LTO=TRUE'
+            // LTO is automatically disabled for debug and sanitizer builds. As LTO linking with GCC and gold (lld is
+            // not supported when using GCC and LTO) takes over an hour, we skip LTO for the GCC release build.
+            no_lto = '-DNO_LTO=TRUE'
 
-    //         // jemalloc's autoconf operates outside of the build folder (#1413). If we start two cmake instances at the
-    //         // same time, we run into conflicts. Thus, run this one (any one, really) first, so that the autoconf step
-    //         // can finish in peace.
-    //         sh "mkdir clang-debug && cd clang-debug &&                                                   ${cmake} ${debug}          ${clang}  ${unity} .. && make -j \$(nproc) libjemalloc-build"
+            // jemalloc's autoconf operates outside of the build folder (#1413). If we start two cmake instances at the
+            // same time, we run into conflicts. Thus, run this one (any one, really) first, so that the autoconf step
+            // can finish in peace.
+            sh "mkdir clang-debug && cd clang-debug &&                                                   ${cmake} ${debug}          ${clang}  ${unity} .. && make -j \$(nproc) libjemalloc-build"
 
-    //         // Configure the rest in parallel. We use unity builds to decrease build times. The only exception is the
-    //         // clang-tidy build as it might otherwise miss some issues (e.g., missing includes).
-    //         sh "mkdir clang-debug-tidy && cd clang-debug-tidy &&                                         ${cmake} ${debug}          ${clang}                      ${ninja} -DENABLE_CLANG_TIDY=ON .. &\
-    //         mkdir clang-debug-unity-odr && cd clang-debug-unity-odr &&                                   ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DCMAKE_UNITY_BUILD_BATCH_SIZE=0 .. &\
-    //         mkdir clang-debug-disable-precompile-headers && cd clang-debug-disable-precompile-headers && ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DCMAKE_DISABLE_PRECOMPILE_HEADERS=On .. &\
-    //         mkdir clang-debug-addr-ub-leak-sanitizers && cd clang-debug-addr-ub-leak-sanitizers &&       ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DENABLE_ADDR_UB_LEAK_SANITIZATION=ON .. &\
-    //         mkdir clang-release-addr-ub-leak-sanitizers && cd clang-release-addr-ub-leak-sanitizers &&   ${cmake} ${release}        ${clang}   ${unity}           ${ninja} -DENABLE_ADDR_UB_LEAK_SANITIZATION=ON .. &\
-    //         mkdir clang-relwithdebinfo-thread-sanitizer && cd clang-relwithdebinfo-thread-sanitizer &&   ${cmake} ${relwithdebinfo} ${clang}   ${unity}           ${ninja} -DENABLE_THREAD_SANITIZATION=ON .. &\
-    //         mkdir clang-release && cd clang-release &&                                                   ${cmake} ${release}        ${clang}   ${unity}           ${ninja} .. &\
-    //         mkdir gcc-debug && cd gcc-debug &&                                                           ${cmake} ${debug}          ${gcc}     ${unity}           ${ninja} .. &\
-    //         mkdir gcc-release && cd gcc-release &&                                                       ${cmake} ${release}        ${gcc}     ${unity} ${no_lto} ${ninja} .. &\
-    //         mkdir clang-16-debug && cd clang-16-debug &&                                                 ${cmake} ${debug}          ${clang16} ${unity}           ${ninja} .. &\
-    //         mkdir gcc-13-debug && cd gcc-13-debug &&                                                     ${cmake} ${debug}          ${gcc13}   ${unity}           ${ninja} .. &\
-    //         wait"
-    //       }
+            // Configure the rest in parallel. We use unity builds to decrease build times. The only exception is the
+            // clang-tidy build as it might otherwise miss some issues (e.g., missing includes).
+            sh "mkdir clang-debug-tidy && cd clang-debug-tidy &&                                         ${cmake} ${debug}          ${clang}                      ${ninja} -DENABLE_CLANG_TIDY=ON .. &\
+            mkdir clang-debug-unity-odr && cd clang-debug-unity-odr &&                                   ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DCMAKE_UNITY_BUILD_BATCH_SIZE=0 .. &\
+            mkdir clang-debug-disable-precompile-headers && cd clang-debug-disable-precompile-headers && ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DCMAKE_DISABLE_PRECOMPILE_HEADERS=On .. &\
+            mkdir clang-debug-addr-ub-leak-sanitizers && cd clang-debug-addr-ub-leak-sanitizers &&       ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DENABLE_ADDR_UB_LEAK_SANITIZATION=ON .. &\
+            mkdir clang-release-addr-ub-leak-sanitizers && cd clang-release-addr-ub-leak-sanitizers &&   ${cmake} ${release}        ${clang}   ${unity}           ${ninja} -DENABLE_ADDR_UB_LEAK_SANITIZATION=ON .. &\
+            mkdir clang-relwithdebinfo-thread-sanitizer && cd clang-relwithdebinfo-thread-sanitizer &&   ${cmake} ${relwithdebinfo} ${clang}   ${unity}           ${ninja} -DENABLE_THREAD_SANITIZATION=ON .. &\
+            mkdir clang-release && cd clang-release &&                                                   ${cmake} ${release}        ${clang}   ${unity}           ${ninja} .. &\
+            mkdir gcc-debug && cd gcc-debug &&                                                           ${cmake} ${debug}          ${gcc}     ${unity}           ${ninja} .. &\
+            mkdir gcc-release && cd gcc-release &&                                                       ${cmake} ${release}        ${gcc}     ${unity} ${no_lto} ${ninja} .. &\
+            mkdir clang-16-debug && cd clang-16-debug &&                                                 ${cmake} ${debug}          ${clang16} ${unity}           ${ninja} .. &\
+            mkdir gcc-13-debug && cd gcc-13-debug &&                                                     ${cmake} ${debug}          ${gcc13}   ${unity}           ${ninja} .. &\
+            wait"
+          }
 
-    //       parallel clangDebug: {
-    //         stage("clang-debug") {
-    //           // We build clang-debug using make to test make once (and clang-debug is the fastest build).
-    //           sh "cd clang-debug && make all -j \$(( \$(nproc) / 4))"
-    //           sh "./clang-debug/hyriseTest clang-debug"
-    //         }
-    //       }, clang16Debug: {
-    //         stage("clang-16-debug") {
-    //           sh "cd clang-16-debug && ninja all -j \$(( \$(nproc) / 4))"
-    //           sh "./clang-16-debug/hyriseTest clang-16-debug"
-    //         }
-    //       }, gccDebug: {
-    //         stage("gcc-debug") {
-    //           sh "cd gcc-debug && ninja all -j \$(( \$(nproc) / 4))"
-    //           sh "cd gcc-debug && ./hyriseTest"
-    //         }
-    //       }, gcc13Debug: {
-    //         stage("gcc-13-debug") {
-    //           sh "cd gcc-13-debug && ninja all -j \$(( \$(nproc) / 4))"
-    //           sh "cd gcc-13-debug && ./hyriseTest"
-    //         }
-    //       }, lint: {
-    //         stage("Linting") {
-    //           sh "scripts/lint.sh"
-    //         }
-    //       }
+          parallel clangDebug: {
+            stage("clang-debug") {
+              // We build clang-debug using make to test make once (and clang-debug is the fastest build).
+              sh "cd clang-debug && make all -j \$(( \$(nproc) / 4))"
+              sh "./clang-debug/hyriseTest clang-debug"
+            }
+          }, clang16Debug: {
+            stage("clang-16-debug") {
+              sh "cd clang-16-debug && ninja all -j \$(( \$(nproc) / 4))"
+              sh "./clang-16-debug/hyriseTest clang-16-debug"
+            }
+          }, gccDebug: {
+            stage("gcc-debug") {
+              sh "cd gcc-debug && ninja all -j \$(( \$(nproc) / 4))"
+              sh "cd gcc-debug && ./hyriseTest"
+            }
+          }, gcc13Debug: {
+            stage("gcc-13-debug") {
+              sh "cd gcc-13-debug && ninja all -j \$(( \$(nproc) / 4))"
+              sh "cd gcc-13-debug && ./hyriseTest"
+            }
+          }, lint: {
+            stage("Linting") {
+              sh "scripts/lint.sh"
+            }
+          }
 
-    //       // We distribute the cores to processes in a way to even the running times. With an even distributions,
-    //       // clang-tidy builds take up to 3h (galileo server). In addition to compile time, the distribution also
-    //       // considers the long test runtimes of clangRelWithDebInfoThreadSanitizer (~50 minutes).
-    //       parallel clangRelease: {
-    //         stage("clang-release") {
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             sh "cd clang-release && ninja all -j \$(( \$(nproc) / 10))"
-    //             sh "./clang-release/hyriseTest clang-release"
-    //             sh "./clang-release/hyriseSystemTest clang-release"
-    //             sh "./scripts/test/hyriseConsole_test.py clang-release"
-    //             sh "./scripts/test/hyriseServer_test.py clang-release"
-    //             sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-release"
-    //             sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-release"
-    //             sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
-    //             sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
+          // We distribute the cores to processes in a way to even the running times. With an even distributions,
+          // clang-tidy builds take up to 3h (galileo server). In addition to compile time, the distribution also
+          // considers the long test runtimes of clangRelWithDebInfoThreadSanitizer (~50 minutes).
+          parallel clangRelease: {
+            stage("clang-release") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "cd clang-release && ninja all -j \$(( \$(nproc) / 10))"
+                sh "./clang-release/hyriseTest clang-release"
+                sh "./clang-release/hyriseSystemTest clang-release"
+                sh "./scripts/test/hyriseConsole_test.py clang-release"
+                sh "./scripts/test/hyriseServer_test.py clang-release"
+                sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-release"
+                sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-release"
+                sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
+                sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
 
-    //           } else {
-    //             Utils.markStageSkippedForConditional("clangRelease")
-    //           }
-    //         }
-    //       }, debugSystemTests: {
-    //         stage("system-tests") {
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             sh "mkdir clang-debug-system &&  ./clang-debug/hyriseSystemTest clang-debug-system"
-    //             sh "mkdir gcc-debug-system &&  ./gcc-debug/hyriseSystemTest gcc-debug-system"
-    //             sh "./scripts/test/hyriseConsole_test.py clang-debug"
-    //             sh "./scripts/test/hyriseServer_test.py clang-debug"
-    //             sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-debug"
-    //             sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-debug"
-    //             sh "cd clang-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
-    //             sh "cd clang-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate cached data
-    //             sh "cd clang-debug && ../scripts/test/hyriseBenchmarkStarSchema_test.py ." // Own folder to isolate cached data
-    //             sh "./scripts/test/hyriseConsole_test.py gcc-debug"
-    //             sh "./scripts/test/hyriseServer_test.py gcc-debug"
-    //             sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-debug"
-    //             sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-debug"
-    //             sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
-    //             sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate cached data
-    //             sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkStarSchema_test.py ." // Own folder to isolate cached data
+              } else {
+                Utils.markStageSkippedForConditional("clangRelease")
+              }
+            }
+          }, debugSystemTests: {
+            stage("system-tests") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "mkdir clang-debug-system &&  ./clang-debug/hyriseSystemTest clang-debug-system"
+                sh "mkdir gcc-debug-system &&  ./gcc-debug/hyriseSystemTest gcc-debug-system"
+                sh "./scripts/test/hyriseConsole_test.py clang-debug"
+                sh "./scripts/test/hyriseServer_test.py clang-debug"
+                sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-debug"
+                sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-debug"
+                sh "cd clang-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
+                sh "cd clang-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate cached data
+                sh "cd clang-debug && ../scripts/test/hyriseBenchmarkStarSchema_test.py ." // Own folder to isolate cached data
+                sh "./scripts/test/hyriseConsole_test.py gcc-debug"
+                sh "./scripts/test/hyriseServer_test.py gcc-debug"
+                sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-debug"
+                sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-debug"
+                sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
+                sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate cached data
+                sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkStarSchema_test.py ." // Own folder to isolate cached data
 
-    //           } else {
-    //             Utils.markStageSkippedForConditional("debugSystemTests")
-    //           }
-    //         }
-    //       }, clangDebugRunShuffled: {
-    //         stage("clang-debug:test-shuffle") {
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             sh "mkdir ./clang-debug/run-shuffled"
-    //             sh "./clang-debug/hyriseTest clang-debug/run-shuffled --gtest_repeat=5 --gtest_shuffle"
-    //             // We do not want to trigger SSB data generation concurrently since it is not concurrency-safe.
-    //             sh "./clang-debug/hyriseSystemTest clang-debug/run-shuffled --gtest_repeat=2 --gtest_shuffle --gtest_filter=\"-SSBTableGeneratorTest.*:SQLiteTestRunnerEncodings/*\""
-    //           } else {
-    //             Utils.markStageSkippedForConditional("clangDebugRunShuffled")
-    //           }
-    //         }
-    //       }, clangDebugUnityODR: {
-    //         stage("clang-debug-unity-odr") {
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             // Check if unity builds work even if everything is batched into a single compilation unit. This helps prevent ODR (one definition rule) issues.
-    //             sh "cd clang-debug-unity-odr && ninja all -j 2"
-    //           } else {
-    //             Utils.markStageSkippedForConditional("clangDebugUnityODR")
-    //           }
-    //         }
-    //       }, clangDebugTidy: {
-    //         stage("clang-debug:tidy") {
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             // We do not run tidy checks on the src/test folder, so there is no point in running the expensive clang-tidy for those files
-    //             sh "cd clang-debug-tidy && ninja hyrise_impl hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer hyriseMvccDeletePlugin hyriseUccDiscoveryPlugin -k 0 -j \$(( \$(nproc) / 5))"
-    //           } else {
-    //             Utils.markStageSkippedForConditional("clangDebugTidy")
-    //           }
-    //         }
-    //       }, clangDebugDisablePrecompileHeaders: {
-    //         stage("clang-debug:disable-precompile-headers") {
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             // Check if builds work even when precompile headers is turned off. Executing the binaries is unnecessary as the observed errors are missing includes.
-    //             sh "cd clang-debug-disable-precompile-headers && ninja hyriseTest hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer -k 0 -j 2"
-    //           } else {
-    //             Utils.markStageSkippedForConditional("clangDebugDisablePrecompileHeaders")
-    //           }
-    //         }
-    //       }, clangDebugAddrUBLeakSanitizers: {
-    //         stage("clang-debug:addr-ub-sanitizers") {
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             sh "cd clang-debug-addr-ub-leak-sanitizers && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 10))"
-    //             sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseTest clang-debug-addr-ub-leak-sanitizers"
-    //             sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-debug-addr-ub-leak-sanitizers"
-    //             sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 1"
-    //           } else {
-    //             Utils.markStageSkippedForConditional("clangDebugAddrUBLeakSanitizers")
-    //           }
-    //         }
-    //       }, gccRelease: {
-    //         if (env.BRANCH_NAME == 'master' || full_ci) {
-    //           stage("gcc-release") {
-    //             sh "cd gcc-release && ninja all -j \$(( \$(nproc) / 10))"
-    //             sh "./gcc-release/hyriseTest gcc-release"
-    //             sh "./gcc-release/hyriseSystemTest gcc-release"
-    //             sh "./scripts/test/hyriseConsole_test.py gcc-release"
-    //             sh "./scripts/test/hyriseServer_test.py gcc-release"
-    //             sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-release"
-    //             sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-release"
-    //             sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
-    //             sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
-    //           }
-    //         } else {
-    //             Utils.markStageSkippedForConditional("gccRelease")
-    //         }
-    //       }, clangReleaseAddrUBLeakSanitizers: {
-    //         stage("clang-release:addr-ub-sanitizers") {
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             sh "cd clang-release-addr-ub-leak-sanitizers && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 5))"
-    //             sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseTest clang-release-addr-ub-leak-sanitizers"
-    //             sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-release-addr-ub-leak-sanitizers"
-    //             sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
-    //             sh "cd clang-release-addr-ub-leak-sanitizers && LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
-    //           } else {
-    //             Utils.markStageSkippedForConditional("clangReleaseAddrUBLeakSanitizers")
-    //           }
-    //         }
-    //       }, clangRelWithDebInfoThreadSanitizer: {
-    //         stage("clang-relwithdebinfo:thread-sanitizer") {
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             sh "cd clang-relwithdebinfo-thread-sanitizer && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC hyriseBenchmarkTPCDS -j \$(( \$(nproc) / 5))"
-    //             sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseTest clang-relwithdebinfo-thread-sanitizer"
-    //             sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-relwithdebinfo-thread-sanitizer"
-    //             sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCH -s .01 -r 100 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
-    //             sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCC -s 1 --time 120 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
-    //             sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCDS -s 1 -r 5 --scheduler --clients 5 --cores \$(( \$(nproc) / 10))"
-    //           } else {
-    //             Utils.markStageSkippedForConditional("clangRelWithDebInfoThreadSanitizer")
-    //           }
-    //         }
-    //       }, clangDebugCoverage: {
-    //         stage("clang-debug-coverage") {
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             sh "./scripts/coverage.sh --generate_badge=true"
-    //             sh "find coverage -type d -exec chmod +rx {} \\;"
-    //             archive 'coverage_badge.svg'
-    //             archive 'coverage_percent.txt'
-    //             publishHTML (target: [
-    //               allowMissing: false,
-    //               alwaysLinkToLastBuild: false,
-    //               keepAll: true,
-    //               reportDir: 'coverage',
-    //               reportFiles: 'index.html',
-    //               reportName: "Llvm-cov_Report"
-    //             ])
-    //             script {
-    //               coverageChange = sh script: "./scripts/compare_coverage.sh", returnStdout: true
-    //               githubNotify context: 'Coverage', description: "$coverageChange", status: 'SUCCESS', targetUrl: "${env.BUILD_URL}/RCov_20Report/index.html"
-    //             }
-    //           } else {
-    //             Utils.markStageSkippedForConditional("clangDebugCoverage")
-    //           }
-    //         }
-    //       }
+              } else {
+                Utils.markStageSkippedForConditional("debugSystemTests")
+              }
+            }
+          }, clangDebugRunShuffled: {
+            stage("clang-debug:test-shuffle") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "mkdir ./clang-debug/run-shuffled"
+                sh "./clang-debug/hyriseTest clang-debug/run-shuffled --gtest_repeat=5 --gtest_shuffle"
+                // We do not want to trigger SSB data generation concurrently since it is not concurrency-safe.
+                sh "./clang-debug/hyriseSystemTest clang-debug/run-shuffled --gtest_repeat=2 --gtest_shuffle --gtest_filter=\"-SSBTableGeneratorTest.*:SQLiteTestRunnerEncodings/*\""
+              } else {
+                Utils.markStageSkippedForConditional("clangDebugRunShuffled")
+              }
+            }
+          }, clangDebugUnityODR: {
+            stage("clang-debug-unity-odr") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                // Check if unity builds work even if everything is batched into a single compilation unit. This helps prevent ODR (one definition rule) issues.
+                sh "cd clang-debug-unity-odr && ninja all -j 2"
+              } else {
+                Utils.markStageSkippedForConditional("clangDebugUnityODR")
+              }
+            }
+          }, clangDebugTidy: {
+            stage("clang-debug:tidy") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                // We do not run tidy checks on the src/test folder, so there is no point in running the expensive clang-tidy for those files
+                sh "cd clang-debug-tidy && ninja hyrise_impl hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer hyriseMvccDeletePlugin hyriseUccDiscoveryPlugin -k 0 -j \$(( \$(nproc) / 5))"
+              } else {
+                Utils.markStageSkippedForConditional("clangDebugTidy")
+              }
+            }
+          }, clangDebugDisablePrecompileHeaders: {
+            stage("clang-debug:disable-precompile-headers") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                // Check if builds work even when precompile headers is turned off. Executing the binaries is unnecessary as the observed errors are missing includes.
+                sh "cd clang-debug-disable-precompile-headers && ninja hyriseTest hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer -k 0 -j 2"
+              } else {
+                Utils.markStageSkippedForConditional("clangDebugDisablePrecompileHeaders")
+              }
+            }
+          }, clangDebugAddrUBLeakSanitizers: {
+            stage("clang-debug:addr-ub-sanitizers") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "cd clang-debug-addr-ub-leak-sanitizers && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 10))"
+                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseTest clang-debug-addr-ub-leak-sanitizers"
+                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-debug-addr-ub-leak-sanitizers"
+                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 1"
+              } else {
+                Utils.markStageSkippedForConditional("clangDebugAddrUBLeakSanitizers")
+              }
+            }
+          }, gccRelease: {
+            if (env.BRANCH_NAME == 'master' || full_ci) {
+              stage("gcc-release") {
+                sh "cd gcc-release && ninja all -j \$(( \$(nproc) / 10))"
+                sh "./gcc-release/hyriseTest gcc-release"
+                sh "./gcc-release/hyriseSystemTest gcc-release"
+                sh "./scripts/test/hyriseConsole_test.py gcc-release"
+                sh "./scripts/test/hyriseServer_test.py gcc-release"
+                sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-release"
+                sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-release"
+                sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
+                sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
+              }
+            } else {
+                Utils.markStageSkippedForConditional("gccRelease")
+            }
+          }, clangReleaseAddrUBLeakSanitizers: {
+            stage("clang-release:addr-ub-sanitizers") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "cd clang-release-addr-ub-leak-sanitizers && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 5))"
+                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseTest clang-release-addr-ub-leak-sanitizers"
+                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-release-addr-ub-leak-sanitizers"
+                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-release-addr-ub-leak-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
+                sh "cd clang-release-addr-ub-leak-sanitizers && LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
+              } else {
+                Utils.markStageSkippedForConditional("clangReleaseAddrUBLeakSanitizers")
+              }
+            }
+          }, clangRelWithDebInfoThreadSanitizer: {
+            stage("clang-relwithdebinfo:thread-sanitizer") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "cd clang-relwithdebinfo-thread-sanitizer && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC hyriseBenchmarkTPCDS -j \$(( \$(nproc) / 5))"
+                sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseTest clang-relwithdebinfo-thread-sanitizer"
+                sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-relwithdebinfo-thread-sanitizer"
+                sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCH -s .01 -r 100 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
+                sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCC -s 1 --time 120 --scheduler --clients 10 --cores \$(( \$(nproc) / 10))"
+                sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCDS -s 1 -r 5 --scheduler --clients 5 --cores \$(( \$(nproc) / 10))"
+              } else {
+                Utils.markStageSkippedForConditional("clangRelWithDebInfoThreadSanitizer")
+              }
+            }
+          }, clangDebugCoverage: {
+            stage("clang-debug-coverage") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "./scripts/coverage.sh --generate_badge=true"
+                sh "find coverage -type d -exec chmod +rx {} \\;"
+                archive 'coverage_badge.svg'
+                archive 'coverage_percent.txt'
+                publishHTML (target: [
+                  allowMissing: false,
+                  alwaysLinkToLastBuild: false,
+                  keepAll: true,
+                  reportDir: 'coverage',
+                  reportFiles: 'index.html',
+                  reportName: "Llvm-cov_Report"
+                ])
+                script {
+                  coverageChange = sh script: "./scripts/compare_coverage.sh", returnStdout: true
+                  githubNotify context: 'Coverage', description: "$coverageChange", status: 'SUCCESS', targetUrl: "${env.BUILD_URL}/RCov_20Report/index.html"
+                }
+              } else {
+                Utils.markStageSkippedForConditional("clangDebugCoverage")
+              }
+            }
+          }
 
-    //       parallel memcheckReleaseTest: {
-    //         stage("memcheckReleaseTest") {
-    //           // Runs after the other sanitizers as it depends on clang-release to be built.
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             sh "mkdir ./clang-release-memcheck-test"
-    //             // If this shows a leak, try --leak-check=full, which is slower but more precise. Valgrind serializes
-    //             // concurrent threads into a single one. Thus, we limit the cores and data preparation cores for the
-    //             // benchmark runs to reduce this serialization overhead. According to the Valgrind documentation,
-    //             // --fair-sched=yes "improves overall responsiveness if you are running an interactive multithreaded
-    //             // program" and "produces better reproducibility of thread scheduling for different executions of a
-    //             // multithreaded application" (i.e., there are no runs that are randomly faster or slower).
-    //             sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseTest clang-release-memcheck-test --gtest_filter=-NUMAMemoryResourceTest.BasicAllocate:SQLiteTestRunner*"
-    //             sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCH -s .01 -r 1 --scheduler --cores 4 --data_preparation_cores 4"
-    //             sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCDS -s 1 -r 1 --scheduler --cores 4 --data_preparation_cores 4"
-    //             sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCC -s 1 --scheduler --cores 4 --data_preparation_cores 4"
-    //           } else {
-    //             Utils.markStageSkippedForConditional("memcheckReleaseTest")
-    //           }
-    //         }
-    //       }, tpchVerification: {
-    //         stage("tpchVerification") {
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             // Verify both single- and multithreaded results.
-    //             sh "./clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 1 -s 1 --verify"
-    //             sh "./clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 1 -s 1 --verify --scheduler --clients 1 --cores 10"
-    //           } else {
-    //             Utils.markStageSkippedForConditional("tpchVerification")
-    //           }
-    //         }
-    //       }, tpchQueryPlans: {
-    //         stage("tpchQueryPlans") {
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             sh "mkdir -p query_plans/tpch; cd query_plans/tpch && ../../clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 2 -s 10 --visualize && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
-    //             archiveArtifacts artifacts: 'query_plans/tpch/*.svg'
-    //             archiveArtifacts artifacts: 'query_plans/tpch/operator_breakdown.pdf'
-    //           } else {
-    //             Utils.markStageSkippedForConditional("tpchQueryPlans")
-    //           }
-    //         }
-    //       }, tpcdsQueryPlansAndVerification: {
-    //         stage("tpcdsQueryPlansAndVerification") {
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             sh "mkdir -p query_plans/tpcds; cd query_plans/tpcds && ln -s ../../resources; ../../clang-release/hyriseBenchmarkTPCDS --dont_cache_binary_tables -r 1 -s 1 --visualize --verify && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
-    //             archiveArtifacts artifacts: 'query_plans/tpcds/*.svg'
-    //             archiveArtifacts artifacts: 'query_plans/tpcds/operator_breakdown.pdf'
-    //           } else {
-    //             Utils.markStageSkippedForConditional("tpcdsQueryPlansAndVerification")
-    //           }
-    //         }
-    //       }, jobQueryPlans: {
-    //         stage("jobQueryPlans") {
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             // In contrast to TPC-H and TPC-DS above, we execute the JoinOrderBenchmark from the project's root directoy because its setup script requires us to do so.
-    //             sh "mkdir -p query_plans/job && ./clang-release/hyriseBenchmarkJoinOrder --dont_cache_binary_tables -r 1 --visualize && ./scripts/plot_operator_breakdown.py ./clang-release/ && mv operator_breakdown.pdf query_plans/job && mv *QP.svg query_plans/job"
-    //             archiveArtifacts artifacts: 'query_plans/job/*.svg'
-    //             archiveArtifacts artifacts: 'query_plans/job/operator_breakdown.pdf'
-    //           } else {
-    //             Utils.markStageSkippedForConditional("jobQueryPlans")
-    //           }
-    //         }
-    //       }, ssbQueryPlans: {
-    //         stage("ssbQueryPlans") {
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             sh "mkdir -p query_plans/ssb; cd query_plans/ssb && ../../clang-release/hyriseBenchmarkStarSchema --dont_cache_binary_tables -r 1 -s 1 --visualize && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
-    //             archiveArtifacts artifacts: 'query_plans/ssb/*.svg'
-    //             archiveArtifacts artifacts: 'query_plans/ssb/operator_breakdown.pdf'
-    //           } else {
-    //             Utils.markStageSkippedForConditional("ssbQueryPlans")
-    //           }
-    //         }
-    //       }, nixSetup: {
-    //         stage('nixSetup') {
-    //           if (env.BRANCH_NAME == 'master' || full_ci) {
-    //             sh "curl -L https://nixos.org/nix/install > nix-install.sh && chmod +x nix-install.sh && ./nix-install.sh --daemon --yes"
-    //             sh "/nix/var/nix/profiles/default/bin/nix-shell resources/nix --pure --run \"mkdir nix-debug && cd nix-debug && cmake ${debug} ${clang} ${unity} ${ninja} .. && ninja all -j \$(( \$(nproc) / 7)) && ./hyriseTest\""
-    //             // We allocate a third of all cores for the release build as several parallel stages should have already finished at this point.
-    //             sh "/nix/var/nix/profiles/default/bin/nix-shell resources/nix --pure --run \"mkdir nix-release && cd nix-release && cmake ${release} ${clang} ${unity} ${ninja} .. && ninja all -j \$(( \$(nproc) / 3)) && ./hyriseTest\""
-    //           } else {
-    //             Utils.markStageSkippedForConditional("nixSetup")
-    //           }
-    //         }
-    //       }
-    //     } finally {
-    //       sh "ls -A1 | xargs rm -rf"
-    //       deleteDir()
-    //     }
-    //   }
-    // }
+          parallel memcheckReleaseTest: {
+            stage("memcheckReleaseTest") {
+              // Runs after the other sanitizers as it depends on clang-release to be built.
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "mkdir ./clang-release-memcheck-test"
+                // If this shows a leak, try --leak-check=full, which is slower but more precise. Valgrind serializes
+                // concurrent threads into a single one. Thus, we limit the cores and data preparation cores for the
+                // benchmark runs to reduce this serialization overhead. According to the Valgrind documentation,
+                // --fair-sched=yes "improves overall responsiveness if you are running an interactive multithreaded
+                // program" and "produces better reproducibility of thread scheduling for different executions of a
+                // multithreaded application" (i.e., there are no runs that are randomly faster or slower).
+                sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseTest clang-release-memcheck-test --gtest_filter=-NUMAMemoryResourceTest.BasicAllocate:SQLiteTestRunner*"
+                sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCH -s .01 -r 1 --scheduler --cores 4 --data_preparation_cores 4"
+                sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCDS -s 1 -r 1 --scheduler --cores 4 --data_preparation_cores 4"
+                sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCC -s 1 --scheduler --cores 4 --data_preparation_cores 4"
+              } else {
+                Utils.markStageSkippedForConditional("memcheckReleaseTest")
+              }
+            }
+          }, tpchVerification: {
+            stage("tpchVerification") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                // Verify both single- and multithreaded results.
+                sh "./clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 1 -s 1 --verify"
+                sh "./clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 1 -s 1 --verify --scheduler --clients 1 --cores 10"
+              } else {
+                Utils.markStageSkippedForConditional("tpchVerification")
+              }
+            }
+          }, tpchQueryPlans: {
+            stage("tpchQueryPlans") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "mkdir -p query_plans/tpch; cd query_plans/tpch && ../../clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 2 -s 10 --visualize && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
+                archiveArtifacts artifacts: 'query_plans/tpch/*.svg'
+                archiveArtifacts artifacts: 'query_plans/tpch/operator_breakdown.pdf'
+              } else {
+                Utils.markStageSkippedForConditional("tpchQueryPlans")
+              }
+            }
+          }, tpcdsQueryPlansAndVerification: {
+            stage("tpcdsQueryPlansAndVerification") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "mkdir -p query_plans/tpcds; cd query_plans/tpcds && ln -s ../../resources; ../../clang-release/hyriseBenchmarkTPCDS --dont_cache_binary_tables -r 1 -s 1 --visualize --verify && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
+                archiveArtifacts artifacts: 'query_plans/tpcds/*.svg'
+                archiveArtifacts artifacts: 'query_plans/tpcds/operator_breakdown.pdf'
+              } else {
+                Utils.markStageSkippedForConditional("tpcdsQueryPlansAndVerification")
+              }
+            }
+          }, jobQueryPlans: {
+            stage("jobQueryPlans") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                // In contrast to TPC-H and TPC-DS above, we execute the JoinOrderBenchmark from the project's root directoy because its setup script requires us to do so.
+                sh "mkdir -p query_plans/job && ./clang-release/hyriseBenchmarkJoinOrder --dont_cache_binary_tables -r 1 --visualize && ./scripts/plot_operator_breakdown.py ./clang-release/ && mv operator_breakdown.pdf query_plans/job && mv *QP.svg query_plans/job"
+                archiveArtifacts artifacts: 'query_plans/job/*.svg'
+                archiveArtifacts artifacts: 'query_plans/job/operator_breakdown.pdf'
+              } else {
+                Utils.markStageSkippedForConditional("jobQueryPlans")
+              }
+            }
+          }, ssbQueryPlans: {
+            stage("ssbQueryPlans") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "mkdir -p query_plans/ssb; cd query_plans/ssb && ../../clang-release/hyriseBenchmarkStarSchema --dont_cache_binary_tables -r 1 -s 1 --visualize && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
+                archiveArtifacts artifacts: 'query_plans/ssb/*.svg'
+                archiveArtifacts artifacts: 'query_plans/ssb/operator_breakdown.pdf'
+              } else {
+                Utils.markStageSkippedForConditional("ssbQueryPlans")
+              }
+            }
+          }, nixSetup: {
+            stage('nixSetup') {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "curl -L https://nixos.org/nix/install > nix-install.sh && chmod +x nix-install.sh && ./nix-install.sh --daemon --yes"
+                sh "/nix/var/nix/profiles/default/bin/nix-shell resources/nix --pure --run \"mkdir nix-debug && cd nix-debug && cmake ${debug} ${clang} ${unity} ${ninja} .. && ninja all -j \$(( \$(nproc) / 7)) && ./hyriseTest\""
+                // We allocate a third of all cores for the release build as several parallel stages should have already finished at this point.
+                sh "/nix/var/nix/profiles/default/bin/nix-shell resources/nix --pure --run \"mkdir nix-release && cd nix-release && cmake ${release} ${clang} ${unity} ${ninja} .. && ninja all -j \$(( \$(nproc) / 3)) && ./hyriseTest\""
+              } else {
+                Utils.markStageSkippedForConditional("nixSetup")
+              }
+            }
+          }
+        } finally {
+          sh "ls -A1 | xargs rm -rf"
+          deleteDir()
+        }
+      }
+    }
   }
 
   parallel clangMacX64: {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -222,7 +222,7 @@ try {
             stage("clang-debug-unity-odr") {
               if (env.BRANCH_NAME == 'master' || full_ci) {
                 // Check if unity builds work even if everything is batched into a single compilation unit. This helps prevent ODR (one definition rule) issues.
-                sh "cd clang-debug-unity-odr && ninja all"
+                sh "cd clang-debug-unity-odr && ninja all -j 2"
               } else {
                 Utils.markStageSkippedForConditional("clangDebugUnityODR")
               }
@@ -240,7 +240,7 @@ try {
             stage("clang-debug:disable-precompile-headers") {
               if (env.BRANCH_NAME == 'master' || full_ci) {
                 // Check if builds work even when precompile headers is turned off. Executing the binaries is unnecessary as the observed errors are missing includes.
-                sh "cd clang-debug-disable-precompile-headers && ninja hyriseTest hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer -k 0"
+                sh "cd clang-debug-disable-precompile-headers && ninja hyriseTest hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer -k 0 -j 2"
               } else {
                 Utils.markStageSkippedForConditional("clangDebugDisablePrecompileHeaders")
               }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 full_ci = env.BRANCH_NAME == 'master' || pullRequest.labels.contains('FullCI')
 
 // Due to their long runtime, we skip several tests in sanitizer and MacOS builds.
-tests_excluded_in_sanitizer_builds = 'SQLiteTestRunnerEncodings/*:TPCDSTableGeneratorTest.GenerateAndStoreRowCounts:TPCHTableGeneratorTest.RowCountsMediumScaleFactor:SSBTableGeneratorTest.GenerateAndStoreRowCounts'
+tests_excluded_in_sanitizer_builds = 'SQLiteTestRunnerEncodings/*:TPCDSTableGeneratorTest.GenerateAndStoreRowCountsAndTableConstraints:TPCHTableGeneratorTest.RowCountsMediumScaleFactor:SSBTableGeneratorTest.GenerateAndStoreRowCounts'
 
 tests_excluded_in_mac_builds = 'TPCCTest*:TPCDSTableGeneratorTest.*:TPCHTableGeneratorTest.RowCountsMediumScaleFactor:SSBTableGeneratorTest.GenerateAndStoreRowCounts'
 
@@ -213,7 +213,7 @@ try {
                 sh "mkdir ./clang-debug/run-shuffled"
                 sh "./clang-debug/hyriseTest clang-debug/run-shuffled --gtest_repeat=5 --gtest_shuffle"
                 // We do not want to trigger SSB data generation concurrently since it is not concurrency-safe.
-                sh "./clang-debug/hyriseSystemTest clang-debug/run-shuffled --gtest_repeat=2 --gtest_shuffle --gtest_filter=\"-SSBTableGeneratorTest.*\""
+                sh "./clang-debug/hyriseSystemTest clang-debug/run-shuffled --gtest_repeat=2 --gtest_shuffle --gtest_filter=\"-SSBTableGeneratorTest.*:SQLiteTestRunnerEncodings/*\""
               } else {
                 Utils.markStageSkippedForConditional("clangDebugRunShuffled")
               }
@@ -222,7 +222,7 @@ try {
             stage("clang-debug-unity-odr") {
               if (env.BRANCH_NAME == 'master' || full_ci) {
                 // Check if unity builds work even if everything is batched into a single compilation unit. This helps prevent ODR (one definition rule) issues.
-                sh "cd clang-debug-unity-odr && ninja all -j \$(( \$(nproc) / 20))"
+                sh "cd clang-debug-unity-odr && ninja all"
               } else {
                 Utils.markStageSkippedForConditional("clangDebugUnityODR")
               }
@@ -240,7 +240,7 @@ try {
             stage("clang-debug:disable-precompile-headers") {
               if (env.BRANCH_NAME == 'master' || full_ci) {
                 // Check if builds work even when precompile headers is turned off. Executing the binaries is unnecessary as the observed errors are missing includes.
-                sh "cd clang-debug-disable-precompile-headers && ninja hyriseTest hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer -k 0 -j \$(( \$(nproc) / 20))"
+                sh "cd clang-debug-disable-precompile-headers && ninja hyriseTest hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer -k 0"
               } else {
                 Utils.markStageSkippedForConditional("clangDebugDisablePrecompileHeaders")
               }
@@ -248,7 +248,7 @@ try {
           }, clangDebugAddrUBLeakSanitizers: {
             stage("clang-debug:addr-ub-sanitizers") {
               if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "cd clang-debug-addr-ub-leak-sanitizers && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 20))"
+                sh "cd clang-debug-addr-ub-leak-sanitizers && ninja hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 10))"
                 sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseTest clang-debug-addr-ub-leak-sanitizers"
                 sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseSystemTest --gtest_filter=-${tests_excluded_in_sanitizer_builds} clang-debug-addr-ub-leak-sanitizers"
                 sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=\${asan_options} ./clang-debug-addr-ub-leak-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 1"
@@ -333,7 +333,7 @@ try {
                 // --fair-sched=yes "improves overall responsiveness if you are running an interactive multithreaded
                 // program" and "produces better reproducibility of thread scheduling for different executions of a
                 // multithreaded application" (i.e., there are no runs that are randomly faster or slower).
-                sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseTest clang-release-memcheck-test --gtest_filter=-NUMAMemoryResourceTest.BasicAllocate"
+                sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseTest clang-release-memcheck-test --gtest_filter=-NUMAMemoryResourceTest.BasicAllocate:SQLiteTestRunner*"
                 sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCH -s .01 -r 1 --scheduler --cores 4 --data_preparation_cores 4"
                 sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCDS -s 1 -r 1 --scheduler --cores 4 --data_preparation_cores 4"
                 sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --fair-sched=yes --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCC -s 1 --scheduler --cores 4 --data_preparation_cores 4"

--- a/src/test/benchmarklib/tpcds/tpcds_table_generator_test.cpp
+++ b/src/test/benchmarklib/tpcds/tpcds_table_generator_test.cpp
@@ -74,17 +74,14 @@ TEST_F(TPCDSTableGeneratorTest, GenerateAndStoreRowCountsAndTableConstraints) {
   TPCDSTableGenerator{1, Chunk::DEFAULT_SIZE, 0}.generate_and_store();
 
   /**
-   * Check whether all TPC-DS tables are created by the TPCDSTableGenerator and added to the StorageManager. Then,
-   * check whether the count is correct for all tables.
+   * Check that
+   *    (i) all TPC-DS tables are created by the TPCDSTableGenerator and added to the StorageManager,
+   *   (ii) their row counts are as expected, and
+   *  (iii) they have one primary key and the expected number of foreign keys.
    */
-  // <row count, number of foreign keys>
-  using TableSpec = std::tuple<uint64_t, uint32_t>;
+  using TableSpec = std::tuple<uint64_t, uint32_t>;  // <row count, number of foreign keys>
   const auto expected_table_info = std::map<std::string, TableSpec>{{"call_center", {6, 2}},
-                                                                    {"catalog_page",
-                                                                     {
-                                                                         11718,
-                                                                         2,
-                                                                     }},
+                                                                    {"catalog_page", {11718, 2}},
                                                                     {"catalog_returns", {144201, 17}},
                                                                     {"catalog_sales", {1440060, 17}},
                                                                     {"customer", {100000, 6}},

--- a/src/test/benchmarklib/tpcds/tpcds_table_generator_test.cpp
+++ b/src/test/benchmarklib/tpcds/tpcds_table_generator_test.cpp
@@ -69,149 +69,56 @@ TEST_F(TPCDSTableGeneratorTest, TableContentsFirstRows) {
   }
 }
 
-TEST_F(TPCDSTableGeneratorTest, GenerateAndStoreRowCounts) {
-  /**
-   * Check whether all TPC-DS tables are created by the TPCDSTableGenerator and added to the StorageManager. Then,
-   * check whether the row count is correct for all tables.
-   */
-
-  const auto expected_sizes = std::map<std::string, uint64_t>{{"call_center", 6},
-                                                              {"catalog_page", 11718},
-                                                              {"catalog_returns", 144201},
-                                                              {"catalog_sales", 1440060},
-                                                              {"customer", 100000},
-                                                              {"customer_address", 50000},
-                                                              {"customer_demographics", 1920800},
-                                                              {"date_dim", 73049},
-                                                              {"household_demographics", 7200},
-                                                              {"income_band", 20},
-                                                              {"inventory", 11745000},
-                                                              {"item", 18000},
-                                                              {"promotion", 300},
-                                                              {"reason", 35},
-                                                              {"ship_mode", 20},
-                                                              {"store", 12},
-                                                              {"store_returns", 288324},
-                                                              {"store_sales", 2879434},
-                                                              {"time_dim", 86400},
-                                                              {"warehouse", 5},
-                                                              {"web_page", 60},
-                                                              {"web_returns", 71746},
-                                                              {"web_sales", 719620},
-                                                              {"web_site", 30}};
-
+TEST_F(TPCDSTableGeneratorTest, GenerateAndStoreRowCountsAndTableConstraints) {
   EXPECT_EQ(Hyrise::get().storage_manager.tables().size(), 0);
-
-  TPCDSTableGenerator(1, Chunk::DEFAULT_SIZE, 0).generate_and_store();
-
-  for (const auto& [name, size] : expected_sizes) {
-    SCOPED_TRACE("checking table " + name);
-    EXPECT_EQ(Hyrise::get().storage_manager.get_table(name)->row_count(), size);
-  }
-}
-
-TEST_F(TPCDSTableGeneratorTest, TableConstraints) {
-  // We do not check the constraints in detail, just verify each table has a PK and the number of FKs as defined in the
-  // specification.
   TPCDSTableGenerator{1, Chunk::DEFAULT_SIZE, 0}.generate_and_store();
 
-  const auto& store_sales_table = Hyrise::get().storage_manager.get_table("store_sales");
-  const auto& store_returns_table = Hyrise::get().storage_manager.get_table("store_returns");
-  const auto& catalog_sales_table = Hyrise::get().storage_manager.get_table("catalog_sales");
-  const auto& catalog_returns_table = Hyrise::get().storage_manager.get_table("catalog_returns");
-  const auto& web_sales_table = Hyrise::get().storage_manager.get_table("web_sales");
-  const auto& web_returns_table = Hyrise::get().storage_manager.get_table("web_returns");
-  const auto& inventory_table = Hyrise::get().storage_manager.get_table("inventory");
+  /**
+   * Check whether all TPC-DS tables are created by the TPCDSTableGenerator and added to the StorageManager. Then,
+   * check whether the count is correct for all tables.
+   */
+  // <row count, number of foreign keys>
+  using TableSpec = std::tuple<uint64_t, uint32_t>;
+  const auto expected_table_info = std::map<std::string, TableSpec>{{"call_center", {6, 2}},
+                                                                    {"catalog_page",
+                                                                     {
+                                                                         11718,
+                                                                         2,
+                                                                     }},
+                                                                    {"catalog_returns", {144201, 17}},
+                                                                    {"catalog_sales", {1440060, 17}},
+                                                                    {"customer", {100000, 6}},
+                                                                    {"customer_address", {50000, 0}},
+                                                                    {"customer_demographics", {1920800, 0}},
+                                                                    {"date_dim", {73049, 0}},
+                                                                    {"household_demographics", {7200, 1}},
+                                                                    {"income_band", {20, 0}},
+                                                                    {"inventory", {11745000, 3}},
+                                                                    {"item", {18000, 0}},
+                                                                    {"promotion", {300, 3}},
+                                                                    {"reason", {35, 0}},
+                                                                    {"ship_mode", {20, 0}},
+                                                                    {"store", {12, 1}},
+                                                                    {"store_returns", {288324, 10}},
+                                                                    {"store_sales", {2879434, 9}},
+                                                                    {"time_dim", {86400, 0}},
+                                                                    {"warehouse", {5, 0}},
+                                                                    {"web_page", {60, 3}},
+                                                                    {"web_returns", {71746, 14}},
+                                                                    {"web_sales", {719620, 17}},
+                                                                    {"web_site", {30, 2}}};
 
-  const auto& store_table = Hyrise::get().storage_manager.get_table("store");
-  const auto& call_center_table = Hyrise::get().storage_manager.get_table("call_center");
-  const auto& catalog_page_table = Hyrise::get().storage_manager.get_table("catalog_page");
-  const auto& web_site_table = Hyrise::get().storage_manager.get_table("web_site");
-  const auto& web_page_table = Hyrise::get().storage_manager.get_table("web_page");
-  const auto& warehouse_table = Hyrise::get().storage_manager.get_table("warehouse");
-  const auto& customer_table = Hyrise::get().storage_manager.get_table("customer");
-  const auto& customer_address_table = Hyrise::get().storage_manager.get_table("customer_address");
-  const auto& customer_demographics_table = Hyrise::get().storage_manager.get_table("customer_demographics");
-  const auto& date_dim_table = Hyrise::get().storage_manager.get_table("date_dim");
-  const auto& household_demographics_table = Hyrise::get().storage_manager.get_table("household_demographics");
-  const auto& item_table = Hyrise::get().storage_manager.get_table("item");
-  const auto& income_band_table = Hyrise::get().storage_manager.get_table("income_band");
-  const auto& promotion_table = Hyrise::get().storage_manager.get_table("promotion");
-  const auto& reason_table = Hyrise::get().storage_manager.get_table("reason");
-  const auto& ship_mode_table = Hyrise::get().storage_manager.get_table("ship_mode");
-  const auto& time_dim_table = Hyrise::get().storage_manager.get_table("time_dim");
+  EXPECT_EQ(Hyrise::get().storage_manager.tables().size(), expected_table_info.size());
+  for (const auto& [name, table_info] : expected_table_info) {
+    SCOPED_TRACE("checking table " + name);
+    const auto table = Hyrise::get().storage_manager.get_table(name);
+    const auto [size, foreign_key_count] = table_info;
+    EXPECT_EQ(table->row_count(), size);
 
-  EXPECT_EQ(store_sales_table->soft_key_constraints().size(), 1);
-  EXPECT_EQ(store_sales_table->soft_foreign_key_constraints().size(), 9);
-
-  EXPECT_EQ(store_returns_table->soft_key_constraints().size(), 1);
-  EXPECT_EQ(store_returns_table->soft_foreign_key_constraints().size(), 10);
-
-  EXPECT_EQ(catalog_sales_table->soft_key_constraints().size(), 1);
-  EXPECT_EQ(catalog_sales_table->soft_foreign_key_constraints().size(), 17);
-
-  EXPECT_EQ(catalog_returns_table->soft_key_constraints().size(), 1);
-  EXPECT_EQ(catalog_returns_table->soft_foreign_key_constraints().size(), 17);
-
-  EXPECT_EQ(web_sales_table->soft_key_constraints().size(), 1);
-  EXPECT_EQ(web_sales_table->soft_foreign_key_constraints().size(), 17);
-
-  EXPECT_EQ(web_returns_table->soft_key_constraints().size(), 1);
-  EXPECT_EQ(web_returns_table->soft_foreign_key_constraints().size(), 14);
-
-  EXPECT_EQ(inventory_table->soft_key_constraints().size(), 1);
-  EXPECT_EQ(inventory_table->soft_foreign_key_constraints().size(), 3);
-
-  EXPECT_EQ(store_table->soft_key_constraints().size(), 1);
-  EXPECT_EQ(store_table->soft_foreign_key_constraints().size(), 1);
-
-  EXPECT_EQ(call_center_table->soft_key_constraints().size(), 1);
-  EXPECT_EQ(call_center_table->soft_foreign_key_constraints().size(), 2);
-
-  EXPECT_EQ(catalog_page_table->soft_key_constraints().size(), 1);
-  EXPECT_EQ(catalog_page_table->soft_foreign_key_constraints().size(), 2);
-
-  EXPECT_EQ(web_site_table->soft_key_constraints().size(), 1);
-  EXPECT_EQ(web_site_table->soft_foreign_key_constraints().size(), 2);
-
-  EXPECT_EQ(web_page_table->soft_key_constraints().size(), 1);
-  EXPECT_EQ(web_page_table->soft_foreign_key_constraints().size(), 3);
-
-  EXPECT_EQ(warehouse_table->soft_key_constraints().size(), 1);
-  EXPECT_TRUE(warehouse_table->soft_foreign_key_constraints().empty());
-
-  EXPECT_EQ(customer_table->soft_key_constraints().size(), 1);
-  EXPECT_EQ(customer_table->soft_foreign_key_constraints().size(), 6);
-
-  EXPECT_EQ(customer_address_table->soft_key_constraints().size(), 1);
-  EXPECT_TRUE(customer_address_table->soft_foreign_key_constraints().empty());
-
-  EXPECT_EQ(customer_demographics_table->soft_key_constraints().size(), 1);
-  EXPECT_TRUE(customer_demographics_table->soft_foreign_key_constraints().empty());
-
-  EXPECT_EQ(date_dim_table->soft_key_constraints().size(), 1);
-  EXPECT_TRUE(date_dim_table->soft_foreign_key_constraints().empty());
-
-  EXPECT_EQ(household_demographics_table->soft_key_constraints().size(), 1);
-  EXPECT_EQ(household_demographics_table->soft_foreign_key_constraints().size(), 1);
-
-  EXPECT_EQ(item_table->soft_key_constraints().size(), 1);
-  EXPECT_TRUE(item_table->soft_foreign_key_constraints().empty());
-
-  EXPECT_EQ(income_band_table->soft_key_constraints().size(), 1);
-  EXPECT_TRUE(income_band_table->soft_foreign_key_constraints().empty());
-
-  EXPECT_EQ(promotion_table->soft_key_constraints().size(), 1);
-  EXPECT_EQ(promotion_table->soft_foreign_key_constraints().size(), 3);
-
-  EXPECT_EQ(reason_table->soft_key_constraints().size(), 1);
-  EXPECT_TRUE(reason_table->soft_foreign_key_constraints().empty());
-
-  EXPECT_EQ(ship_mode_table->soft_key_constraints().size(), 1);
-  EXPECT_TRUE(ship_mode_table->soft_foreign_key_constraints().empty());
-
-  EXPECT_EQ(time_dim_table->soft_key_constraints().size(), 1);
-  EXPECT_TRUE(time_dim_table->soft_foreign_key_constraints().empty());
+    // All TPC-DS table have a primary key.
+    EXPECT_EQ(table->soft_key_constraints().size(), 1);
+    EXPECT_EQ(table->soft_foreign_key_constraints().size(), foreign_key_count);
+  }
 }
 
 }  // namespace hyrise

--- a/src/test/lib/concurrency/stress_test.cpp
+++ b/src/test/lib/concurrency/stress_test.cpp
@@ -482,7 +482,7 @@ TEST_F(StressTest, ConcurrentInsertsSetChunksImmutable) {
 
   // We observed long runtimes in Debug builds, especially with UBSan enabled. Thus, we reduce the load a bit in this
   // case.
-  const auto insert_count = 20 * (HYRISE_DEBUG && HYRISE_WITH_ADDR_UB_LEAK_SAN ? 1 : DEFAULT_LOAD_FACTOR) + 1;
+  const auto insert_count = 19 * (HYRISE_DEBUG && HYRISE_WITH_ADDR_UB_LEAK_SAN ? 1 : DEFAULT_LOAD_FACTOR) + 1;
   const auto thread_count = uint32_t{100};
   auto threads = std::vector<std::thread>{};
   threads.reserve(thread_count);
@@ -529,7 +529,7 @@ TEST_F(StressTest, ConcurrentInsertsSetChunksImmutable) {
     EXPECT_FALSE(chunk->is_mutable());
   }
 
-  EXPECT_EQ(table->last_chunk()->size(), 2);
+  EXPECT_EQ(table->last_chunk()->size(), 1);
   EXPECT_TRUE(table->last_chunk()->is_mutable());
 }
 

--- a/src/test/lib/concurrency/stress_test.cpp
+++ b/src/test/lib/concurrency/stress_test.cpp
@@ -209,8 +209,8 @@ TEST_F(StressTest, NodeSchedulerStressTest) {
   }
 
   // Create a large number of nodes in a fake topology (many workers will share the same thread).
-  const auto node_count =
-      std::thread::hardware_concurrency() * (HYRISE_WITH_ADDR_UB_LEAK_SAN ? 1 : DEFAULT_LOAD_FACTOR);
+  const auto node_count = std::thread::hardware_concurrency() *
+                          (HYRISE_WITH_ADDR_UB_LEAK_SAN || HYRISE_WITH_TSAN ? 1 : DEFAULT_LOAD_FACTOR);
 
   Hyrise::get().topology.use_fake_numa_topology(node_count, 1);
   const auto node_queue_scheduler = std::make_shared<NodeQueueScheduler>();
@@ -482,7 +482,7 @@ TEST_F(StressTest, ConcurrentInsertsSetChunksImmutable) {
 
   // We observed long runtimes in Debug builds, especially with UBSan enabled. Thus, we reduce the load a bit in this
   // case.
-  const auto insert_count = 30 * (HYRISE_DEBUG && HYRISE_WITH_ADDR_UB_LEAK_SAN ? 1 : DEFAULT_LOAD_FACTOR) + 1;
+  const auto insert_count = 20 * (HYRISE_DEBUG && HYRISE_WITH_ADDR_UB_LEAK_SAN ? 1 : DEFAULT_LOAD_FACTOR) + 1;
   const auto thread_count = uint32_t{100};
   auto threads = std::vector<std::thread>{};
   threads.reserve(thread_count);

--- a/src/test/lib/concurrency/stress_test.cpp
+++ b/src/test/lib/concurrency/stress_test.cpp
@@ -32,7 +32,7 @@ class StressTest : public BaseTest {
 
   static constexpr auto DEFAULT_LOAD_FACTOR = uint32_t{10};
 
-  const uint32_t CPU_COUNT = std::thread::hardware_concurrency();
+  const uint32_t CPU_COUNT = std::min(std::thread::hardware_concurrency(), uint32_t{32});
   const std::vector<std::vector<uint32_t>> FAKE_SINGLE_NODE_NUMA_TOPOLOGIES = {
       {CPU_COUNT}, {CPU_COUNT, 0, 0}, {0, CPU_COUNT, 0}, {0, 0, CPU_COUNT}};
 

--- a/src/test/lib/sql/sqlite_testrunner/sqlite_testrunner.hpp
+++ b/src/test/lib/sql/sqlite_testrunner/sqlite_testrunner.hpp
@@ -16,6 +16,7 @@
 #include "SQLParser.h"
 
 #include "base_test.hpp"
+#include "cache/gdfs_cache.hpp"
 #include "concurrency/transaction_context.hpp"
 #include "hyrise.hpp"
 #include "logical_query_plan/create_view_node.hpp"
@@ -50,7 +51,8 @@ class SQLiteTestRunner : public BaseTestWithParam<SQLiteTestRunnerParam> {
 
   using TableCache = std::map<std::string, TableCacheEntry>;
 
-  static void SetUpTestCase();
+  static void SetUpTestSuite();
+  static void TearDownTestSuite();
 
   void SetUp() override;
 
@@ -64,6 +66,8 @@ class SQLiteTestRunner : public BaseTestWithParam<SQLiteTestRunnerParam> {
 
   inline static std::shared_ptr<SQLLogicalPlanCache> _lqp_cache;
   inline static std::shared_ptr<SQLPhysicalPlanCache> _pqp_cache;
+
+  inline static GDFSCache<std::string, std::shared_ptr<const Table>> _sqlite_result_cache{10};
 
   inline static bool _last_run_successful{true};
 };

--- a/src/test/lib/sql/sqlite_testrunner/sqlite_testrunner_encodings.cpp
+++ b/src/test/lib/sql/sqlite_testrunner/sqlite_testrunner_encodings.cpp
@@ -3,9 +3,27 @@
 
 namespace hyrise {
 
+namespace {
+
+std::vector<EncodingType> encoding_types_without_unencoded() {
+  static auto encodings = std::vector<EncodingType>{};
+
+  if (encodings.empty()) {
+    for (const auto encoding_type : encoding_types) {
+      if (encoding_type != EncodingType::Unencoded) {
+        encodings.push_back(encoding_type);
+      }
+    }
+  }
+
+  return encodings;
+}
+
+}  // namespace
+
 INSTANTIATE_TEST_SUITE_P(SQLiteTestRunnerEncodings, SQLiteTestRunner,
                          testing::Combine(::testing::ValuesIn(SQLiteTestRunner::queries()),
-                                          ::testing::ValuesIn(encoding_types)),
+                                          ::testing::ValuesIn(encoding_types_without_unencoded())),
                          sqlite_testrunner_formatter);
 
 }  // namespace hyrise


### PR DESCRIPTION
Our CI pipeline now runs around 3 to 3.5 hours, this PR tries to push it more to ~2.5 h.
Decrease the CI pipeline runtime by:
- Combining tests for row counts and PKs/FKs of TPCDSTableGenerator
- Omitting SQLite tests with encoded data in shuffled system tests
- Giving more resources to clang release build with TSan
- Skipping SQLite tests in valgrind stage
- Reducing the load of some stress tests (at least in sanitizer builds), skip tests for unencoded data in _encoded_ SQLite tests, cache SQLite results there

If we want to further decrease the runtime, the following ideas might be taken into account:
- skip release build on x64 Mac
- run TPC-DS verification in parallel to the pipeline, skip Nix release build 
- further look into decreasing system test runtime, e.g., TPCC tests.