### PR TITLE
[DYOD] Group 5: Add tests for constraint utils and segment encoding utils

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -192,6 +192,7 @@ set(
     lib/storage/encoded_segment_test.cpp
     lib/storage/encoded_string_segment_test.cpp
     lib/storage/encoding_test.hpp
+    lib/storage/segment_encoding_utils_test.cpp
     lib/storage/fixed_string_dictionary_segment/fixed_string_test.cpp
     lib/storage/fixed_string_dictionary_segment/fixed_string_vector_test.cpp
     lib/storage/fixed_string_dictionary_segment_test.cpp

--- a/src/test/lib/storage/constraints/constraint_utils_test.cpp
+++ b/src/test/lib/storage/constraints/constraint_utils_test.cpp
@@ -173,4 +173,12 @@ TEST_F(ConstraintUtilsTest, CheckIfTableKeyConstraintIsKnownToBeInvalid) {
       _table_b, {{ColumnID{1}}, KeyConstraintType::UNIQUE, CommitID{1}, CommitID{2}}));
 }
 
+TEST_F(ConstraintUtilsTest, CheckConstraintEqualityOperator) {
+  EXPECT_EQ(TableKeyConstraint({ColumnID{0}, ColumnID{1}}, KeyConstraintType::PRIMARY_KEY),
+    TableKeyConstraint({ColumnID{0}, ColumnID{1}}, KeyConstraintType::PRIMARY_KEY));
+
+  EXPECT_NE(TableKeyConstraint({ColumnID{0}, ColumnID{1}}, KeyConstraintType::PRIMARY_KEY),
+    TableKeyConstraint({ColumnID{0}, ColumnID{1}}, KeyConstraintType::UNIQUE));
+}
+
 }  // namespace hyrise

--- a/src/test/lib/storage/constraints/constraint_utils_test.cpp
+++ b/src/test/lib/storage/constraints/constraint_utils_test.cpp
@@ -175,10 +175,10 @@ TEST_F(ConstraintUtilsTest, CheckIfTableKeyConstraintIsKnownToBeInvalid) {
 
 TEST_F(ConstraintUtilsTest, CheckConstraintEqualityOperator) {
   EXPECT_EQ(TableKeyConstraint({ColumnID{0}, ColumnID{1}}, KeyConstraintType::PRIMARY_KEY),
-    TableKeyConstraint({ColumnID{0}, ColumnID{1}}, KeyConstraintType::PRIMARY_KEY));
+            TableKeyConstraint({ColumnID{0}, ColumnID{1}}, KeyConstraintType::PRIMARY_KEY));
 
   EXPECT_NE(TableKeyConstraint({ColumnID{0}, ColumnID{1}}, KeyConstraintType::PRIMARY_KEY),
-    TableKeyConstraint({ColumnID{0}, ColumnID{1}}, KeyConstraintType::UNIQUE));
+            TableKeyConstraint({ColumnID{0}, ColumnID{1}}, KeyConstraintType::UNIQUE));
 }
 
 }  // namespace hyrise

--- a/src/test/lib/storage/segment_encoding_utils_test.cpp
+++ b/src/test/lib/storage/segment_encoding_utils_test.cpp
@@ -2,16 +2,27 @@
 #include "storage/segment_encoding_utils.hpp"
 
 namespace hyrise {
-class SegmentEncodingUtilsTest : public BaseTest {
-};
+class SegmentEncodingUtilsTest : public BaseTest {};
 
 TEST_F(SegmentEncodingUtilsTest, TestAutoSelectChunkEncodingSpec) {
   EXPECT_EQ(auto_select_chunk_encoding_spec({DataType::Double, DataType::Int, DataType::Int, DataType::String},
                                             {ColumnID{0}, ColumnID{2}}),
-            (ChunkEncodingSpec{SegmentEncodingSpec{EncodingType::Unencoded},
-                               SegmentEncodingSpec{EncodingType::FrameOfReference},
-                               SegmentEncodingSpec{EncodingType::Unencoded},
-                               SegmentEncodingSpec{EncodingType::Dictionary}}));
+            (ChunkEncodingSpec{
+                SegmentEncodingSpec{EncodingType::Unencoded}, SegmentEncodingSpec{EncodingType::FrameOfReference},
+                SegmentEncodingSpec{EncodingType::Unencoded}, SegmentEncodingSpec{EncodingType::Dictionary}}));
+}
+
+TEST_F(SegmentEncodingUtilsTest, TestParentVectorCompressionType) {
+  EXPECT_EQ(parent_vector_compression_type(CompressedVectorType::FixedWidthInteger4Byte),
+            VectorCompressionType::FixedWidthInteger);
+
+  EXPECT_EQ(parent_vector_compression_type(CompressedVectorType::FixedWidthInteger2Byte),
+            VectorCompressionType::FixedWidthInteger);
+
+  EXPECT_EQ(parent_vector_compression_type(CompressedVectorType::FixedWidthInteger1Byte),
+            VectorCompressionType::FixedWidthInteger);
+
+  EXPECT_EQ(parent_vector_compression_type(CompressedVectorType::BitPacking), VectorCompressionType::BitPacking);
 }
 
 }  // namespace hyrise

--- a/src/test/lib/storage/segment_encoding_utils_test.cpp
+++ b/src/test/lib/storage/segment_encoding_utils_test.cpp
@@ -1,0 +1,17 @@
+#include "base_test.hpp"
+#include "storage/segment_encoding_utils.hpp"
+
+namespace hyrise {
+class SegmentEncodingUtilsTest : public BaseTest {
+};
+
+TEST_F(SegmentEncodingUtilsTest, TestAutoSelectChunkEncodingSpec) {
+  EXPECT_EQ(auto_select_chunk_encoding_spec({DataType::Double, DataType::Int, DataType::Int, DataType::String},
+                                            {ColumnID{0}, ColumnID{2}}),
+            (ChunkEncodingSpec{SegmentEncodingSpec{EncodingType::Unencoded},
+                               SegmentEncodingSpec{EncodingType::FrameOfReference},
+                               SegmentEncodingSpec{EncodingType::Unencoded},
+                               SegmentEncodingSpec{EncodingType::Dictionary}}));
+}
+
+}  // namespace hyrise


### PR DESCRIPTION
This PR adds another test case for the constraint utilities and introduces two initial test cases for the segment encoding utilities.