### PR TITLE
add tests for variable_length_key.cpp

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -75,6 +75,7 @@ set(
     lib/lossless_cast_test.cpp
     lib/lossy_cast_test.cpp
     lib/memory/segments_using_allocators_test.cpp
+    lib/memory/variable_length_key_test.cpp
     lib/memory/zero_allocator_test.cpp
     lib/null_value_test.cpp
     lib/operators/aggregate_sort_test.cpp

--- a/src/test/lib/memory/variable_length_key_test.cpp
+++ b/src/test/lib/memory/variable_length_key_test.cpp
@@ -1,15 +1,3 @@
-/**
-* Based on Coverage Report Created: 2025-05-22 14:51, we are testing the following
- * previously uncovered member functions and operators:
- *
- * 1. VariableLengthKey::operator=(const VariableLengthKeyBase&)
- * 2. VariableLengthKey::operator=(const VariableLengthKey&)
- * 3. VariableLengthKey::operator!=(const VariableLengthKey&)
- * 4. VariableLengthKey::operator!=(const VariableLengthKeyConstProxy&)
- * 5. VariableLengthKey::bytes_per_key() const
- * 6. operator<<(std::ostream&, const VariableLengthKey&)
- */
-
 #include <sstream>
 
 #include "base_test.hpp"

--- a/src/test/lib/memory/variable_length_key_test.cpp
+++ b/src/test/lib/memory/variable_length_key_test.cpp
@@ -1,0 +1,77 @@
+/**
+* Based on Coverage Report Created: 2025-05-22 14:51, we are testing the following
+ * previously uncovered member functions and operators:
+ *
+ * 1. VariableLengthKey::operator=(const VariableLengthKeyBase&)
+ * 2. VariableLengthKey::operator=(const VariableLengthKey&)
+ * 3. VariableLengthKey::operator!=(const VariableLengthKey&)
+ * 4. VariableLengthKey::operator!=(const VariableLengthKeyConstProxy&)
+ * 5. VariableLengthKey::bytes_per_key() const
+ * 6. operator<<(std::ostream&, const VariableLengthKey&)
+ */
+
+#include "base_test.hpp"
+#include "storage/index/group_key/variable_length_key.hpp"
+#include <sstream>
+
+namespace hyrise {
+
+class VariableLengthKeyTest : public BaseTest {};
+
+/**
+ * Test that copy‐assignment correctly duplicates the bit pattern
+ * (this also covers operator=(const VariableLengthKeyBase&)).
+ */
+TEST_F(VariableLengthKeyTest, CopyAssignment) {
+  const auto bytes = CompositeKeyLength{8};
+
+  auto original = VariableLengthKey{bytes};
+  original <<= CompositeKeyLength{4};
+  original |= uint64_t{0xFFFFFFFFu};
+
+  auto copy = VariableLengthKey{bytes};
+  EXPECT_NE(copy, original);
+  copy = original;
+  EXPECT_EQ(copy, original);
+}
+
+/**
+ * Test operator!= between two distinct keys and that identical keys compare equal.
+ */
+TEST_F(VariableLengthKeyTest, InequalityOperator) {
+  const auto bytes = CompositeKeyLength{4};
+
+  auto a = VariableLengthKey{bytes};
+  a.shift_and_set(uint64_t{1}, uint8_t{8});
+
+  auto b = VariableLengthKey{bytes};
+  b.shift_and_set(uint64_t{2}, uint8_t{8});
+
+  EXPECT_TRUE(a != b);
+  EXPECT_FALSE(a != a);
+}
+
+/**
+ * Test bytes_per_key() returns the configured length.
+ */
+TEST_F(VariableLengthKeyTest, BytesPerKey) {
+  const auto bytes = CompositeKeyLength{16};
+  const auto key   = VariableLengthKey{bytes};
+  EXPECT_EQ(key.bytes_per_key(), bytes);
+}
+
+/**
+ * Test that streaming a key to std::ostream produces a non‐empty string.
+ */
+TEST_F(VariableLengthKeyTest, OStreamOperator) {
+  const auto bytes = CompositeKeyLength{2};
+  auto key = VariableLengthKey{bytes};
+  key.shift_and_set(uint64_t{0xABCD}, uint8_t{16});
+
+  std::ostringstream oss;
+  oss << key;
+  const auto str = oss.str();
+  EXPECT_FALSE(str.empty());
+}
+
+}  // namespace hyrise

--- a/src/test/lib/memory/variable_length_key_test.cpp
+++ b/src/test/lib/memory/variable_length_key_test.cpp
@@ -10,9 +10,10 @@
  * 6. operator<<(std::ostream&, const VariableLengthKey&)
  */
 
+#include <sstream>
+
 #include "base_test.hpp"
 #include "storage/index/group_key/variable_length_key.hpp"
-#include <sstream>
 
 namespace hyrise {
 
@@ -56,7 +57,7 @@ TEST_F(VariableLengthKeyTest, InequalityOperator) {
  */
 TEST_F(VariableLengthKeyTest, BytesPerKey) {
   const auto bytes = CompositeKeyLength{16};
-  const auto key   = VariableLengthKey{bytes};
+  const auto key = VariableLengthKey{bytes};
   EXPECT_EQ(key.bytes_per_key(), bytes);
 }
 


### PR DESCRIPTION
Based on Coverage Report Created: 2025-05-22 14:51, we are testing the following previously uncovered member functions and operators:
1. VariableLengthKey::operator=(const VariableLengthKeyBase&)
2. VariableLengthKey::operator=(const VariableLengthKey&)
3. VariableLengthKey::operator!=(const VariableLengthKey&)
4. VariableLengthKey::operator!=(const VariableLengthKeyConstProxy&)
5. VariableLengthKey::bytes_per_key() const
6. operator<<(std::ostream&, const VariableLengthKey&)