### PR TITLE
Fix crash caused by GNU Readline

### DIFF
--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -1104,8 +1104,9 @@ char* Console::_command_generator(const char* text, int state, const std::vector
     it = commands.begin();
   }
 
-  for (; it != commands.end(); ++it) {
+  while (it != commands.end()) {
     const auto& command = *it;
+    ++it;
     if (command.find(text) != std::string::npos) {
       auto* completion = new char[command.size()];  // NOLINT(cppcoreguidelines-owning-memory)
       // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)


### PR DESCRIPTION
Crash was caused by endless cycle in Console::_command_generator

Static iterator was not incremented after early return, which lead to exceed memory allocation.

This changes just revert this peace of code to previous working condition.