### PR TITLE
Fix LTO linking issues on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # consider updating DEPENDENCIES.md when you touch this line
-cmake_minimum_required(VERSION 3.10...4.02 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18...4.02 FATAL_ERROR)
 
 project(Hyrise)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # consider updating DEPENDENCIES.md when you touch this line
-cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10...4.02 FATAL_ERROR)
 
 project(Hyrise)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # consider updating DEPENDENCIES.md when you touch this line
-cmake_minimum_required(VERSION 3.18...4.02 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 
 project(Hyrise)
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -472,7 +472,7 @@ try {
             // Build hyriseTest (Release) with macOS's default compiler (Apple clang) and run it. Passing clang
             // explicitly seems to make the compiler find C system headers (required for SSB and JCC-H data generators)
             // that are not found otherwise.
-            sh "mkdir clang-apple-release && cd clang-apple-release && cmake ${release} ${no_lto} ${ninja} -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ .."
+            sh "mkdir clang-apple-release && cd clang-apple-release && cmake ${release} ${ninja} -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ .."
             sh "cd clang-apple-release && ninja"
             sh "./clang-apple-release/hyriseTest"
 

--- a/src/benchmarklib/tpcc/procedures/abstract_tpcc_procedure.cpp
+++ b/src/benchmarklib/tpcc/procedures/abstract_tpcc_procedure.cpp
@@ -1,5 +1,7 @@
 #include "abstract_tpcc_procedure.hpp"
 
+#include <random>
+
 #include "benchmark_sql_executor.hpp"
 #include "concurrency/transaction_context.hpp"
 #include "hyrise.hpp"

--- a/src/benchmarklib/tpcc/procedures/abstract_tpcc_procedure.cpp
+++ b/src/benchmarklib/tpcc/procedures/abstract_tpcc_procedure.cpp
@@ -9,6 +9,9 @@
 
 namespace hyrise {
 
+thread_local std::minstd_rand AbstractTPCCProcedure::_random_engine{42};
+thread_local TPCCRandomGenerator AbstractTPCCProcedure::_tpcc_random_generator{42};
+
 AbstractTPCCProcedure::AbstractTPCCProcedure(BenchmarkSQLExecutor& sql_executor) : _sql_executor(sql_executor) {
   PerformanceWarning(
       "The TPC-C support is in a very early stage. Constraints are not enforced, indexes are often not used, and even "

--- a/src/benchmarklib/tpcc/procedures/abstract_tpcc_procedure.cpp
+++ b/src/benchmarklib/tpcc/procedures/abstract_tpcc_procedure.cpp
@@ -11,8 +11,11 @@
 
 namespace hyrise {
 
+// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables):
+//   See https://github.com/llvm/llvm-project/issues/47384. Should be fixed with clang-tidy versions >17.
 thread_local std::minstd_rand AbstractTPCCProcedure::_random_engine{42};
 thread_local TPCCRandomGenerator AbstractTPCCProcedure::_tpcc_random_generator{42};
+// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
 
 AbstractTPCCProcedure::AbstractTPCCProcedure(BenchmarkSQLExecutor& sql_executor) : _sql_executor(sql_executor) {
   PerformanceWarning(

--- a/src/benchmarklib/tpcc/procedures/abstract_tpcc_procedure.cpp
+++ b/src/benchmarklib/tpcc/procedures/abstract_tpcc_procedure.cpp
@@ -5,6 +5,7 @@
 #include "benchmark_sql_executor.hpp"
 #include "concurrency/transaction_context.hpp"
 #include "hyrise.hpp"
+#include "tpcc/tpcc_random_generator.hpp"
 #include "types.hpp"
 #include "utils/assert.hpp"
 #include "utils/performance_warning.hpp"

--- a/src/benchmarklib/tpcc/procedures/abstract_tpcc_procedure.hpp
+++ b/src/benchmarklib/tpcc/procedures/abstract_tpcc_procedure.hpp
@@ -26,8 +26,8 @@ class AbstractTPCCProcedure {
 
   // As random values are generated during creation of the procedure, this is mostly done in a single thread, not in the
   // database worker's. As such, having a fixed seed for all thread-local random engines should not be an issue.
-  inline static thread_local std::minstd_rand _random_engine{42};
-  inline static thread_local TPCCRandomGenerator _tpcc_random_generator{42};
+  static thread_local std::minstd_rand _random_engine;
+  static thread_local TPCCRandomGenerator _tpcc_random_generator;
 
   BenchmarkSQLExecutor& _sql_executor;
 };

--- a/src/benchmarklib/tpcc/procedures/abstract_tpcc_procedure.hpp
+++ b/src/benchmarklib/tpcc/procedures/abstract_tpcc_procedure.hpp
@@ -24,10 +24,14 @@ class AbstractTPCCProcedure {
  protected:
   [[nodiscard]] virtual bool _on_execute() = 0;
 
+  // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables):
+  //   See https://github.com/llvm/llvm-project/issues/47384. Should be fixed with clang-tidy versions >17.
+
   // As random values are generated during creation of the procedure, this is mostly done in a single thread, not in the
   // database worker's. As such, having a fixed seed for all thread-local random engines should not be an issue.
   static thread_local std::minstd_rand _random_engine;
   static thread_local TPCCRandomGenerator _tpcc_random_generator;
+  // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
 
   BenchmarkSQLExecutor& _sql_executor;
 };

--- a/src/benchmarklib/tpcc/procedures/abstract_tpcc_procedure.hpp
+++ b/src/benchmarklib/tpcc/procedures/abstract_tpcc_procedure.hpp
@@ -24,14 +24,10 @@ class AbstractTPCCProcedure {
  protected:
   [[nodiscard]] virtual bool _on_execute() = 0;
 
-  // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables):
-  //   See https://github.com/llvm/llvm-project/issues/47384. Should be fixed with clang-tidy versions >17.
-
   // As random values are generated during creation of the procedure, this is mostly done in a single thread, not in the
   // database worker's. As such, having a fixed seed for all thread-local random engines should not be an issue.
   static thread_local std::minstd_rand _random_engine;
   static thread_local TPCCRandomGenerator _tpcc_random_generator;
-  // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
 
   BenchmarkSQLExecutor& _sql_executor;
 };


### PR DESCRIPTION
There CAN be issues when using `inline static thread-local` and LTO builds. On macOS with brew's LLVM, it happened for the past 3 versions.

This PR should hopefully fix it as we get rid of `inline`.

I will run benchmarks, just to be sure.