### PR TITLE
Install script: Install time util on Ubuntu

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -51,7 +51,7 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
             if sudo apt-get update >/dev/null; then
 
                 # Packages added here should also be added to the Dockerfile
-                if ! sudo apt-get install --no-install-recommends -y software-properties-common lsb-release git python3 python3-pip autoconf bash-completion bc clang-19 llvm-20 clang-20 clang-format-20 clang-tidy-20 libclang-rt-dev cmake curl dos2unix g++-15 gcc-15 graphviz libboost-all-dev libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld-20 man parallel postgresql-server-dev-all valgrind; then
+                if ! sudo apt-get install --no-install-recommends -y software-properties-common lsb-release git python3 python3-pip autoconf bash-completion bc clang-19 llvm-20 clang-20 clang-format-20 clang-tidy-20 libclang-rt-dev cmake curl dos2unix g++-15 gcc-15 graphviz libboost-all-dev libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld-20 man parallel postgresql-server-dev-all time valgrind; then
                     echo "Error during apt-get installations."
                     exit 1
                 fi


### PR DESCRIPTION
It took me way to long to realize while a new server did not run the `benchmark_all.sh` script. It is a Ubuntu 25.04 and I used `install_dependencies.sh` to set it up.

When running the benchmark_all script, it silently fails as we pipe the output to a file. So it's not immediately clear why nothing happens after the call to `ninja clean`.

This branch simply adds `time` to the list of items to install via `apt`.