### PR TITLE
Show p-values in Benchmark Comparison Again

### DIFF
--- a/scripts/benchmark_all.sh
+++ b/scripts/benchmark_all.sh
@@ -16,7 +16,8 @@ benchmarks='hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkTPCC hyriseB
 # #2405 for some preliminary reasoning.
 warmup_seconds=1
 mt_shuffled_runtime=1200
-runs=50
+st_runs=50
+mt_runs=100
 
 # Setting the number of clients used for the multi-threaded scenario to the machine's physical core count. This only
 # works for macOS and Linux. We do not use hyper-threads because the benchmark results are less stable on them. We
@@ -122,17 +123,17 @@ do
       ( "${build_folder}"/"$benchmark" -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st.log"
     else
       echo "Running $benchmark for $commit... (single-threaded)"
-      ( "${build_folder}"/"$benchmark" -r ${runs} -w ${warmup_seconds} -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st.log"
+      ( "${build_folder}"/"$benchmark" -r ${st_runs} -w ${warmup_seconds} -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st.log"
     fi
 
     if [ "$benchmark" = "hyriseBenchmarkTPCH" ]; then
       echo "Running $benchmark for $commit... (single-threaded, SF 0.01)"
-      ( "${build_folder}"/"$benchmark" -s .01 -r ${runs} -w ${warmup_seconds} -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st_s01.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st_s01.log"
+      ( "${build_folder}"/"$benchmark" -s .01 -r ${mt_runs} -w ${warmup_seconds} -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st_s01.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st_s01.log"
     fi
 
     if [ "$benchmark" != "hyriseBenchmarkTPCC" ]; then
       echo "Running $benchmark for $commit... (multi-threaded, ordered, 1 client)"
-      ( "${build_folder}"/"$benchmark" --scheduler --clients 1 --cores ${num_phy_cores} -m Ordered -r ${runs} -w ${warmup_seconds} -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt_ordered.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt_ordered.log"
+      ( "${build_folder}"/"$benchmark" --scheduler --clients 1 --cores ${num_phy_cores} -m Ordered -r ${mt_runs} -w ${warmup_seconds} -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt_ordered.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt_ordered.log"
     fi
 
     if [ "$benchmark" = "hyriseBenchmarkTPCC" ]; then

--- a/scripts/benchmark_all.sh
+++ b/scripts/benchmark_all.sh
@@ -17,7 +17,7 @@ benchmarks='hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkTPCC hyriseB
 warmup_seconds=1
 mt_shuffled_runtime=1200
 st_runs=50
-mt_runs=100
+mt_runs=100  # Used for MT runs and TPC-H SF 0.01 ST runs due to the very short runtimes.
 
 # Setting the number of clients used for the multi-threaded scenario to the machine's physical core count. This only
 # works for macOS and Linux. We do not use hyper-threads because the benchmark results are less stable on them. We

--- a/scripts/build_pgo_bolt.py
+++ b/scripts/build_pgo_bolt.py
@@ -37,7 +37,7 @@ from argparse import (
 from os import getcwd
 from subprocess import run
 
-if platform.system() != 'Linux':
+if platform.system() != "Linux":
     # Note: macOS support is possible but currently out of scope.
     print("PGO/BOLT builds have only been tested on Linux.")
     sys.exit(1)
@@ -82,7 +82,7 @@ parser.add_argument(
     "--import-profile",
     action=BooleanOptionalAction,
     default=False,
-    help="Do not run benchmarks, just import the profile data from the resources folder and build an optimized library."
+    help="Do not run benchmarks, just import profile data from the resources folder and build an optimized library.",
 )
 parser.add_argument(
     "-p", "--pgo", action=BooleanOptionalAction, default=True, help="Use PGO for profiling / optimization."
@@ -136,12 +136,12 @@ def build(
     run_in_build_folder(f"{args.build_system} clean")
     run_in_build_folder(
         "cmake",
-        f"-DCOMPILE_FOR_BOLT={"On" if bolt_instrument or bolt_optimize else "Off"}",
-        f"-DPGO_INSTRUMENT={"On" if pgo_instrument else "Off"}",
+        f"""-DCOMPILE_FOR_BOLT={"On" if bolt_instrument or bolt_optimize else "Off"}""",
+        f"""-DPGO_INSTRUMENT={"On" if pgo_instrument else "Off"}""",
         "-DPGO_OPTIMIZE=libhyrise.profdata" if pgo_optimize else "-UPGO_OPTIMIZE",
         "..",
     )
-    run_in_build_folder(f"{args.build_system} {" ".join(targets)} -j {args.num_cores}")
+    run_in_build_folder(f"""{args.build_system} {" ".join(targets)} -j {args.num_cores}""")
     if bolt_instrument:
         run_in_build_folder("mv lib/libhyrise_impl.so lib/libhyrise_impl_prebolt.so")
         run_in_build_folder("llvm-bolt lib/libhyrise_impl_prebolt.so -instrument -o lib/libhyrise_impl.so")
@@ -167,7 +167,7 @@ def build(
 # if it can be sure that itself build the proper library and no input files changed.
 def build_with_bolt_from_previous_build(*targets):
     run_in_build_folder("mv lib/libhyrise_impl_prebolt.so lib/libhyrise_impl.so")
-    run_in_build_folder(f"{args.build_system} {" ".join(targets)} -j {args.num_cores}")
+    run_in_build_folder(f"""{args.build_system} {" ".join(targets)} -j {args.num_cores}""")
     run_in_build_folder("mv lib/libhyrise_impl.so lib/libhyrise_impl_prebolt.so")
     run_in_build_folder(
         "llvm-bolt",

--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -325,8 +325,8 @@ for line_number, line in enumerate(lines):
     table_string_reformatted += line + "\n"
 
 
-# In case the runs for the executed benchmark have been cut or the runs were insufficient for the p-value calcution, we
-# add notes to the end of the table.
+# In case the runs for the executed benchmark have been cut or the runs were insufficient for the p-value calculation,
+# we add notes to the end of the table.
 if any(add_note_for_capped_runs, add_note_for_insufficient_pvalue_runs, add_note_for_high_variance_runs):
     first_column_width = len(lines[1].split("|")[1])
     width_for_note = len(lines[0]) - first_column_width - 5  # 5 for seperators and spaces

--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -60,14 +60,13 @@ def calculate_and_format_p_value(old_durations, new_durations):
         global add_note_for_insufficient_pvalue_runs
         add_note_for_insufficient_pvalue_runs = True
         return colored("˅", "yellow", attrs=["bold"])
+
     # The results for a query are considered to be statistically not significant if the runtime is unstable. In a normal
     # distribution, 68% of all values lie in an interval of `mean +/- standard deviation`. We do not want this interval
     # to be too wide. For now, we assume that this is the case if the standard deviation is higher than 15% of the mean
     # runtime, i.e., more than approximately one third of the measurements differs by more than 30% (compared to the
     # mean runtime).
-    elif old_deviation > max_deviation * np.mean(old_durations) or new_deviation > max_deviation * np.mean(
-        new_durations
-    ):
+    if old_deviation > max_deviation * np.mean(old_durations) or new_deviation > max_deviation * np.mean(new_durations):
         return "(deviation too high)"
 
     return colored(f"{p_value:.4f}", "white") if is_significant else colored(f"{p_value:.4f}", "yellow", attrs=["bold"])

--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -17,8 +17,7 @@ os.environ["FORCE_COLOR"] = "1"
 
 p_value_significance_threshold = 0.001
 min_iterations = 10
-min_runtime_ns = 59 * 1000 * 1000 * 1000
-min_iterations_disabling_min_runtime = 100
+max_deviation = 0.15
 
 
 def format_diff(diff):
@@ -51,30 +50,27 @@ def calculate_and_format_p_value(old_durations, new_durations):
     p_value = ttest_ind(old_durations, new_durations)[1]
     is_significant = p_value < p_value_significance_threshold
 
-    old_runtime = sum(runtime for runtime in old_durations)
-    new_runtime = sum(runtime for runtime in new_durations)
+    old_deviation = np.std(old_durations)
+    new_deviation = np.std(new_durations)
 
-    # The results for a query are considered to be statistically not significant if the runtime is too short. However,
-    # if the item has been executed > `min_iterations_disabling_min_runtime` times, it is considered significant.
-    if (old_runtime < min_runtime_ns or new_runtime < min_runtime_ns) and (
-        len(old_durations) < min_iterations_disabling_min_runtime
-        or len(new_durations) < min_iterations_disabling_min_runtime
-    ):
+    # If we cannot decide whether the change is significant due to an insufficient number of measurements, the
+    # `add_note_for_insufficient_pvalue_runs` flag it set, for which a note is later added to the table output.
+    if len(old_durations) < min_iterations or len(new_durations) < min_iterations:
         is_significant = False
-        return "(run time too short)"
-    elif len(old_durations) < min_iterations or len(new_durations) < min_iterations:
-        is_significant = False
-
-        # In case we cannot decide whether the change is significant due to an insufficient number of measurements, the
-        # add_note_for_insufficient_pvalue_runs flag it set, for which a note is later added to the table output.
         global add_note_for_insufficient_pvalue_runs
         add_note_for_insufficient_pvalue_runs = True
         return colored("˅", "yellow", attrs=["bold"])
-    else:
-        if is_significant:
-            return colored(f"{p_value:.4f}", "white")
-        else:
-            return colored(f"{p_value:.4f}", "yellow", attrs=["bold"])
+    # The results for a query are considered to be statistically not significant if the runtime is unstable. In a normal
+    # distribution, 68% of all values lie in an interval of `mean +/- standard deviation`. We do not want this interval
+    # to be too wide. For now, we assume that this is the case if the standard deviation is higher than 15% of the mean
+    # runtime, i.e., more than approximately one third of the measurements differs by more than 30% (compared to the
+    # mean runtime).
+    elif old_deviation > max_deviation * np.mean(old_durations) or new_deviation > max_deviation * np.mean(
+        new_durations
+    ):
+        return "(deviation too high)"
+
+    return colored(f"{p_value:.4f}", "white") if is_significant else colored(f"{p_value:.4f}", "yellow", attrs=["bold"])
 
 
 def create_context_overview(old_config, new_config, github_format):

--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -17,7 +17,7 @@ os.environ["FORCE_COLOR"] = "1"
 
 p_value_significance_threshold = 0.001
 min_iterations = 10
-max_deviation = 0.15
+cv_significance_threshold = 0.1
 
 
 def format_diff(diff):
@@ -50,9 +50,6 @@ def calculate_and_format_p_value(old_durations, new_durations):
     p_value = ttest_ind(old_durations, new_durations)[1]
     is_significant = p_value < p_value_significance_threshold
 
-    old_deviation = np.std(old_durations)
-    new_deviation = np.std(new_durations)
-
     # If we cannot decide whether the change is significant due to an insufficient number of measurements, the
     # `add_note_for_insufficient_pvalue_runs` flag it set, for which a note is later added to the table output.
     if len(old_durations) < min_iterations or len(new_durations) < min_iterations:
@@ -61,13 +58,14 @@ def calculate_and_format_p_value(old_durations, new_durations):
         add_note_for_insufficient_pvalue_runs = True
         return colored("˅", "yellow", attrs=["bold"])
 
-    # The results for a query are considered to be statistically not significant if the runtime is unstable. In a normal
-    # distribution, 68% of all values lie in an interval of `mean +/- standard deviation`. We do not want this interval
-    # to be too wide. For now, we assume that this is the case if the standard deviation is higher than 15% of the mean
-    # runtime, i.e., more than approximately one third of the measurements differs by more than 30% (compared to the
-    # mean runtime).
-    if old_deviation > max_deviation * np.mean(old_durations) or new_deviation > max_deviation * np.mean(new_durations):
-        return "(deviation too high)"
+    # The results for a query are considered to be statistically not significant if the runtime is unstable. To assess
+    # the variance, we use the coefficient of variation (C.V.): `C.V = standard deviation / mean`. If that value is
+    # higher than 10% (which seems to be a common value), we do not trust the p-value.
+    # For details, see https://www.geeksforgeeks.org/data-science/coefficient-of-variation-meaning-formula-and-examples
+    old_cv = np.std(old_durations) / np.mean(old_durations)
+    new_cv = np.std(new_durations) / np.mean(new_durations)
+    if old_cv > cv_significance_threshold or new_cv > cv_significance_threshold:
+        return "(variance too high)"
 
     return colored(f"{p_value:.4f}", "white") if is_significant else colored(f"{p_value:.4f}", "yellow", attrs=["bold"])
 

--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -65,7 +65,9 @@ def calculate_and_format_p_value(old_durations, new_durations):
     old_cv = np.std(old_durations) / np.mean(old_durations)
     new_cv = np.std(new_durations) / np.mean(new_durations)
     if old_cv > cv_significance_threshold or new_cv > cv_significance_threshold:
-        return "(variance too high)"
+        global add_note_for_high_variance_runs
+        add_note_for_high_variance_runs = True
+        return colored("*", "yellow", attrs=["bold"])
 
     return colored(f"{p_value:.4f}", "white") if is_significant else colored(f"{p_value:.4f}", "yellow", attrs=["bold"])
 
@@ -155,7 +157,8 @@ total_runtime_old = 0
 total_runtime_new = 0
 
 add_note_for_capped_runs = False  # Flag set when max query runs was set for benchmark run
-add_note_for_insufficient_pvalue_runs = False  # Flag set when runs was insufficient for p-value calculation
+add_note_for_insufficient_pvalue_runs = False  # Flag set when runs were insufficient for p-value calculation
+add_note_for_high_variance_runs = False  # Flag set when there was too much variance for p-value calculations
 
 
 # Create table header:
@@ -322,9 +325,9 @@ for line_number, line in enumerate(lines):
     table_string_reformatted += line + "\n"
 
 
-# In case the runs for the executed benchmark have been cut or the number of runs was insufficient for the p-value
-# calcution, we add notes to the end of the table.
-if add_note_for_capped_runs or add_note_for_insufficient_pvalue_runs:
+# In case the runs for the executed benchmark have been cut or the runs were insufficient for the p-value calcution, we
+# add notes to the end of the table.
+if any(add_note_for_capped_runs, add_note_for_insufficient_pvalue_runs, add_note_for_high_variance_runs):
     first_column_width = len(lines[1].split("|")[1])
     width_for_note = len(lines[0]) - first_column_width - 5  # 5 for seperators and spaces
     if add_note_for_capped_runs:
@@ -332,7 +335,10 @@ if add_note_for_capped_runs or add_note_for_insufficient_pvalue_runs:
         table_string_reformatted += "|" + (" Notes ".rjust(first_column_width, " "))
         table_string_reformatted += "|| " + note.ljust(width_for_note, " ") + "|\n"
     if add_note_for_insufficient_pvalue_runs:
-        note = "˅" + " Insufficient number of runs for p-value calculation"
+        note = "˅ Insufficient number of runs for p-value calculation"
+        table_string_reformatted += "|" + (" " * first_column_width) + "|| " + note.ljust(width_for_note, " ") + "|\n"
+    if add_note_for_high_variance_runs:
+        note = "* Variance of measurements is too high"
         table_string_reformatted += "|" + (" " * first_column_width) + "|| " + note.ljust(width_for_note, " ") + "|\n"
     table_string_reformatted += lines[-1] + "\n"
 

--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -59,7 +59,7 @@ def calculate_and_format_p_value(old_durations, new_durations):
         return colored("˅", "yellow", attrs=["bold"])
 
     # The results for a query are considered to be statistically not significant if the runtime is unstable. To assess
-    # the variance, we use the coefficient of variation (C.V.): `C.V = standard deviation / mean`. If that value is
+    # the variance, we use the coefficient of variation (CV): `CV = standard deviation / mean`. If that value is
     # higher than 10% (which seems to be a common value), we do not trust the p-value.
     # For details, see https://www.geeksforgeeks.org/data-science/coefficient-of-variation-meaning-formula-and-examples
     old_cv = np.std(old_durations) / np.mean(old_durations)

--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -327,7 +327,7 @@ for line_number, line in enumerate(lines):
 
 # In case the runs for the executed benchmark have been cut or the runs were insufficient for the p-value calculation,
 # we add notes to the end of the table.
-if any(add_note_for_capped_runs, add_note_for_insufficient_pvalue_runs, add_note_for_high_variance_runs):
+if add_note_for_capped_runs or add_note_for_insufficient_pvalue_runs or add_note_for_high_variance_runs:
     first_column_width = len(lines[1].split("|")[1])
     width_for_note = len(lines[0]) - first_column_width - 5  # 5 for seperators and spaces
     if add_note_for_capped_runs:


### PR DESCRIPTION
Currently, the p-values are rarely shown when we run `benchmark_all.sh`. See, for instance, https://github.com/hyrise/hyrise/pull/2757#issuecomment-4807709027.

The problem is that we consider the runtime "too short" if all runs in sum are less than 59s and the item was executed less than 100 times. `benchmark_all.sh`, however, executes each query for at most 60s (*without* taking any result after 60s into account) or for 50 times (ordered benchmarks). Thus, we rarely hit the threshold by chance.

This PR changes this behavior. Now, we plot p-values if the measurements are not too unstable. Independently of the overall execution time and number of runs, we consider the measurements stable if the standard deviation is smaller than 15% of the reported mean runtime, i.e., at least ≈⅔ of the measurements lie in a +/- 15% interval around the mean.

That definition is pretty arbitrary, though. We could also reason about the width of some actual percentiles, for instance.  