### PR TITLE
LQP-Visualizer: Display cardinality estimates of 0 

### DIFF
--- a/src/lib/visualization/lqp_visualizer.cpp
+++ b/src/lib/visualization/lqp_visualizer.cpp
@@ -206,7 +206,7 @@ void LQPVisualizer::_build_dataflow(const std::shared_ptr<AbstractLQPNode>& sour
   auto info = _default_edge;
   info.label = label_stream.str();
   info.label_tooltip = tooltip_stream.str();
-  // pen widths are normalized later during graph construction so assigning 0 or NAN is acceptable.
+  // `pen_width` is normalized later during graph construction, so assigning 0 or NAN is acceptable.
   info.pen_width = row_count;
   if (target_node->input_count() == 2) {
     info.arrowhead = side == InputSide::Left ? "lnormal" : "rnormal";


### PR DESCRIPTION
Displays 0 instead of "no est." when the cardinality estimator return 0. 

Adds input_counts for union_nodes instead of multiplying them. (This matches the way it is done in the cardinality estimator.) 

Setting the pen_width to 0 is not a problem since we are normalising the pen_widths later.

[master: TPC-H_19_LQP](https://hyrise-ci.epic-hpi.de/job/hyrise/job/hyrise/job/master/lastStableBuild/artifact/query_plans/tpch/TPC-H_19-LQP.svg)
With the changes, TPC-H_19_LQP:
<img width="979" height="1280" alt="image" src="https://github.com/user-attachments/assets/8e5fb355-e38f-4e76-8b1e-9c9923332a9a" />