### PR TITLE
Update GoogleBench and use C++23

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -98,7 +98,7 @@ WarningsAsErrors: '*'
 #   - bugprone-unchecked-optional-access                        Too many false positives (with clang-tidy 14/15). TODO(anyone): Re-evaluate for future clang versions.
 #   - llvm-header-guard                                         We prefer the simpler `#pragma once`. The main arguments (e.g., lacking support in old compilers)
 #                                                               do not matter with our limited set of supported compilers.
-#   - boost-use-ranges                                          As most boost-ranges implementations are now in C++20, we prefer `std::ranges`.
+#   - boost-use-ranges                                          As most boost-ranges implementations are in C++23, we prefer `std::ranges`.
 #   - portability-template-virtual-member-function              We do not mind being incompatible with the MSVC compiler.
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang")
  endif()
 
 # Starting with GCC 14's libstdc++, std::atomic_load for shared pointers is deprecated (as part of C++20). However, as
-# of LLVM 19, libc++ has not implemented std::atomic<std::shared_ptr> (see P0718R2,
+# of LLVM 22, libc++ has not implemented std::atomic<std::shared_ptr> (see P0718R2,
 # https://en.cppreference.com/w/cpp/compiler_support). As we use libstdc++ when compiling with clang on Linux, we
 # disable deprecation warnings.
 # We only disable this warning on Linux because clang on macOS uses libc++. Once libc++ implements the missing atomics,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,7 +40,7 @@ endif()
 
 # Global flags and include directories
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 
 add_compile_options(-pthread -Wno-unknown-warning-option)
 

