### PR TITLE
Change clangDebugTidy run in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,7 +121,7 @@ try {
 
             // Configure the rest in parallel. We use unity builds to decrease build times. The only exceptions are the
             // clang-tidy and precompiled-headers build as they might otherwise miss some issues (e.g., missing includes).
-            sh "mkdir clang-debug-tidy && cd clang-debug-tidy &&                                         ${cmake} ${debug}          ${clang}                      ${ninja} -DENABLE_CLANG_TIDY=ON .. &\
+            sh "mkdir clang-debug-tidy && cd clang-debug-tidy &&                                         ${cmake} ${debug}          ${clang}                      ${ninja} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_DISABLE_PRECOMPILE_HEADERS=On .. &\
             mkdir clang-debug-unity-odr && cd clang-debug-unity-odr &&                                   ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DCMAKE_UNITY_BUILD_BATCH_SIZE=0 .. &\
             mkdir clang-debug-disable-precompile-headers && cd clang-debug-disable-precompile-headers && ${cmake} ${debug}          ${clang}                      ${ninja} -DCMAKE_DISABLE_PRECOMPILE_HEADERS=On .. &\
             mkdir clang-debug-addr-ub-leak-sanitizers && cd clang-debug-addr-ub-leak-sanitizers &&       ${cmake} ${debug}          ${clang}   ${unity}           ${ninja} -DENABLE_ADDR_UB_LEAK_SANITIZATION=ON .. &\
@@ -138,27 +138,31 @@ try {
           parallel clangDebug: {
             stage("clang-debug") {
               // We build clang-debug using make to test make once (and clang-debug is the fastest build).
-              sh "cd clang-debug && make all -j \$(( \$(nproc) / 4))"
+              sh "cd clang-debug && make all -j \$(( \$(nproc) / 5))"
               sh "./clang-debug/hyriseTest clang-debug"
             }
           }, clang19Debug: {
             stage("clang-19-debug") {
-              sh "cd clang-19-debug && ninja all -j \$(( \$(nproc) / 4))"
+              sh "cd clang-19-debug && ninja all -j \$(( \$(nproc) / 5))"
               sh "./clang-19-debug/hyriseTest clang-19-debug"
             }
           }, gccDebug: {
             stage("gcc-debug") {
-              sh "cd gcc-debug && ninja all -j \$(( \$(nproc) / 4))"
+              sh "cd gcc-debug && ninja all -j \$(( \$(nproc) / 5))"
               sh "cd gcc-debug && ./hyriseTest"
             }
           }, gcc13Debug: {
             stage("gcc-13-debug") {
-              sh "cd gcc-13-debug && ninja all -j \$(( \$(nproc) / 4))"
+              sh "cd gcc-13-debug && ninja all -j \$(( \$(nproc) / 5))"
               sh "cd gcc-13-debug && ./hyriseTest"
             }
           }, lint: {
             stage("Linting") {
               sh "scripts/lint.sh"
+            }
+          }, clangDebugTidy: {
+            stage("clang-debug:tidy-changed-files") {
+              sh "bash ./scripts/clang_tidy.sh clang-debug-tidy \$(( \$(nproc) / 5 ))"
             }
           }
 
@@ -226,13 +230,12 @@ try {
                 Utils.markStageSkippedForConditional("clangDebugUnityODR")
               }
             }
-          }, clangDebugTidy: {
-            stage("clang-debug:tidy") {
+          }, clangDebugTidyAllIncludingTUs: {
+            stage("clang-debug:tidy-all-including-tus") {
               if (env.BRANCH_NAME == 'master' || full_ci) {
-                // We do not run tidy checks on the src/test folder, so there is no point in running the expensive clang-tidy for those files
-                sh "cd clang-debug-tidy && ninja hyrise_impl hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer hyriseMvccDeletePlugin hyriseUccDiscoveryPlugin -k 0 -j \$(( \$(nproc) / 2))"
+                sh "CLANG_TIDY_ALL_INCLUDING_TUS=1 bash ./scripts/clang_tidy.sh clang-debug-tidy \$(( \$(nproc) / 4 ))"
               } else {
-                Utils.markStageSkippedForConditional("clangDebugTidy")
+                Utils.markStageSkippedForConditional("clangDebugTidyAllIncludingTUs")
               }
             }
           }, clangDebugDisablePrecompileHeaders: {
@@ -324,10 +327,14 @@ try {
             }
           }, bolt: {
             stage('bolt') {
-              sh "mkdir cmake-build-bolt"
-              sh "cd cmake-build-bolt && cmake ${release} ${clang} ${unity} ${ninja} .."
-              sh "cd cmake-build-bolt && python3 ../scripts/build_pgo_bolt.py -n \$(( \$(nproc) / 5)) --ci"
-              sh "cd cmake-build-bolt && ./hyriseTest"
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "mkdir cmake-build-bolt"
+                sh "cd cmake-build-bolt && cmake ${release} ${clang} ${unity} ${ninja} .."
+                sh "cd cmake-build-bolt && python3 ../scripts/build_pgo_bolt.py -n \$(( \$(nproc) / 5)) --ci"
+                sh "cd cmake-build-bolt && ./hyriseTest"
+              } else {
+                Utils.markStageSkippedForConditional("bolt")
+              }
             }
           }
 

