### PR TITLE
WIP: clang-tidy experiment in FullCI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,8 +160,11 @@ try {
             stage("Linting") {
               sh "scripts/lint.sh"
             }
+          }, clangDebugTidy: {
+            stage("clang-debug:tidy-changed-files") {
+              sh "CLANG_TIDY_DEBUG=1 bash ./scripts/clang_tidy.sh clang-debug-tidy"
+            }
           }
-
           // We distribute the cores to processes in a way to even the running times. With an even distributions,
           // clang-tidy builds take up to 3h (galileo server). In addition to compile time, the distribution also
           // considers the long test runtimes of clangRelWithDebInfoThreadSanitizer (~50 minutes).
@@ -228,12 +231,8 @@ try {
             }
           }, clangDebugTidy: {
             stage("clang-debug:tidy-changed-files") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                // We do not run the expensive clang-tidy for the non-changed files.
-                sh "CLANG_TIDY_DEBUG=1 bash ./scripts/clang_tidy.sh clang-debug-tidy"
-              } else {
-                Utils.markStageSkippedForConditional("clangDebugTidy")
-              }
+              def allInc = pullRequest != null && pullRequest.labels.contains('Refactor')
+              sh "CLANG_TIDY_ALL_INCLUDERS=${allInc ? 1 : 0} CLANG_TIDY_DEBUG=1 bash ./scripts/clang_tidy.sh clang-debug-tidy"
             }
           }, clangDebugDisablePrecompileHeaders: {
             stage("clang-debug:disable-precompile-headers") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,7 +121,7 @@ try {
 
             // Configure the rest in parallel. We use unity builds to decrease build times. The only exceptions are the
             // clang-tidy and precompiled-headers build as they might otherwise miss some issues (e.g., missing includes).
-            sh "mkdir clang-debug-tidy && cd clang-debug-tidy &&                                         ${cmake} ${debug}          ${clang}                      ${ninja} -DENABLE_CLANG_TIDY=ON .. &\
+            sh "mkdir clang-debug-tidy && cd clang-debug-tidy &&                                         ${cmake} ${debug}          ${clang}                      ${ninja} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_DISABLE_PRECOMPILE_HEADERS=On .. &\
             mkdir clang-debug-unity-odr && cd clang-debug-unity-odr &&                                   ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DCMAKE_UNITY_BUILD_BATCH_SIZE=0 .. &\
             mkdir clang-debug-disable-precompile-headers && cd clang-debug-disable-precompile-headers && ${cmake} ${debug}          ${clang}                      ${ninja} -DCMAKE_DISABLE_PRECOMPILE_HEADERS=On .. &\
             mkdir clang-debug-addr-ub-leak-sanitizers && cd clang-debug-addr-ub-leak-sanitizers &&       ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DENABLE_ADDR_UB_LEAK_SANITIZATION=ON .. &\
@@ -227,10 +227,10 @@ try {
               }
             }
           }, clangDebugTidy: {
-            stage("clang-debug:tidy") {
+            stage("clang-debug:tidy-changed-files") {
               if (env.BRANCH_NAME == 'master' || full_ci) {
-                // We do not run tidy checks on the src/test folder, so there is no point in running the expensive clang-tidy for those files
-                sh "cd clang-debug-tidy && ninja hyrise_impl hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer hyriseMvccDeletePlugin hyriseUccDiscoveryPlugin -k 0 -j \$(( \$(nproc) / 2))"
+                // We do not run the expensive clang-tidy for the non-changed files.
+                sh "CLANG_TIDY_DEBUG=1 bash ./scripts/clang_tidy.sh clang-debug-tidy"
               } else {
                 Utils.markStageSkippedForConditional("clangDebugTidy")
               }

--- a/scripts/clang_tidy.sh
+++ b/scripts/clang_tidy.sh
@@ -1,19 +1,12 @@
 #!/bin/bash
-# Run clang-tidy only on the files a PR changed, for fast CI feedback.
-#
-# Selection:
-#   * every changed .cpp is analyzed;
-#   * For a changed header (.hpp/.ipp), we analyze ONE representative
-#     direct includer. A header is not its own translation unit, so it can only be
-#     analyzed through a .cpp that includes it. 
-#   * CLANG_TIDY_ALL_INCLUDERS=1 (the
-#     "Refactor" label) analyzes all direct includers instead.
+# Run clang-tidy only on files changed in a PR, for faster CI feedback.
+# A changed header is checked via a .cpp that includes it: the first one found,
+# or all of them when CLANG_TIDY_ALL_INCLUDERS=1 (set by the "Refactor" label).
 #
 # Env:
-#   CLANG_TIDY_ALL_INCLUDERS=1  expand headers to all includers (Refactor label)
+#   CLANG_TIDY_ALL_INCLUDERS=1  check all includers of a changed header
 #   CLANG_TIDY_DIFF_BASE=<ref>  override the diff base (local dev)
-#   CLANG_TIDY_DEBUG=1          verbose selection diagnostics
-
+#   CLANG_TIDY_DEBUG=1          print the selected files
 set -o pipefail
 
 build_dir="${1:-clang-debug-tidy}"
@@ -22,34 +15,19 @@ jobs="${2:-$(( $(nproc) / 4 ))}"
 all_includers="${CLANG_TIDY_ALL_INCLUDERS:-0}"
 debug="${CLANG_TIDY_DEBUG:-0}"
 
-command -v clang-tidy >/dev/null || { echo "FATAL: clang-tidy not on PATH"; exit 1; }
 [ -f "$build_dir/compile_commands.json" ] || {
-  echo "FATAL: no compile_commands.json in $build_dir"
-  echo "       (configure it with -DCMAKE_EXPORT_COMPILE_COMMANDS=ON)"; exit 1; }
+  echo "FATAL: no compile_commands.json in $build_dir (need -DCMAKE_EXPORT_COMPILE_COMMANDS=ON)"; exit 1; }
 
-# version.hpp is generated at build time; build just that target so the one TU
-# including it can be parsed without a full build.
-[ -f "$build_dir/build.ninja" ] && ninja -C "$build_dir" version.hpp >/dev/null 2>&1
-
-# --- diff base -------------------------------------------------------------
-#   master builds: diff against the previous state of master (what the latest
-#                  merge introduced); branch/PR builds: merge-base with master.
+# Diff base: previous commit on master, else the merge-base with master.
 if [ -n "$CLANG_TIDY_DIFF_BASE" ]; then
   base="$CLANG_TIDY_DIFF_BASE"
 elif [ "$BRANCH_NAME" = "master" ]; then
-  if [ -n "$GIT_PREVIOUS_SUCCESSFUL_COMMIT" ] \
-     && git cat-file -e "$GIT_PREVIOUS_SUCCESSFUL_COMMIT" 2>/dev/null; then
-    base="$GIT_PREVIOUS_SUCCESSFUL_COMMIT"
-  else
-    base=$(git rev-parse HEAD^1)
-  fi
+  base=$(git rev-parse HEAD^1)
 else
   git fetch --no-tags --quiet origin master
   base=$(git merge-base FETCH_HEAD HEAD)
 fi
-[ "$debug" = 1 ] && echo "[debug] diff base: $base  (all_includers=$all_includers, jobs=$jobs)"
 
-# Changed, tidy-relevant files:
 changed=$( { git diff --diff-filter=d --name-only "$base"; \
              git ls-files --others --exclude-standard; } \
            | grep -E '^src/.*\.[chi]pp$' | grep -v '^src/test' | sort -u )
@@ -58,55 +36,22 @@ changed=$( { git diff --diff-filter=d --name-only "$base"; \
 cpps=$(echo "$changed" | grep '\.cpp$')
 hdrs=$(echo "$changed" | grep -E '\.[hi]pp$')
 
-# Get a header's rooted include spelling.
-# NOTE: sed delimiter is '#', not '|' -- '|' would clash with the alternation.
-rooted_spelling() { printf '%s' "$1" | sed -E 's#^src/(lib|bin|benchmarklib|plugins)/##'; }
-
-# Resolve a header's direct .cpp includers:
-includers_of() {
-  local h="$1" rooted dir base_name
-  rooted=$(rooted_spelling "$h")
-  dir=$(dirname "$h"); base_name=$(basename "$h")
-  {
-    grep -rlF "#include \"$rooted\"" \
-         src/lib src/bin src/benchmarklib src/plugins --include=*.cpp 2>/dev/null
-    grep -lF "#include \"$base_name\"" "$dir"/*.cpp 2>/dev/null
-  } | grep -v '^src/test' | sort -u
-}
-
-# Expand headers to includers
+# For each changed header, find .cpp files that mention it and add the first
+# one (or all of them in Refactor mode).
 for h in $hdrs; do
-  inc=$(includers_of "$h")
-  if [ -z "$inc" ]; then
-    [ "$debug" = 1 ] && echo "[debug] header $h -> no .cpp includer (skipped)"
-    continue
-  fi
-  if [ "$all_includers" = 1 ]; then
-    [ "$debug" = 1 ] && echo "[debug] header $h -> $(echo "$inc" | grep -c .) includer(s) [all]"
-    cpps=$(printf '%s\n%s' "$cpps" "$inc")
-  else
-    one=$(echo "$inc" | head -n 1)
-    [ "$debug" = 1 ] && echo "[debug] header $h -> representative TU: $one"
-    cpps=$(printf '%s\n%s' "$cpps" "$one")
-  fi
+  inc=$(grep -rlF "$(basename "$h")" src --include=*.cpp | grep -v '^src/test' | sort)
+  [ -z "$inc" ] && continue
+  [ "$all_includers" = 1 ] || inc=$(echo "$inc" | head -n 1)
+  cpps=$(printf '%s\n%s' "$cpps" "$inc")
 done
 cpps=$(printf '%s\n' "$cpps" | grep -v '^$' | sort -u)
-[ -z "$cpps" ] && { echo "No .cpp translation units to analyze."; exit 0; }
+[ -z "$cpps" ] && { echo "No translation units to analyze."; exit 0; }
 
-# Header-filter: attribute findings to the changed headers only:
-hf=$(for h in $hdrs; do rooted_spelling "$h"; echo; done \
-     | grep -v '^$' \
-     | sed 's/[.^$*+?()|{}[]/\\&/g' \
-     | paste -sd'|' -)
+# Restrict header diagnostics to the changed headers.
+hf=$(for h in $hdrs; do basename "$h"; done | paste -sd'|' -)
 
-n_tu=$(printf '%s\n' "$cpps" | grep -c .)
-if [ "$debug" = 1 ]; then
-  echo "[debug] header-filter: [${hf}]"
-  echo "[debug] translation units to analyze: $n_tu"
-  printf '%s\n' "$cpps" | sed 's/^/  run: /'
-fi
+[ "$debug" = 1 ] && { echo "[debug] base=$base  tus=$(echo "$cpps" | grep -c .)"; echo "$cpps" | sed 's/^/  /'; }
 
-# Run and report findings.
 printf '%s\n' "$cpps" | xargs -r -P "$jobs" -n 1 \
   clang-tidy -p "$build_dir" --quiet --warnings-as-errors='*' \
   ${hf:+--header-filter="($hf)\$"}

--- a/scripts/clang_tidy.sh
+++ b/scripts/clang_tidy.sh
@@ -1,19 +1,42 @@
 #!/bin/bash
-set -o pipefail
-build_dir="${1:-clang-debug-tidy}"
+# Run clang-tidy only on the files a PR changed, for fast CI feedback.
+#
+# Selection:
+#   * every changed .cpp is analyzed;
+#   * For a changed header (.hpp/.ipp), we analyze ONE representative
+#     direct includer. A header is not its own translation unit, so it can only be
+#     analyzed through a .cpp that includes it. 
+#   * CLANG_TIDY_ALL_INCLUDERS=1 (the
+#     "Refactor" label) analyzes all direct includers instead.
+#
+# Env:
+#   CLANG_TIDY_ALL_INCLUDERS=1  expand headers to all includers (Refactor label)
+#   CLANG_TIDY_DIFF_BASE=<ref>  override the diff base (local dev)
+#   CLANG_TIDY_DEBUG=1          verbose selection diagnostics
 
-# Set CLANG_TIDY_DEBUG=1 for verbose diagnostics.
+set -o pipefail
+
+build_dir="${1:-clang-debug-tidy}"
+jobs="${2:-$(( $(nproc) / 4 ))}"
+[ "$jobs" -lt 1 ] && jobs=1
+all_includers="${CLANG_TIDY_ALL_INCLUDERS:-0}"
 debug="${CLANG_TIDY_DEBUG:-0}"
 
-# Determine diff base:
-#  - master builds: diff against the previous state of master, so we tidy
-#    exactly what the latest merge introduced.
-#  - branch/PR builds: diff against the merge-base with origin/master.
+command -v clang-tidy >/dev/null || { echo "FATAL: clang-tidy not on PATH"; exit 1; }
+[ -f "$build_dir/compile_commands.json" ] || {
+  echo "FATAL: no compile_commands.json in $build_dir"
+  echo "       (configure it with -DCMAKE_EXPORT_COMPILE_COMMANDS=ON)"; exit 1; }
+
+# version.hpp is generated at build time; build just that target so the one TU
+# including it can be parsed without a full build.
+[ -f "$build_dir/build.ninja" ] && ninja -C "$build_dir" version.hpp >/dev/null 2>&1
+
+# --- diff base -------------------------------------------------------------
+#   master builds: diff against the previous state of master (what the latest
+#                  merge introduced); branch/PR builds: merge-base with master.
 if [ -n "$CLANG_TIDY_DIFF_BASE" ]; then
   base="$CLANG_TIDY_DIFF_BASE"
 elif [ "$BRANCH_NAME" = "master" ]; then
-  # Prefer the last successfully built commit (covers multi-commit pushes);
-  # fall back to first parent.
   if [ -n "$GIT_PREVIOUS_SUCCESSFUL_COMMIT" ] \
      && git cat-file -e "$GIT_PREVIOUS_SUCCESSFUL_COMMIT" 2>/dev/null; then
     base="$GIT_PREVIOUS_SUCCESSFUL_COMMIT"
@@ -24,8 +47,9 @@ else
   git fetch --no-tags --quiet origin master
   base=$(git merge-base FETCH_HEAD HEAD)
 fi
-[ "$debug" = 1 ] && echo "[debug] diff base: $base"
+[ "$debug" = 1 ] && echo "[debug] diff base: $base  (all_includers=$all_includers, jobs=$jobs)"
 
+# Changed, tidy-relevant files:
 changed=$( { git diff --diff-filter=d --name-only "$base"; \
              git ls-files --others --exclude-standard; } \
            | grep -E '^src/.*\.[chi]pp$' | grep -v '^src/test' | sort -u )
@@ -34,63 +58,55 @@ changed=$( { git diff --diff-filter=d --name-only "$base"; \
 cpps=$(echo "$changed" | grep '\.cpp$')
 hdrs=$(echo "$changed" | grep -E '\.[hi]pp$')
 
-if [ "$debug" = 1 ]; then
-  echo "[debug] changed tidy-relevant files:"
-  echo "$changed" | sed 's/^/  /'
-  echo "[debug] directly changed .cpp: $(echo "$cpps" | grep -c .)"
-  echo "[debug] changed headers/.ipp:  $(echo "$hdrs" | grep -c .)"
-fi
+# Get a header's rooted include spelling.
+# NOTE: sed delimiter is '#', not '|' -- '|' would clash with the alternation.
+rooted_spelling() { printf '%s' "$1" | sed -E 's#^src/(lib|bin|benchmarklib|plugins)/##'; }
 
-# Header/ipp → direct includers. Hyrise includes are rooted at src/lib etc.,
+# Resolve a header's direct .cpp includers:
+includers_of() {
+  local h="$1" rooted dir base_name
+  rooted=$(rooted_spelling "$h")
+  dir=$(dirname "$h"); base_name=$(basename "$h")
+  {
+    grep -rlF "#include \"$rooted\"" \
+         src/lib src/bin src/benchmarklib src/plugins --include=*.cpp 2>/dev/null
+    grep -lF "#include \"$base_name\"" "$dir"/*.cpp 2>/dev/null
+  } | grep -v '^src/test' | sort -u
+}
+
+# Expand headers to includers
 for h in $hdrs; do
-  inc=$(echo "$h" | sed -E 's|^src/(lib\|bin\|benchmarklib\|plugins)/||')
-  includers=$(grep -rlE "#include \"$inc\"" src/lib src/bin src/benchmarklib src/plugins | grep '\.cpp$')
-  [ "$debug" = 1 ] && echo "[debug] header $h -> $(echo "$includers" | grep -c .) direct .cpp includer(s)"
-  cpps=$(printf "%s\n%s" "$cpps" "$includers")
+  inc=$(includers_of "$h")
+  if [ -z "$inc" ]; then
+    [ "$debug" = 1 ] && echo "[debug] header $h -> no .cpp includer (skipped)"
+    continue
+  fi
+  if [ "$all_includers" = 1 ]; then
+    [ "$debug" = 1 ] && echo "[debug] header $h -> $(echo "$inc" | grep -c .) includer(s) [all]"
+    cpps=$(printf '%s\n%s' "$cpps" "$inc")
+  else
+    one=$(echo "$inc" | head -n 1)
+    [ "$debug" = 1 ] && echo "[debug] header $h -> representative TU: $one"
+    cpps=$(printf '%s\n%s' "$cpps" "$one")
+  fi
 done
-cpps=$(echo "$cpps" | grep -v '^$' | sort -u)
-[ -z "$cpps" ] && { echo "Changed headers have no direct .cpp includers."; exit 0; }
+cpps=$(printf '%s\n' "$cpps" | grep -v '^$' | sort -u)
+[ -z "$cpps" ] && { echo "No .cpp translation units to analyze."; exit 0; }
 
-# Restrict header diagnostics to the *changed* headers only.
-hf=$(echo "$hdrs" | sed -E 's|^src/(lib\|bin\|benchmarklib\|plugins)/||' | paste -sd'|' -)
+# Header-filter: attribute findings to the changed headers only:
+hf=$(for h in $hdrs; do rooted_spelling "$h"; echo; done \
+     | grep -v '^$' \
+     | sed 's/[.^$*+?()|{}[]/\\&/g' \
+     | paste -sd'|' -)
 
-n_tu=$(echo "$cpps" | grep -c .)
+n_tu=$(printf '%s\n' "$cpps" | grep -c .)
 if [ "$debug" = 1 ]; then
   echo "[debug] header-filter: [${hf}]"
-  if [ -f "$build_dir/compile_commands.json" ] && command -v jq >/dev/null; then
-    echo "[debug] compile_commands.json entries: $(jq length "$build_dir/compile_commands.json")"
-  else
-    echo "[debug] compile_commands.json: missing or jq unavailable at $build_dir"
-  fi
   echo "[debug] translation units to analyze: $n_tu"
-  echo "$cpps" | sed 's/^/  run: /'
+  printf '%s\n' "$cpps" | sed 's/^/  run: /'
 fi
 
-# --- Run tidy ---------------------------------------------------------------
-if [ "$debug" = 1 ]; then
-  # Capture per-file output so we can summarize what actually fired.
-  log_dir=$(mktemp -d)
-  echo "$cpps" | xargs -r -P "$(nproc)" -n 1 -I{} \
-    bash -c 'f="$1"; ld="$2"; bd="$3"; hf="$4";
-             out="$ld/$(echo "$f" | tr / _).log";
-             if [ -n "$hf" ]; then
-               clang-tidy -p "$bd" --quiet --header-filter="($hf)\$" "$f" >"$out" 2>&1
-             else
-               clang-tidy -p "$bd" --quiet "$f" >"$out" 2>&1
-             fi
-             echo "  $f: exit=$? lines=$(wc -l <"$out")"' _ {} "$log_dir" "$build_dir" "$hf"
-  rc=$?
-
-  echo "=== per-check breakdown (deduplicated by check name) ==="
-  cat "$log_dir"/*.log 2>/dev/null \
-    | grep -oE '\[[a-z0-9]+(-[a-z0-9]+)*(,[a-z0-9-]+)*\]$' \
-    | sort | uniq -c | sort -rn
-  echo "=== unique (file:line:col: severity) findings ==="
-  cat "$log_dir"/*.log 2>/dev/null | grep -E ': (warning|error):' | sort -u | wc -l
-  echo "[debug] per-file logs in: $log_dir"
-  exit "$rc"
-else
-  echo "$cpps" | xargs -r -P "$(nproc)" -n 1 \
-    clang-tidy -p "$build_dir" --quiet --warnings-as-errors='*' \
-    ${hf:+--header-filter="($hf)\$"}
-fi
+# Run and report findings.
+printf '%s\n' "$cpps" | xargs -r -P "$jobs" -n 1 \
+  clang-tidy -p "$build_dir" --quiet --warnings-as-errors='*' \
+  ${hf:+--header-filter="($hf)\$"}

--- a/scripts/clang_tidy.sh
+++ b/scripts/clang_tidy.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+set -o pipefail
+build_dir="${1:-clang-debug-tidy}"
+
+# Set CLANG_TIDY_DEBUG=1 for verbose diagnostics.
+debug="${CLANG_TIDY_DEBUG:-0}"
+
+# Determine diff base:
+#  - master builds: diff against the previous state of master, so we tidy
+#    exactly what the latest merge introduced.
+#  - branch/PR builds: diff against the merge-base with origin/master.
+if [ -n "$CLANG_TIDY_DIFF_BASE" ]; then
+  base="$CLANG_TIDY_DIFF_BASE"
+elif [ "$BRANCH_NAME" = "master" ]; then
+  # Prefer the last successfully built commit (covers multi-commit pushes);
+  # fall back to first parent.
+  if [ -n "$GIT_PREVIOUS_SUCCESSFUL_COMMIT" ] \
+     && git cat-file -e "$GIT_PREVIOUS_SUCCESSFUL_COMMIT" 2>/dev/null; then
+    base="$GIT_PREVIOUS_SUCCESSFUL_COMMIT"
+  else
+    base=$(git rev-parse HEAD^1)
+  fi
+else
+  git fetch --no-tags --quiet origin master
+  base=$(git merge-base FETCH_HEAD HEAD)
+fi
+[ "$debug" = 1 ] && echo "[debug] diff base: $base"
+
+changed=$( { git diff --diff-filter=d --name-only "$base"; \
+             git ls-files --others --exclude-standard; } \
+           | grep -E '^src/.*\.[chi]pp$' | grep -v '^src/test' | sort -u )
+[ -z "$changed" ] && { echo "No tidy-relevant files changed."; exit 0; }
+
+cpps=$(echo "$changed" | grep '\.cpp$')
+hdrs=$(echo "$changed" | grep -E '\.[hi]pp$')
+
+if [ "$debug" = 1 ]; then
+  echo "[debug] changed tidy-relevant files:"
+  echo "$changed" | sed 's/^/  /'
+  echo "[debug] directly changed .cpp: $(echo "$cpps" | grep -c .)"
+  echo "[debug] changed headers/.ipp:  $(echo "$hdrs" | grep -c .)"
+fi
+
+# Header/ipp → direct includers. Hyrise includes are rooted at src/lib etc.,
+for h in $hdrs; do
+  inc=$(echo "$h" | sed -E 's|^src/(lib\|bin\|benchmarklib\|plugins)/||')
+  includers=$(grep -rlE "#include \"$inc\"" src/lib src/bin src/benchmarklib src/plugins | grep '\.cpp$')
+  [ "$debug" = 1 ] && echo "[debug] header $h -> $(echo "$includers" | grep -c .) direct .cpp includer(s)"
+  cpps=$(printf "%s\n%s" "$cpps" "$includers")
+done
+cpps=$(echo "$cpps" | grep -v '^$' | sort -u)
+[ -z "$cpps" ] && { echo "Changed headers have no direct .cpp includers."; exit 0; }
+
+# Restrict header diagnostics to the *changed* headers only.
+hf=$(echo "$hdrs" | sed -E 's|^src/(lib\|bin\|benchmarklib\|plugins)/||' | paste -sd'|' -)
+
+n_tu=$(echo "$cpps" | grep -c .)
+if [ "$debug" = 1 ]; then
+  echo "[debug] header-filter: [${hf}]"
+  if [ -f "$build_dir/compile_commands.json" ] && command -v jq >/dev/null; then
+    echo "[debug] compile_commands.json entries: $(jq length "$build_dir/compile_commands.json")"
+  else
+    echo "[debug] compile_commands.json: missing or jq unavailable at $build_dir"
+  fi
+  echo "[debug] translation units to analyze: $n_tu"
+  echo "$cpps" | sed 's/^/  run: /'
+fi
+
+# --- Run tidy ---------------------------------------------------------------
+if [ "$debug" = 1 ]; then
+  # Capture per-file output so we can summarize what actually fired.
+  log_dir=$(mktemp -d)
+  echo "$cpps" | xargs -r -P "$(nproc)" -n 1 -I{} \
+    bash -c 'f="$1"; ld="$2"; bd="$3"; hf="$4";
+             out="$ld/$(echo "$f" | tr / _).log";
+             if [ -n "$hf" ]; then
+               clang-tidy -p "$bd" --quiet --header-filter="($hf)\$" "$f" >"$out" 2>&1
+             else
+               clang-tidy -p "$bd" --quiet "$f" >"$out" 2>&1
+             fi
+             echo "  $f: exit=$? lines=$(wc -l <"$out")"' _ {} "$log_dir" "$build_dir" "$hf"
+  rc=$?
+
+  echo "=== per-check breakdown (deduplicated by check name) ==="
+  cat "$log_dir"/*.log 2>/dev/null \
+    | grep -oE '\[[a-z0-9]+(-[a-z0-9]+)*(,[a-z0-9-]+)*\]$' \
+    | sort | uniq -c | sort -rn
+  echo "=== unique (file:line:col: severity) findings ==="
+  cat "$log_dir"/*.log 2>/dev/null | grep -E ': (warning|error):' | sort -u | wc -l
+  echo "[debug] per-file logs in: $log_dir"
+  exit "$rc"
+else
+  echo "$cpps" | xargs -r -P "$(nproc)" -n 1 \
+    clang-tidy -p "$build_dir" --quiet --warnings-as-errors='*' \
+    ${hf:+--header-filter="($hf)\$"}
+fi

--- a/src/lib/operators/abstract_operator.cpp
+++ b/src/lib/operators/abstract_operator.cpp
@@ -31,6 +31,7 @@
 
 namespace hyrise {
 
+
 AbstractOperator::AbstractOperator(const OperatorType type, const std::shared_ptr<const AbstractOperator>& left,
                                    const std::shared_ptr<const AbstractOperator>& right,
                                    std::unique_ptr<AbstractOperatorPerformanceData> init_performance_data)

--- a/src/lib/operators/sort.cpp
+++ b/src/lib/operators/sort.cpp
@@ -29,7 +29,6 @@
 #include "utils/assert.hpp"
 #include "utils/timer.hpp"
 
-
 namespace {
 
 using namespace hyrise;

--- a/src/lib/operators/sort.cpp
+++ b/src/lib/operators/sort.cpp
@@ -29,6 +29,7 @@
 #include "utils/assert.hpp"
 #include "utils/timer.hpp"
 
+
 namespace {
 
 using namespace hyrise;

--- a/src/lib/operators/sort.cpp
+++ b/src/lib/operators/sort.cpp
@@ -53,6 +53,9 @@ std::shared_ptr<Table> write_materialized_output_table(const std::shared_ptr<con
 
   const auto output_chunk_count = div_ceil(pos_list.size(), output_chunk_size);
   Assert(pos_list.size() == unsorted_table->row_count(), "Mismatching size of input table and PosList");
+  
+  int unused_var = 35;
+  std::string unused_string = "This is an unused string variable. It's meant to be very long as well to create a long line, frankly I haven't checked what's the limit; I would have assumed 100, but the prior line is >100 already";
 
   // Vector of segments for each chunk
   auto output_segments_by_chunk = std::vector<Segments>{output_chunk_count};

--- a/src/lib/operators/sort.cpp
+++ b/src/lib/operators/sort.cpp
@@ -53,9 +53,7 @@ std::shared_ptr<Table> write_materialized_output_table(const std::shared_ptr<con
 
   const auto output_chunk_count = div_ceil(pos_list.size(), output_chunk_size);
   Assert(pos_list.size() == unsorted_table->row_count(), "Mismatching size of input table and PosList");
-  
-  int unused_var = 35;
-  std::string unused_string = "This is an unused string variable. It's meant to be very long as well to create a long line, frankly I haven't checked what's the limit; I would have assumed 100, but the prior line is >100 already";
+
 
   // Vector of segments for each chunk
   auto output_segments_by_chunk = std::vector<Segments>{output_chunk_count};

--- a/src/lib/types.hpp
+++ b/src/lib/types.hpp
@@ -38,6 +38,7 @@ STRONG_TYPEDEF(uint32_t, WorkerID);
 STRONG_TYPEDEF(uint32_t, TaskID);
 STRONG_TYPEDEF(uint32_t, ChunkOffset);
 
+
 // When changing the following two strong typedefs to 64-bit types, please be aware that both are used with
 // std::atomics and not all platforms that Hyrise runs on support atomic 64-bit instructions. Any Intel and AMD CPU
 // since 2010 should work fine. For 64-bit atomics on ARM CPUs, the instruction set should be at least ARMv8.1-A.

--- a/src/lib/types.hpp
+++ b/src/lib/types.hpp
@@ -254,6 +254,7 @@ inline bool operator==(const SortColumnDefinition& lhs, const SortColumnDefiniti
   return lhs.column == rhs.column && lhs.sort_mode == rhs.sort_mode;
 }
 
+
 class Noncopyable {
  public:
   Noncopyable(const Noncopyable&) = delete;

--- a/src/lib/types.hpp
+++ b/src/lib/types.hpp
@@ -38,7 +38,6 @@ STRONG_TYPEDEF(uint32_t, WorkerID);
 STRONG_TYPEDEF(uint32_t, TaskID);
 STRONG_TYPEDEF(uint32_t, ChunkOffset);
 
-
 // When changing the following two strong typedefs to 64-bit types, please be aware that both are used with
 // std::atomics and not all platforms that Hyrise runs on support atomic 64-bit instructions. Any Intel and AMD CPU
 // since 2010 should work fine. For 64-bit atomics on ARM CPUs, the instruction set should be at least ARMv8.1-A.


### PR DESCRIPTION
This PR is experimenting with shorting clangDebugTidy's time. Previously it ran on the entire build regardless of the diff; this PR moves it to run only on changed files.

**Before**

A 1–2 line change triggered a full 2h 27m clangDebugTidy run.

**After**

A test edit in in one CPP file: ~4 min.
Typical PR (a handful of files affected): under ~10 min.

**Open question**

Should a changed header trigger checks on all .cpp files that include it?

Testing the worst case:

Changing a commonly-included header (244 translation units) took around 2h 20m. Observing the debug logs, we can note that they stalled between roughly the 20m and 1h30m marks. I think it looks like resource contention rather than tidy itself being slow. But nonetheless, it seems like 1-2 hours of unnecessary cost we can avoid.

Observation:

For a changed header, one translation unit is enough to lint the header's own code. A header is analyzed through an including .cpp, and re-checking it via every includer mostly reproduces the same diagnostics (with a few exceptions).

**Decision**

On every run (including Full CI), clangDebugTidy checks one representative translation unit per changed header.
With a Refactor label, it expands to all direct includers, for changes where cross-file effects matter.

Tested including one translation unit per changed header reduced the clangDebugTidy run from 2h 20m to <4 minutes.

**Pipeline position**
I also tested running the stage earlier in the pipeline. Its standalone runtime didn't change meaningfully by moving it, so there's no cost to doing so. But there's a clear benefit in having it earlier: failing fast on a lint-class error is better than discovering it after a long wait. So, let's keep it in the early phase.

**When to run?**
After moving it earlier in the pipeline and ensuring its cost is minimal, I think it's okay to run it even when the fullCI label is not added.