--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -401,6 +401,7 @@ void AbstractTableGenerator::_create_table_indexes(
     const auto& table = table_info_by_name[table_name].table;
 
     auto chunk_ids = std::vector<ChunkID>(table->chunk_count());
+    // NOLINTNEXTLINE(modernize-use-ranges): We need LLVM 21's libc++ for std::ranges::iota.
     std::iota(chunk_ids.begin(), chunk_ids.end(), ChunkID{0});
     for (const auto& index_column_names : indexes) {
       Assert(index_column_names.size() == 1, "Multi-column indexes are currently not supported.");

--- a/src/benchmarklib/file_based_benchmark_item_runner.cpp
+++ b/src/benchmarklib/file_based_benchmark_item_runner.cpp
@@ -55,6 +55,7 @@ FileBasedBenchmarkItemRunner::FileBasedBenchmarkItemRunner(
   }
 
   _items.resize(_queries.size());
+  // NOLINTNEXTLINE(modernize-use-ranges): We need LLVM 21's libc++ for std::ranges::iota.
   std::iota(_items.begin(), _items.end(), BenchmarkItemID{0});
 
   // Sort queries by name.

--- a/src/benchmarklib/tpch/tpch_benchmark_item_runner.cpp
+++ b/src/benchmarklib/tpch/tpch_benchmark_item_runner.cpp
@@ -44,6 +44,7 @@ TPCHBenchmarkItemRunner::TPCHBenchmarkItemRunner(const std::shared_ptr<Benchmark
       _scale_factor(scale_factor),
       _clustering_configuration(clustering_configuration) {
   _items.resize(22);
+  // NOLINTNEXTLINE(modernize-use-ranges): We need LLVM 21's libc++ for std::ranges::iota.
   std::iota(_items.begin(), _items.end(), BenchmarkItemID{0});
 }
 

--- a/src/lib/operators/aggregate_hash.cpp
+++ b/src/lib/operators/aggregate_hash.cpp
@@ -1284,6 +1284,7 @@ std::shared_ptr<const Table> AggregateHash::_on_execute() {
   auto entireposlist_indexes = std::vector<ColumnID>{};
   entireposlist_indexes.reserve(_aggregates.size());
 
+  // NOLINTNEXTLINE(modernize-use-ranges): We need LLVM 21's libc++ for std::ranges::iota.
   std::iota(reference_segment_indexes.begin(), reference_segment_indexes.end(), ColumnID{0});
   auto output_column_id = ColumnID{static_cast<ColumnID::base_type>(_groupby_column_ids.size())};
   for (const auto& aggregate : _aggregates) {

--- a/src/lib/operators/union_positions.cpp
+++ b/src/lib/operators/union_positions.cpp
@@ -112,10 +112,12 @@ std::shared_ptr<const Table> UnionPositions::_on_execute() {
   /**
    * Init the virtual pos lists
    */
+  // NOLINTBEGIN(modernize-use-ranges): We need LLVM 21's libc++ for std::ranges::iota.
   auto virtual_pos_list_left = VirtualPosList(left_in_table.row_count(), 0);
   std::iota(virtual_pos_list_left.begin(), virtual_pos_list_left.end(), 0);
   auto virtual_pos_list_right = VirtualPosList(right_input_table()->row_count(), 0);
   std::iota(virtual_pos_list_right.begin(), virtual_pos_list_right.end(), 0);
+  // NOLINTEND(modernize-use-ranges)
 
   /**
    * Sort the virtual pos lists so that they bring the rows in their respective ReferenceMatrix into order.

--- a/src/lib/scheduler/worker.cpp
+++ b/src/lib/scheduler/worker.cpp
@@ -44,6 +44,8 @@ Worker::Worker(const std::shared_ptr<TaskQueue>& queue, WorkerID worker_id, CpuI
     : _queue(queue), _id(worker_id), _cpu_id(cpu_id) {
   // Generate a random distribution from 0-99 for later use, see below
   _random.resize(100);
+
+  // NOLINTNEXTLINE(modernize-use-ranges): We need LLVM 21's libc++ for std::ranges::iota.
   std::iota(_random.begin(), _random.end(), 0);
   std::shuffle(_random.begin(), _random.end(), std::default_random_engine{std::random_device{}()});
 }

--- a/src/lib/storage/constraints/foreign_key_constraint.cpp
+++ b/src/lib/storage/constraints/foreign_key_constraint.cpp
@@ -24,7 +24,7 @@ using namespace hyrise;  // NOLINT(build/namespaces)
 std::vector<size_t> sort_indexes(const std::vector<ColumnID>& column_ids) {
   auto permutation = std::vector<size_t>(column_ids.size());
   // Fill permutation with [0, 1, ..., n - 1] and order the permutation by sorting column_ids.
-  std::iota(permutation.begin(), permutation.end(), 0);
+  std::iota(permutation.begin(), permutation.end(), 0);  // NOLINT(modernize-use-ranges): Needs LLVM 21's libc++.
   std::ranges::sort(permutation, [&](auto lhs, auto rhs) {
     return column_ids[lhs] < column_ids[rhs];
   });

--- a/src/test/lib/scheduler/scheduler_test.cpp
+++ b/src/test/lib/scheduler/scheduler_test.cpp
@@ -1,5 +1,4 @@
 #include <chrono>
-#include <mdspan>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -461,18 +460,6 @@ TEST_F(SchedulerTest, ExecuteNextFromNonWorker) {
   EXPECT_EQ(node_queue_scheduler->active_worker_count(), 1);
   auto empty_task = std::make_shared<JobTask>([&]() {});
   EXPECT_THROW(worker->execute_next(empty_task), std::logic_error);
-}
-
-TEST_F(SchedulerTest, TemporaryMDSPANTestPleaseRemoveMe17) {
-  auto v = std::vector<size_t>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
-
-  auto span = std::mdspan<size_t, std::dextents<size_t, 2>>{v.data(), 2, 4};
-
-  EXPECT_EQ((span[0, 1]), 1);
-  EXPECT_EQ((span[0, 3]), 3);
-  EXPECT_EQ((span[1, 0]), 4);
-  EXPECT_EQ((span[2, 0]), 8);
-  EXPECT_EQ((span[3, 3]), 15);
 }
 
 }  // namespace hyrise

--- a/src/test/lib/scheduler/scheduler_test.cpp
+++ b/src/test/lib/scheduler/scheduler_test.cpp
@@ -1,4 +1,5 @@
 #include <chrono>
+#include <mdspan>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -460,6 +461,18 @@ TEST_F(SchedulerTest, ExecuteNextFromNonWorker) {
   EXPECT_EQ(node_queue_scheduler->active_worker_count(), 1);
   auto empty_task = std::make_shared<JobTask>([&]() {});
   EXPECT_THROW(worker->execute_next(empty_task), std::logic_error);
+}
+
+TEST_F(SchedulerTest, TemporaryMDSPANTestPleaseRemoveMe17) {
+  auto v = std::vector<size_t>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+
+  auto span = std::mdspan<size_t, std::dextents<size_t, 2>>{v.data(), 2, 4};
+
+  EXPECT_EQ((span[0, 1]), 1);
+  EXPECT_EQ((span[0, 3]), 3);
+  EXPECT_EQ((span[1, 0]), 4);
+  EXPECT_EQ((span[2, 0]), 8);
+  EXPECT_EQ((span[3, 3]), 15);
 }
 
 }  // namespace hyrise


### PR DESCRIPTION
This pull request updates Google Benchmark to fix an issue on MacOS (preparation for DYOD):
`third_party/benchmark/src/sysinfo.cc:645:3: error: unknown type name 'cpu_set_t'`

Further, it updates Hyrise to C++23.

~Further, I wanted to test C++23 on the CI and `std::mdspan` (we are discussing it in #2734).~

Todos:

- [x] Update documentation/wiki