--- a/scripts/clang_tidy.sh
+++ b/scripts/clang_tidy.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Run clang-tidy only on files changed compared to master branch.
+# A changed header is checked via a .cpp that includes it: the first one found,
+# or all of them when CLANG_TIDY_ALL_INCLUDING_TUS=1. Test files are not checked.
+#
+# Env:
+#   CLANG_TIDY_ALL_INCLUDING_TUS=1  check all includers of a changed header
+#   CLANG_TIDY_DIFF_BASE=<ref>      tidy files changed since <ref> (default: merge-base with master)
+#   CLANG_TIDY_DEBUG=1              print the selected files to tidy
+set -o pipefail
+
+build_dir="${1:-clang-debug-tidy}"
+jobs="${2:-$(nproc)}"
+all_includers="${CLANG_TIDY_ALL_INCLUDING_TUS:-0}"
+debug="${CLANG_TIDY_DEBUG:-0}"
+
+[ -f "$build_dir/compile_commands.json" ] || {
+  echo "FATAL: no compile_commands.json in $build_dir (need -DCMAKE_EXPORT_COMPILE_COMMANDS=ON)"; exit 1; }
+
+# version.hpp and the jemalloc headers are generated during the build, but this build dir is only configured. Build
+# just those two targets so that the files clang-tidy needs to parse exist.
+[ -f "$build_dir/build.ninja" ] && ninja -C "$build_dir" libjemalloc-build version.hpp >/dev/null 2>&1
+
+# Diff base: previous commit on master, else the merge-base with master.
+if [ -n "$CLANG_TIDY_DIFF_BASE" ]; then
+  base="$CLANG_TIDY_DIFF_BASE"
+elif [ "$BRANCH_NAME" = "master" ]; then
+  base=$(git rev-parse HEAD^1)
+else
+  git fetch --no-tags --quiet origin master
+  base=$(git merge-base FETCH_HEAD HEAD)
+fi
+
+changed=$( { git diff --diff-filter=d --name-only "$base"; \
+             git ls-files --others --exclude-standard; } \
+           | grep -E '^src/.*\.[chi]pp$' | grep -v '^src/test' | sort -u )
+[ -z "$changed" ] && { echo "No tidy-relevant files changed."; exit 0; }
+
+cpps=$(echo "$changed" | grep '\.cpp$')
+hdrs=$(echo "$changed" | grep -E '\.[hi]pp$')
+
+# A header is not a translation unit and has no entry in compile_commands.json, so clang-tidy cannot be run on it
+# directly. It is analyzed through a .cpp that includes it; we add the first includer we find (or all of them).
+for h in $hdrs; do
+  inc=$(grep -rlF "$(basename "$h")" src --include=*.cpp | grep -v '^src/test' | sort)
+  [ -z "$inc" ] && continue
+  [ "$all_includers" = 1 ] || inc=$(echo "$inc" | head -n 1)
+  cpps=$(printf '%s\n%s' "$cpps" "$inc")
+done
+# Drop duplicates (a .cpp can include several changed headers) and the empty line that the printf above adds when no
+# .cpp file itself was changed.
+cpps=$(printf '%s\n' "$cpps" | grep -v '^$' | sort -u)
+[ -z "$cpps" ] && { echo "No translation units to analyze."; exit 0; }
+
+# Regex of the changed headers for --header-filter below, e.g. "sort.hpp|table.hpp".
+hf=$(for h in $hdrs; do basename "$h"; done | paste -sd'|' -)
+
+# Print the diff base and the translation units we selected.
+[ "$debug" = 1 ] && { echo "[debug] base=$base  tus=$(echo "$cpps" | grep -c .)"; echo "$cpps" | sed 's/^/  /'; }
+
+# Run clang-tidy for each file, $jobs at a time. --header-filter restricts header diagnostics to the changed headers
+# (omitted when none changed), so we do not fail on pre-existing issues in untouched headers.
+printf '%s\n' "$cpps" | xargs -r -P "$jobs" -n 1 \
+  clang-tidy -p "$build_dir" --quiet --warnings-as-errors='*' \
+  ${hf:+--header-filter="($hf)\$"}


### PR DESCRIPTION
### Motivation:

`clangDebugTidy` previously ran clang-tidy on the entire build regardless of the diff (~2h 27m even for a 1-2 line change). This PR makes it run only on changed files and moves it earlier in the pipeline. `clangDebugTidy` will run in two phases, providing a quick check for all PRs, and a thorough check with the FullCI label.
 
### What changed:
 
- **Runs on changed files only.** Every changed `.cpp` is tidied. A changed header is checked through one representative `.cpp` that includes it (1 translation unit), for the first phase. For the second, all TUs that include it are checked.
- **Run earlier**, into the first parallel block (with the debug builds and lint), so tidy failures surface early. 
- **Kept later**, Runs again in the second parallel block, for a more thorough check.
- **Runs on every PR**  now that the first check is cheap, it no longer needs the Full CI label.

### Diff in numbers, 1st phase:
 
| | Before | After |
|---|---|---|
| 1-2 line `.cpp` change | 2h 27m | ~4 min |
| Commonly-included header (244 TUs) | ~2h 20m | <4 min |

### Diff in numbers, 2nd phase:
 
| | Before | After |
|---|---|---|
| 1-2 line `.cpp` change | 2h 27m | ~4 min |
| Commonly-included header (244 TUs) | ~2h 20m | ~2h |
 
See https://github.com/hyrise/hyrise/pull/2764 for the full experiments.