### PR TITLE
Fix segfault in LZ4 encoding when encoding JOB data

### DIFF
--- a/src/lib/storage/lz4_segment/lz4_encoder.hpp
+++ b/src/lib/storage/lz4_segment/lz4_encoder.hpp
@@ -59,7 +59,7 @@ class LZ4Encoder : public SegmentEncoder<LZ4Encoder> {
    * at once (refer to the comment above).
    */
   static constexpr auto BLOCK_SIZE = size_t{16'384};
-  static_assert(BLOCK_SIZE <= size_t{std::numeric_limits<int>::max()},
+  static_assert(BLOCK_SIZE <= size_t{std::numeric_limits<int32_t>::max()},
                 "LZ4 block size cannot be larger than the maximum value of a 32 bit signed int");
 
   template <typename T>

--- a/src/lib/storage/lz4_segment/lz4_encoder.hpp
+++ b/src/lib/storage/lz4_segment/lz4_encoder.hpp
@@ -58,15 +58,13 @@ class LZ4Encoder : public SegmentEncoder<LZ4Encoder> {
    * (due to not enough data) the compression ratio suffers, since LZ4 can only view and compress small amounts of data
    * at once (refer to the comment above).
    */
-  static constexpr auto BLOCK_SIZE = size_t{16384};
+  static constexpr auto BLOCK_SIZE = size_t{16'384};
   static_assert(BLOCK_SIZE <= size_t{std::numeric_limits<int>::max()},
-                "LZ4 block size can't be larger than the maximum value of a 32 bit signed int");
+                "LZ4 block size cannot be larger than the maximum value of a 32 bit signed int");
 
   template <typename T>
   std::shared_ptr<AbstractEncodedSegment> on_encode(const AnySegmentIterable<T>& segment_iterable,
                                                     const PolymorphicAllocator<T>& allocator) {
-    // TODO(anyone): when value segments switch to using pmr_vectors, the data can be copied directly instead of
-    // copying it element by element
     auto values = pmr_vector<T>{allocator};
     auto null_values = pmr_vector<bool>{allocator};
 
@@ -133,7 +131,7 @@ class LZ4Encoder : public SegmentEncoder<LZ4Encoder> {
                                                     const PolymorphicAllocator<pmr_string>& allocator) {
     /**
      * First iterate over the values for two reasons.
-     * 1) If all the strings are empty LZ4 will try to compress an empty vector which will cause a segmentation fault.
+     * 1) If all the strings are empty, LZ4 will try to compress an empty vector which will cause a segmentation fault.
      *    In this case we can and need to do an early exit.
      * 2) Sum the length of the strings to improve the performance when copying the data to the char vector.
      */
@@ -146,7 +144,7 @@ class LZ4Encoder : public SegmentEncoder<LZ4Encoder> {
       }
     });
 
-    // copy values and null flags from value segment
+    // Copy values and null flags from value segment.
     auto values = pmr_vector<char>{allocator};
     values.reserve(num_chars);
     auto null_values = pmr_vector<bool>{allocator};
@@ -180,7 +178,7 @@ class LZ4Encoder : public SegmentEncoder<LZ4Encoder> {
 
       null_values.resize(segment_size);
       offsets.resize(segment_size);
-      string_samples_lengths.resize(segment_size);
+      string_samples_lengths.reserve(segment_size);
 
       auto offset = uint32_t{0};
       // iterate over the iterator to access the values and increment the row index to write to the values and null
@@ -192,7 +190,6 @@ class LZ4Encoder : public SegmentEncoder<LZ4Encoder> {
         null_values[row_index] = contains_null;
         segment_contains_null = segment_contains_null || contains_null;
         offsets[row_index] = offset;
-        auto sample_size = size_t{0};
         if (!contains_null) {
           const auto& value = segment_element.value();
           const auto string_length = value.size();
@@ -200,10 +197,9 @@ class LZ4Encoder : public SegmentEncoder<LZ4Encoder> {
           Assert(string_length <= std::numeric_limits<uint32_t>::max(),
                  "The size of string row value exceeds the maximum of uint32 in LZ4 encoding.");
           offset += static_cast<uint32_t>(string_length);
-          sample_size = string_length;
+          string_samples_lengths.push_back(string_length);
         }
 
-        string_samples_lengths[row_index] = sample_size;
         ++row_index;
       }
     });
@@ -414,8 +410,8 @@ class LZ4Encoder : public SegmentEncoder<LZ4Encoder> {
       return pmr_vector<char>{};
     }
 
-    DebugAssert(dictionary_size <= max_dictionary_size,
-                "Generated ZSTD dictionary in LZ4 compression is larger than the memory allocated for it.");
+    Assert(dictionary_size <= max_dictionary_size,
+           "Generated ZSTD dictionary in LZ4 compression is larger than the memory allocated for it.");
 
     // Shrink the allocated dictionary size to the actual size.
     dictionary.resize(dictionary_size);

--- a/src/lib/storage/lz4_segment/lz4_encoder.hpp
+++ b/src/lib/storage/lz4_segment/lz4_encoder.hpp
@@ -149,10 +149,8 @@ class LZ4Encoder : public SegmentEncoder<LZ4Encoder> {
     values.reserve(num_chars);
     auto null_values = pmr_vector<bool>{allocator};
 
-    /**
-     * If the null value vector only contains the value false, then the value segment does not have any row value that
-     * is null. In that case, we don't store the null value vector to reduce the LZ4 segment's memory footprint.
-     */
+    // If the null value vector only contains the value false, then the value segment does not have any row value that
+    // is null. In that case, we don't store the null value vector to reduce the LZ4 segment's memory footprint.
     auto segment_contains_null = false;
 
     /**
@@ -168,9 +166,7 @@ class LZ4Encoder : public SegmentEncoder<LZ4Encoder> {
      */
     auto offsets = pmr_vector<uint32_t>{allocator};
 
-    /**
-     * These are the lengths of each string. They are needed to train the zstd dictionary.
-     */
+    // These are the lengths of each string. They are needed to train the zstd dictionary.
     auto string_samples_lengths = pmr_vector<size_t>{allocator};
 
     segment_iterable.with_iterators([&](auto it, const auto& end) {
@@ -181,8 +177,8 @@ class LZ4Encoder : public SegmentEncoder<LZ4Encoder> {
       string_samples_lengths.reserve(segment_size);
 
       auto offset = uint32_t{0};
-      // iterate over the iterator to access the values and increment the row index to write to the values and null
-      // values vectors
+      // Iterate over the iterator to access the values and increment the row index to write to the values and null
+      // values vectors.
       auto row_index = size_t{0};
       for (; it != end; ++it) {
         const auto segment_element = *it;

--- a/src/test/lib/storage/lz4_segment_test.cpp
+++ b/src/test/lib/storage/lz4_segment_test.cpp
@@ -303,12 +303,11 @@ TEST_F(StorageLZ4SegmentTest, LongStringsFollowedByEmptyOnes) {
   constexpr auto row_count = 15'000;
   constexpr auto null_row_count = (row_count / 5) * 4;
 
-  for (auto index = size_t{0}; index < row_count; ++index) {
-    if (index < null_row_count) {
-      vs_str->append(NULL_VALUE);
-    } else {
-      vs_str->append(AllTypeVariant{pmr_string{"this is element number #" + std::to_string(index)}});
-    }
+  for (auto index = size_t{0}; index < null_row_count; ++index) {
+    vs_str->append(NULL_VALUE);
+  }
+  for (auto index = size_t{null_row_count}; index < row_count; ++index) {
+    vs_str->append(AllTypeVariant{pmr_string{"this is element number #" + std::to_string(index)}});
   }
 
   const auto lz4_segment = compress(vs_str, DataType::String);

--- a/src/test/lib/storage/lz4_segment_test.cpp
+++ b/src/test/lib/storage/lz4_segment_test.cpp
@@ -252,7 +252,7 @@ TEST_F(StorageLZ4SegmentTest, CompressMultiBlockStringSegment) {
 }
 
 TEST_F(StorageLZ4SegmentTest, CompressDictionaryStringSegment) {
-  const auto block_size = LZ4Encoder::BLOCK_SIZE;
+  constexpr auto block_size = LZ4Encoder::BLOCK_SIZE;
   constexpr auto num_rows = 100'000 / 20;
 
   for (auto index = size_t{0}; index < num_rows; ++index) {

--- a/src/test/lib/storage/lz4_segment_test.cpp
+++ b/src/test/lib/storage/lz4_segment_test.cpp
@@ -259,7 +259,7 @@ TEST_F(StorageLZ4SegmentTest, CompressDictionaryStringSegment) {
     vs_str->append(AllTypeVariant{pmr_string{"this is element " + std::to_string(index)}});
   }
 
-  auto lz4_segment = compress(vs_str, DataType::String);
+  const auto lz4_segment = compress(vs_str, DataType::String);
 
   // Test segment size.
   EXPECT_EQ(lz4_segment->size(), num_rows);
@@ -296,6 +296,27 @@ TEST_F(StorageLZ4SegmentTest, CompressDictionaryStringSegment) {
   EXPECT_EQ(decompressed_data[1234], "this is element 1234");
   EXPECT_EQ(decompressed_data[4312], "this is element 4312");
   EXPECT_EQ(decompressed_data[4014], "this is element 4014");
+}
+
+// Testing fix of segfault when segment contains many NULLs (issue #2641).
+TEST_F(StorageLZ4SegmentTest, LongStringsFollowedByEmptyOnes) {
+  constexpr auto row_count = 15'000;
+  constexpr auto null_row_count = (row_count / 5) * 4;
+
+  for (auto index = size_t{0}; index < row_count; ++index) {
+    if (index < null_row_count) {
+      vs_str->append(NULL_VALUE);
+    } else {
+      vs_str->append(AllTypeVariant{pmr_string{"this is element number #" + std::to_string(index)}});
+    }
+  }
+
+  const auto lz4_segment = compress(vs_str, DataType::String);
+  EXPECT_EQ(lz4_segment->size(), row_count);
+  EXPECT_FALSE(lz4_segment->dictionary().empty());
+  const auto last_index = row_count - 1;
+  EXPECT_EQ(lz4_segment->decompress(ChunkOffset{last_index}),
+            pmr_string{std::format("this is element number #{}", last_index)});
 }
 
 TEST_F(StorageLZ4SegmentTest, CompressDictionaryIntSegment) {

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -90,7 +90,7 @@ target_include_directories(
     PUBLIC
     ${LZ4_LIBRARY_DIR}
 )
-target_compile_options(lz4 PRIVATE -fPIC)
+target_compile_options(lz4 PRIVATE -fPIC INTERFACE -Wno-documentation-unknown-command)
 
 # Build compact_vector library
 add_library(compact_vector INTERFACE)


### PR DESCRIPTION
To build the zstd dictionary, we sampled strings(`std::vector<char>`) together with their offsets (`std::vector<size_t>`). In some cases where we had many NULLs in the beginning of a vector, we had a long list of zero lengths, followed by actual strings and offsets.
For Join Order data and LZ4 encoding, this lead to segfaults (not always though).

This PR changes the offsets to only store non-zero lengths. It also adds a test that fails on master with ASAN builds and updates LZ4.

Fixes #2671 