### PR TITLE
DYOD2026 Group4

### DIFF
--- a/resources/test_data/sqlite_testrunner_queries.sql
+++ b/resources/test_data/sqlite_testrunner_queries.sql
@@ -266,7 +266,7 @@ SELECT DISTINCT * FROM mixed;
 SELECT DISTINCT a, MIN(b) FROM mixed GROUP BY a;
 SELECT DISTINCT MIN(b) FROM mixed GROUP BY a;
 SELECT DISTINCT id + b FROM mixed ORDER BY id + b DESC LIMIT 10;
-SELECT DISTINCT id + b, id + c FROM mixed ORDER BY id + b;
+SELECT DISTINCT id + b, id + c FROM mixed ORDER BY id + b, id + c;
 
 -- Join, GROUP BY, Having, ...
 SELECT c_custkey, c_name, COUNT(a) FROM tpch_customer JOIN id_int_int_int_100 ON c_custkey = a GROUP BY c_custkey, c_name HAVING COUNT(a) >= 2;

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -22,8 +22,6 @@ target_link_libraries(
 
     hyrise
     hyriseBenchmarkLib
-    perf-cpp-wrapper
-    perfetto-wrapper
 )
 
 # Configure DYODEvaluation

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -220,6 +220,8 @@ set(
     operators/abstract_read_write_operator.cpp
     operators/abstract_read_write_operator.hpp
     operators/aggregate/window_function_traits.hpp
+    operators/aggregate_dyod.cpp
+    operators/aggregate_dyod.hpp
     operators/aggregate_hash.cpp
     operators/aggregate_hash.hpp
     operators/aggregate_sort.cpp

--- a/src/lib/operators/aggregate_dyod.cpp
+++ b/src/lib/operators/aggregate_dyod.cpp
@@ -1,0 +1,1049 @@
+#include "aggregate_dyod.hpp"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <format>
+#include <functional>
+#include <limits>
+#include <memory>
+#include <memory_resource>
+#include <numeric>
+#include <ranges>
+#include <span>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <boost/sort/pdqsort/pdqsort.hpp>
+
+#include "uninitialized_vector.hpp"
+
+#include "all_type_variant.hpp"
+#include "expression/abstract_expression.hpp"
+#include "expression/pqp_column_expression.hpp"
+#include "hyrise.hpp"
+#include "operators/abstract_aggregate_operator.hpp"
+#include "operators/abstract_operator.hpp"
+#include "storage/abstract_segment.hpp"
+#include "storage/segment_iterate.hpp"
+#include "storage/table.hpp"
+#include "storage/table_column_definition.hpp"
+#include "types.hpp"
+
+namespace hyrise {
+
+AggregateDYOD::AggregateDYOD(const std::shared_ptr<AbstractOperator>& input_operator,
+                             const std::vector<std::shared_ptr<WindowFunctionExpression>>& aggregates,
+                             const std::vector<ColumnID>& groupby_column_ids)
+    : AbstractAggregateOperator(input_operator, aggregates, groupby_column_ids) {
+  _groupby_string_count = std::ranges::count_if(_groupby_column_ids, [&](auto column_id) {
+    return left_input_table()->column_data_type(column_id) == DataType::String;
+  });
+}
+
+const std::string& AggregateDYOD::name() const {
+  static const auto name = std::string{"AggregateDYOD"};
+  return name;
+}
+
+template <typename ColumnDataType, typename AggregateType>
+class WindowFunctionBuilder<ColumnDataType, AggregateType, WindowFunction::Any> {
+ public:
+  auto get_aggregate_function() {
+    return [](const ColumnDataType& new_value, const size_t aggregate_count, AggregateType& accumulator) {
+      accumulator = new_value;
+    };
+  }
+};
+
+template <typename Functor>
+void resolve_window_function(const WindowFunction window_function, const Functor& functor) {
+  switch (window_function) {
+    case WindowFunction::Min:
+      functor(std::integral_constant<WindowFunction, WindowFunction::Min>{});
+      return;
+    case WindowFunction::Max:
+      functor(std::integral_constant<WindowFunction, WindowFunction::Max>{});
+      return;
+    case WindowFunction::Sum:
+      functor(std::integral_constant<WindowFunction, WindowFunction::Sum>{});
+      return;
+    case WindowFunction::Avg:
+      functor(std::integral_constant<WindowFunction, WindowFunction::Avg>{});
+      return;
+    case WindowFunction::Count:
+      functor(std::integral_constant<WindowFunction, WindowFunction::Count>{});
+      return;
+    case WindowFunction::CountDistinct:
+      functor(std::integral_constant<WindowFunction, WindowFunction::CountDistinct>{});
+      return;
+    case WindowFunction::Any:
+      functor(std::integral_constant<WindowFunction, WindowFunction::Any>{});
+      return;
+    case WindowFunction::StandardDeviationSample:
+      functor(std::integral_constant<WindowFunction, WindowFunction::StandardDeviationSample>{});
+      return;
+    default:
+      Fail(std::format("Unsupported aggregate function '{}'.", window_function_to_string.left.at(window_function)));
+  }
+}
+
+namespace {
+template <typename DataType>
+void _normalize_numerical(const DataType value, const bool is_null, uint8_t* byte_ptr) {
+  const auto* const bytes = reinterpret_cast<const std::uint8_t*>(&value);
+  std::memcpy(byte_ptr, bytes, sizeof(value));
+  *(byte_ptr + sizeof(value)) = is_null ? 0 : 255;
+}
+
+const auto MAX_STRING_KEY_LENGTH = uint64_t{8};
+
+void _normalize_string(const pmr_string& value, const bool is_null, uint8_t* byte_ptr) {
+  const auto write_length = std::min(MAX_STRING_KEY_LENGTH, uint64_t{value.length()});
+  std::memcpy(byte_ptr, value.data(), write_length);
+  std::memset(byte_ptr + write_length, 0, MAX_STRING_KEY_LENGTH - write_length);
+  *(byte_ptr + MAX_STRING_KEY_LENGTH) = is_null ? 0 : 255;
+}
+
+uint8_t key_data_length(const DataType data_type) {
+  return (data_type == DataType::Int || data_type == DataType::Float) ? 4 : 8;
+}
+
+uint8_t key_data_length_null(const DataType data_type) {
+  return key_data_length(data_type) + 1;
+}
+
+}  // namespace
+
+void AggregateDYOD::_normalize_chunk_groupby(const std::shared_ptr<const Chunk>& input_chunk, const ChunkID chunk_id,
+                                             const uint64_t row_offset,
+                                             uninitialized_vector<AggregateDYOD::NormalizedKey>& key_vector,
+                                             uninitialized_vector<uint8_t>& byte_vector,
+                                             pmr_vector<pmr_string>& groupby_strings) {
+  auto groupby_string_index = uint64_t{0};
+  const auto chunk_size = input_chunk->size();
+  auto byte_offset = uint64_t{0};
+
+  for (const auto column_id : groupby_column_ids()) {
+    const auto column_data_type = left_input_table()->column_data_type(column_id);
+    resolve_data_type(column_data_type, [&](auto type) {
+      using ColumnDataType = typename decltype(type)::type;
+      const auto segment = input_chunk->get_segment(column_id);
+      auto row_id = uint64_t{0};
+      segment_iterate<ColumnDataType>(*segment, [&](auto position) {
+        const auto byte_index =
+            (row_offset + row_id) * (_normalized_key_size + _groupby_string_count * 8) + byte_offset;
+        auto base_byte = byte_vector.data() + byte_index - byte_offset;
+        auto* byte_representation = byte_vector.data() + byte_index;
+        if constexpr (std::is_arithmetic_v<ColumnDataType>) {
+          const auto value = position.is_null() ? ColumnDataType{0} : position.value();
+          _normalize_numerical<ColumnDataType>(value, position.is_null(), byte_representation);
+        } else if constexpr (std::is_same_v<ColumnDataType, pmr_string>) {
+          // For strings we additionally need to store the whole string value in the groupy_strings vector
+          const auto value = position.is_null() ? "" : position.value();
+          _normalize_string(value, position.is_null(), byte_representation);
+          const auto string_index = (row_offset * _groupby_string_count) + (groupby_string_index * chunk_size) + row_id;
+          // We store the index to the string at the back of the key, which we do not use for comparisons
+          std::memcpy(base_byte + _normalized_key_size + (groupby_string_index * 8), &string_index,
+                      sizeof(string_index));
+          groupby_strings[string_index] = value;
+        } else {
+          Fail("DataType is not supported by Hyrise.");
+        }
+        key_vector[row_offset + row_id] = (row_offset + row_id) * (_normalized_key_size + _groupby_string_count * 8);
+        ++row_id;
+      });
+      if constexpr (std::is_same_v<ColumnDataType, pmr_string>) {
+        ++groupby_string_index;
+      }
+    });
+    byte_offset += key_data_length_null(column_data_type);
+  }
+}
+
+void AggregateDYOD::_materialize_chunk_aggregates(const std::shared_ptr<const Chunk>& input_chunk,
+                                                  const uint64_t row_offset) {
+  const auto column_count = _unique_aggregate_columns.size();
+  for (auto column_position = uint64_t{0}; column_position < column_count; ++column_position) {
+    const auto column_id = _unique_aggregate_columns[column_position];
+
+    resolve_data_type(left_input_table()->column_data_type(column_id), [&](auto type) {
+      using ColumnDataType = typename decltype(type)::type;
+
+      auto materialized_column = std::static_pointer_cast<MaterializedColumn<ColumnDataType>>(
+          _materialized_aggregate_columns[column_position]);
+
+      auto* const values = materialized_column->values.data() + row_offset;
+      auto* const null_values = materialized_column->null_values.data() + row_offset;
+
+      auto row_index = uint64_t{0};
+      segment_iterate<ColumnDataType>(*input_chunk->get_segment(column_id), [&](const auto& position) {
+        values[row_index] = position.is_null() ? ColumnDataType{} : position.value();
+        null_values[row_index] = position.is_null();
+        ++row_index;
+      });
+    });
+  }
+}
+
+std::shared_ptr<const Table> AggregateDYOD::_on_execute() {
+  using Morsel = AggregateDYOD::Morsel;
+
+  _validate_aggregates();
+
+  const auto input_table = left_input_table();
+  const auto row_count = input_table->row_count();
+
+  // Create group column definitions and calculate size of normalized keys
+  for (const auto& column_id : _groupby_column_ids) {
+    _output_column_definitions.emplace_back(input_table->column_name(column_id),
+                                            input_table->column_data_type(column_id),
+                                            input_table->column_is_nullable(column_id));
+
+    const auto data_type = left_input_table()->column_data_type(column_id);
+    _normalized_key_size += key_data_length(data_type);
+    _normalized_key_size += 1;
+  }
+
+  // Create aggregate column definitions
+  auto aggregate_index = ColumnID{0};
+  auto aggregate_column_offset = uint64_t{0};
+
+  for (const auto& aggregate : _aggregates) {
+    const auto& pqp_column = static_cast<const PQPColumnExpression&>(*aggregate->argument());
+    const auto column_id = pqp_column.column_id;
+
+    // We determine the set of unique columns that are needed for aggregation as to not
+    // materialize the same columns multiple times
+    if (column_id != INVALID_COLUMN_ID && !_aggregate_column_position.contains(column_id)) {
+      _unique_aggregate_columns.push_back(column_id);
+      _aggregate_column_position[column_id] = aggregate_column_offset++;
+    }
+    /*
+     * Special case for COUNT(*), which is the only case where column equals INVALID_COLUMN_ID:
+     * Usually, the data type of the aggregate can depend on the data type of the corresponding input column.
+     * For example, the sum of ints is an int, while the sum of doubles is a double.
+     * For COUNT(*), the aggregate type is always Long, regardless of the input type.
+     * As the input type does not matter and we do not even have an input column,
+     * but the function call expects an input type, we choose Long to be consistent with the output type.
+     */
+    const auto data_type = column_id == INVALID_COLUMN_ID ? DataType::Long : input_table->column_data_type(column_id);
+
+    resolve_data_type(data_type, [&, aggregate_index](auto type) {
+      _create_aggregate_column_definitions(type, aggregate_index, aggregate->window_function);
+    });
+
+    ++aggregate_index;
+  }
+
+  // Create a MaterializedColumn of the concrete type for each column some aggregte refers to
+  const auto num_unique_aggregate_columns = _unique_aggregate_columns.size();
+  _materialized_aggregate_columns.resize(num_unique_aggregate_columns);
+  for (auto position = uint64_t{0}; position < num_unique_aggregate_columns; ++position) {
+    const auto column_id = _unique_aggregate_columns[position];
+    resolve_data_type(input_table->column_data_type(column_id), [&](auto type) {
+      using ColumnDataType = typename decltype(type)::type;
+      _materialized_aggregate_columns[position] = std::make_shared<MaterializedColumn<ColumnDataType>>(row_count);
+    });
+  }
+
+  auto result_table = std::make_shared<Table>(_output_column_definitions, TableType::Data);
+
+  /*
+   * Handle empty input table according to the SQL standard
+   *  if group by columns exist -> empty result
+   *  else -> one row with default values
+   */
+  if (input_table->empty()) {
+    if (_groupby_column_ids.empty()) {
+      std::vector<AllTypeVariant> default_values;
+      default_values.reserve(_aggregates.size());
+      for (const auto& aggregate : _aggregates) {
+        if (aggregate->window_function == WindowFunction::Count ||
+            aggregate->window_function == WindowFunction::CountDistinct) {
+          default_values.emplace_back(int64_t{0});
+        } else {
+          default_values.emplace_back(NULL_VALUE);
+        }
+      }
+      result_table->append(default_values);
+    }
+    return result_table;
+  }
+
+  /*
+   * We distinguish two cases:
+   *  1. There are no columns to group by:
+   *    In this case the aggregation only needs to iterate over each column and aggregte with the respective function,
+   *    resulting in a table with a single row
+  */
+  if (_groupby_column_ids.empty()) {
+    auto aggregate_values = pmr_vector<std::shared_ptr<AbstractSegment>>(_aggregates.size());
+    aggregate_index = 0;
+    for (const auto& aggregate : _aggregates) {
+      const auto& pqp_expression = static_cast<const PQPColumnExpression&>(*_aggregates[aggregate_index]->argument());
+      const auto pqp_column_id = pqp_expression.column_id;
+
+      const auto data_type =
+          pqp_column_id == INVALID_COLUMN_ID ? DataType::Long : input_table->column_data_type(pqp_column_id);
+
+      resolve_data_type(data_type, [&](auto type) {
+        using ColumnDataType = typename decltype(type)::type;
+
+        resolve_window_function(aggregate->window_function, [&](auto window_function_constant) {
+          constexpr auto aggregate_function = decltype(window_function_constant)::value;
+          using AggregateType = typename WindowFunctionTraits<ColumnDataType, aggregate_function>::ReturnType;
+
+          aggregate_values[aggregate_index] =
+              _aggregate_values_without_groups<ColumnDataType, AggregateType, aggregate_function>(aggregate_index);
+        });
+      });
+      ++aggregate_index;
+    }
+    result_table->append_chunk(aggregate_values);
+    return result_table;
+  } else {
+    /*  
+   * 2. There are columns to group by:
+   *      In this case, we initialize vectors to hold the bytes for NormalizedKeys, pointers to these keys
+   *      and all strings in the group-by columns. These need to be stored seperately as we do not want to
+   *      have keys of different sizes and such that the different values  of each column are aligned in
+   *      every key.
+   *      The normalization is done in parallel for every chunk and each thread/task writes to a distinct
+   *      range of the vectors.
+   *      Now the rows are split into morsels. Then all morsels are queued to perform their aggregations.
+   *      When all morsels have finished, we binary merge the morsels together.
+   *      We then write the group and aggregate values into the result table and return.
+  */
+    const auto row_count = input_table->row_count();
+
+    auto key_bytes = uninitialized_vector<uint8_t>(row_count * (_normalized_key_size + _groupby_string_count * 8));
+    auto normalized_keys = uninitialized_vector<NormalizedKey>(row_count);
+    auto groupby_strings = pmr_vector<pmr_string>(row_count * _groupby_string_count);
+
+    const auto chunk_count = input_table->chunk_count();
+    auto chunk_normalization_tasks = std::vector<std::shared_ptr<AbstractTask>>(chunk_count);
+
+    auto row_offset = uint64_t{0};
+    for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
+      chunk_normalization_tasks[chunk_id] = std::make_shared<JobTask>([&, chunk_id, row_offset]() {
+        const auto chunk = input_table->get_chunk(chunk_id);
+        _normalize_chunk_groupby(chunk, chunk_id, row_offset, normalized_keys, key_bytes, groupby_strings);
+        _materialize_chunk_aggregates(chunk, row_offset);
+      });
+      row_offset += input_table->get_chunk(chunk_id)->size();
+    }
+
+    Hyrise::get().scheduler()->schedule_and_wait_for_tasks(chunk_normalization_tasks);
+
+    constexpr auto DESIRED_MORSEL_SIZE = ChunkOffset{10'000};
+    const auto is_multi_threaded = Hyrise::get().is_multi_threaded();
+    // const auto is_multi_threaded = false;
+    const auto morsel_count =
+        is_multi_threaded ? (normalized_keys.size() + DESIRED_MORSEL_SIZE - 1) / DESIRED_MORSEL_SIZE : 1;
+
+    auto morsels = std::vector<std::shared_ptr<Morsel>>(morsel_count);
+
+    auto morsel_index = uint64_t{0};
+    for (auto& morsel : morsels) {
+      const auto morsel_range_start = morsel_index * DESIRED_MORSEL_SIZE;
+      const auto morsel_range_end = std::min(morsel_range_start + DESIRED_MORSEL_SIZE, input_table->row_count()) - 1;
+      const auto morsel_size = morsel_range_end - morsel_range_start + 1;
+      auto normalized_key_span = std::span<NormalizedKey>(normalized_keys.begin() + morsel_range_start, morsel_size);
+
+      morsel = std::make_shared<Morsel>(*this, morsel_size, morsel_range_start, key_bytes, normalized_key_span,
+                                        groupby_strings);
+      ++morsel_index;
+    }
+    auto aggregation_tasks = std::vector<std::shared_ptr<AbstractTask>>{};
+    aggregation_tasks.reserve(morsel_count);
+
+    for (auto& morsel : morsels) {
+      aggregation_tasks.push_back(std::make_shared<JobTask>([&]() {
+        morsel->_sort_morsel_range();
+
+        auto aggregate_index = uint64_t{0};
+        for (const auto& aggregate : _aggregates) {
+          const auto& pqp_expression = static_cast<const PQPColumnExpression&>(*aggregate->argument());
+          const auto pqp_column_id = pqp_expression.column_id;
+
+          const auto data_type =
+              pqp_column_id == INVALID_COLUMN_ID ? DataType::Long : input_table->column_data_type(pqp_column_id);
+          resolve_data_type(data_type, [&](auto type) {
+            using ColumnDataType = typename decltype(type)::type;
+
+            resolve_window_function(aggregate->window_function, [&](auto window_function_constant) {
+              constexpr auto aggregate_function = decltype(window_function_constant)::value;
+              using AggregateType = typename WindowFunctionTraits<ColumnDataType, aggregate_function>::ReturnType;
+
+              morsel->_aggregate_morsel<ColumnDataType, aggregate_function, AggregateType>(aggregate_index);
+            });
+          });
+          ++aggregate_index;
+        }
+      }));
+    }
+
+    Hyrise::get().scheduler()->schedule_and_wait_for_tasks(aggregation_tasks);
+
+    for (auto merge_distance = size_t{1}; merge_distance < morsel_count; merge_distance *= 2) {
+      auto merge_tasks = std::vector<std::shared_ptr<AbstractTask>>{};
+      merge_tasks.reserve((morsel_count + merge_distance - 1) / (2 * merge_distance));
+      for (auto morsel_id = size_t{0}; morsel_id + merge_distance < morsel_count; morsel_id += 2 * merge_distance) {
+        merge_tasks.push_back(std::make_shared<JobTask>([&, morsel_id, merge_distance]() {
+          auto morsel1 = morsels[morsel_id];
+          auto morsel2 = morsels[morsel_id + merge_distance];
+
+          morsel1->_merge_morsel(morsel2);
+        }));
+      }
+
+      Hyrise::get().scheduler()->schedule_and_wait_for_tasks(merge_tasks);
+    }
+
+    // Our binary merge strategy guarantees that the final results are in the first morsel.
+    const auto final_morsel = morsels[0];
+    const auto value_count = final_morsel->group_count;
+
+    // Writing the group values to the table
+    // Since we store everything except strings directly in its byte representation in the keys
+    // we simply decode it from there. For strings we decode the index into the global string
+    // buffer and get the string from there.
+    auto group_key_offset = uint64_t{0};
+    auto group_string_offset = uint64_t{0};
+    for (const auto& column_id : _groupby_column_ids) {
+      const auto column_is_nullable = left_input_table()->column_is_nullable(column_id);
+      const auto data_type = left_input_table()->column_data_type(column_id);
+      const auto data_length = key_data_length(data_type);
+      auto value_index = uint64_t{0};
+      resolve_data_type(data_type, [&](auto type) {
+        using ColumnDataType = typename decltype(type)::type;
+
+        auto values = pmr_vector<ColumnDataType>(value_count);
+        auto null_values = pmr_vector<bool>(value_count);
+
+        for (const auto& key : final_morsel->group_keys) {
+          if constexpr (std::is_arithmetic_v<ColumnDataType>) {
+            std::memcpy(&values[value_index], key_bytes.data() + key + group_key_offset, data_length);
+          } else {
+            auto string_index = uint64_t{0};
+            std::memcpy(&string_index, key_bytes.data() + key + _normalized_key_size + (group_string_offset * 8), 8);
+            values[value_index] = groupby_strings[string_index];
+          }
+          null_values[value_index] = key_bytes[key + group_key_offset + data_length] == 0;
+          ++value_index;
+        }
+
+        if (column_is_nullable) {
+          _output_segments.push_back(
+              std::make_shared<ValueSegment<ColumnDataType>>(std::move(values), std::move(null_values)));
+        } else {
+          _output_segments.push_back(std::make_shared<ValueSegment<ColumnDataType>>(std::move(values)));
+        }
+        group_key_offset += key_data_length_null(data_type);
+        if constexpr (std::is_same_v<ColumnDataType, pmr_string>) {
+          ++group_string_offset;
+        }
+      });
+    }
+
+    auto aggregate_index = uint64_t{0};
+    for (const auto& aggregate : _aggregates) {
+      const auto& pqp_expression = static_cast<const PQPColumnExpression&>(*aggregate->argument());
+      const auto pqp_column_id = pqp_expression.column_id;
+      const auto data_type =
+          pqp_column_id == INVALID_COLUMN_ID ? DataType::Long : input_table->column_data_type(pqp_column_id);
+      resolve_data_type(data_type, [&](auto type) {
+        using ColumnDataType = typename decltype(type)::type;
+        resolve_window_function(aggregate->window_function, [&](auto window_function_constant) {
+          constexpr auto aggregate_function = decltype(window_function_constant)::value;
+          using AggregateType = typename WindowFunctionTraits<ColumnDataType, aggregate_function>::ReturnType;
+          const auto nullable =
+              (aggregate_function != WindowFunction::Count && aggregate_function != WindowFunction::CountDistinct &&
+               aggregate_function != WindowFunction::Any) ||
+              (aggregate_function == WindowFunction::Any && left_input_table()->column_is_nullable(pqp_column_id));
+
+          // This case is needed here to tell the compiler that _to_value_segment will not
+          // be instantiated with StandardDeviationSample and a non-arithmetic type.
+          if constexpr (aggregate_function == WindowFunction::StandardDeviationSample &&
+                        !std::is_arithmetic_v<ColumnDataType>) {
+            Fail("Standard Deviation sampling is not supported on non-arithmetic types.");
+            return;
+          } else if constexpr (aggregate_function == WindowFunction::CountDistinct) {
+            _output_segments.push_back(final_morsel->_distinct_to_value_segment<ColumnDataType>(aggregate_index));
+          } else {
+            _output_segments.push_back(
+                final_morsel->_to_value_segment<aggregate_function, AggregateType>(aggregate_index, nullable));
+          }
+        });
+      });
+      ++aggregate_index;
+    }
+
+    result_table->append_chunk(_output_segments);
+    return result_table;
+  }
+}
+
+std::shared_ptr<AbstractOperator> AggregateDYOD::_on_deep_copy(
+    const std::shared_ptr<AbstractOperator>& copied_left_input,
+    const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
+  return std::make_shared<AggregateDYOD>(copied_left_input, _aggregates, _groupby_column_ids);
+}
+
+std::weak_ordering AggregateDYOD::Morsel::_compare_keys(const NormalizedKey& first, const NormalizedKey& second) {
+  const auto key_size = morsel_operator._normalized_key_size;
+  const auto memcmp_result = memcmp(&key_bytes[first], &key_bytes[second], key_size);
+
+  if (memcmp_result < 0) {
+    return std::weak_ordering::less;
+  } else if (memcmp_result > 0) {
+    return std::weak_ordering::greater;
+  } else {
+    for (auto index = uint64_t{0}; index < morsel_operator._groupby_string_count; ++index) {
+      auto index1 = uint64_t{0}, index2 = uint64_t{0};
+      std::memcpy(&index1, key_bytes.data() + first + key_size + (index * 8), 8);
+      std::memcpy(&index2, key_bytes.data() + second + key_size + (index * 8), 8);
+      // We use the <=> operator to directly get an ordering of the compared strings.
+      const auto strcmp_result = groupby_strings[index1] <=> groupby_strings[index2];
+      if (strcmp_result == 0) {
+        continue;
+      }
+      return strcmp_result;
+    }
+  }
+  return std::weak_ordering::equivalent;
+}
+
+void AggregateDYOD::Morsel::_sort_morsel_range() {
+  /*
+   * To sort the morsel we sort indices of the rows according to the normalized keys.
+   * With these indices we can then reorder the MaterializedColumns for the aggregates
+   * without the need to materialize into a row-wise format. We pack the key-index and
+   * the row-reference-index into a pair to get more predictable accesses on this level.
+   * When accessing the keys themselves, this may still be quite random.
+  */
+  auto sort_values = std::vector<std::pair<NormalizedKey, uint64_t>>(row_count);
+  for (auto index = uint64_t{0}; index < row_count; ++index) {
+    auto& [key, sort_index] = sort_values[index];
+    key = std::move(normalized_keys[index]);
+    sort_index = index;
+  }
+
+  boost::sort::pdqsort(sort_values.begin(), sort_values.end(), [&](auto first_key, auto second_key) {
+    return _compare_keys(first_key.first, second_key.first) < 0;
+  });
+
+  auto sorted_indices = std::vector<uint64_t>();
+  sorted_indices.reserve(row_count);
+  for (auto index = uint64_t{0}; index < row_count; ++index) {
+    auto& [key, sort_index] = sort_values[index];
+    normalized_keys[index] = std::move(key);
+    sorted_indices.push_back(sort_index);
+  }
+
+  auto& unique_aggregate_columns = morsel_operator._unique_aggregate_columns;
+  const auto num_unique_aggregate_columns = unique_aggregate_columns.size();
+  for (auto position = uint64_t{0}; position < num_unique_aggregate_columns; ++position) {
+    const auto column_id = unique_aggregate_columns[position];
+    resolve_data_type(morsel_operator.left_input_table()->column_data_type(column_id), [&](auto type) {
+      using ColumnDataType = typename decltype(type)::type;
+      auto materialized_column = std::static_pointer_cast<MaterializedColumn<ColumnDataType>>(
+          morsel_operator._materialized_aggregate_columns[morsel_operator._aggregate_column_position.at(column_id)]);
+      auto* values = materialized_column->values.data() + initial_row_offset;
+      auto* null_values = materialized_column->null_values.data() + initial_row_offset;
+
+      auto reordered_values = pmr_vector<ColumnDataType>(row_count);
+      auto reordered_nulls = uninitialized_vector<uint8_t>(row_count);
+
+      for (auto index = uint64_t{0}; index < row_count; ++index) {
+        reordered_values[index] = std::move(values[sorted_indices[index]]);
+        reordered_nulls[index] = std::move(null_values[sorted_indices[index]]);
+      }
+
+      // Since (pmr_)strings are not TriviallyCopyable we cannot use memcpy for them.
+      if constexpr (std::is_same_v<ColumnDataType, pmr_string>) {
+        std::move(reordered_values.begin(), reordered_values.end(),
+                  materialized_column->values.begin() + initial_row_offset);
+      } else {
+        std::memcpy(values, reordered_values.data(), row_count * sizeof(ColumnDataType));
+      }
+      std::memcpy(null_values, reordered_nulls.data(), row_count * sizeof(uint8_t));
+    });
+  }
+
+  // We compare subsequent keys to figure out the group sizes and
+  // to get a representative key for each group (which are by definition
+  // the same for each group member)
+  // Since the keys are already ordered, we know that they will compare
+  // either less or equal and we do not have to check for greater.
+  auto current_group_size = uint64_t{0};
+  for (auto row_index = uint64_t{0}; row_index < row_count - 1; ++row_index) {
+    ++current_group_size;
+    if (_compare_keys(normalized_keys[row_index], normalized_keys[row_index + 1]) != 0) {
+      group_sizes.push_back(current_group_size);
+      group_keys.push_back(normalized_keys[row_index]);
+      current_group_size = 0;
+    }
+  }
+  group_sizes.push_back(current_group_size + 1);
+  group_keys.push_back(normalized_keys.back());
+  group_count = group_sizes.size();
+}
+
+template <typename ColumnType, WindowFunction aggregate_function, typename AggregateType>
+void AggregateDYOD::Morsel::_aggregate_morsel(const uint64_t aggregate_index) {
+  const auto& pqp_column =
+      static_cast<const PQPColumnExpression&>(*morsel_operator._aggregates[aggregate_index]->argument());
+  const auto input_column_id = pqp_column.column_id;
+  auto value_count = uint64_t{0};
+
+  auto accumulator = AggregateAccumulator<aggregate_function, AggregateType>{};
+  auto aggregator = WindowFunctionBuilder<ColumnType, AggregateType, aggregate_function>().get_aggregate_function();
+  auto distinct_values = std::unordered_set<ColumnType>{};
+
+  using Results = AggregateResults<aggregate_function, AggregateType>;
+  using DistinctResults = AggregateResults<WindowFunction::CountDistinct, ColumnType>;
+
+  auto results = std::make_shared<
+      std::conditional_t<aggregate_function == WindowFunction::CountDistinct, DistinctResults, Results>>(group_count);
+
+  aggregate_results[aggregate_index] = results;
+
+  auto& accumulators = results->accumulators;
+  auto& counts = results->counts;
+
+  // Special COUNT(*) implementation
+  // Since we already have the group sizes from the sorting, we can use them to return the counts.
+  // We have to split both conditions so that we can make the first
+  // constexpr to guarantee the compiler that the AggregateResult
+  // will not be templated with WindowFunction::CountDistinct, which requires
+  // the DistinctResult.
+  if constexpr (aggregate_function == WindowFunction::Count) {
+    if (input_column_id == INVALID_COLUMN_ID) {
+      auto last_group_offset = uint64_t{0};
+      for (auto group_index = uint64_t{0}; group_index < group_count; ++group_index) {
+        const auto group_size = group_sizes[group_index];
+        const auto next_offset = last_group_offset + group_size;
+        accumulators[group_index] = accumulator;
+        counts[group_index] = group_size;
+        group_keys[group_index] = normalized_keys[next_offset - 1];
+        last_group_offset = next_offset;
+      }
+      return;
+    }
+  }
+
+  const auto column_index = morsel_operator._aggregate_column_position.at(input_column_id);
+  const auto column = std::static_pointer_cast<MaterializedColumn<ColumnType>>(
+      morsel_operator._materialized_aggregate_columns[column_index]);
+  auto* values = column->values.data() + initial_row_offset;
+  auto* null_values = column->null_values.data() + initial_row_offset;
+
+  auto current_group_offset = uint64_t{0};
+  for (auto group_index = uint64_t{0}; group_index < group_count; ++group_index) {
+    const auto group_size = group_sizes[group_index];
+    for (auto row_index = current_group_offset; row_index < current_group_offset + group_size; ++row_index) {
+      const auto is_null = null_values[row_index];
+      if (is_null) {
+        continue;
+      }
+      auto& value = values[row_index];
+
+      aggregator(value, value_count, accumulator);
+      ++value_count;
+      if constexpr (aggregate_function == WindowFunction::Any) {
+        continue;
+      }
+      if constexpr (aggregate_function == WindowFunction::CountDistinct) {
+        distinct_values.insert(value);
+      }
+    }
+
+    if constexpr (aggregate_function == WindowFunction::CountDistinct) {
+      accumulators[group_index] = pmr_vector<ColumnType>(distinct_values.begin(), distinct_values.end());
+      counts[group_index] = accumulators[group_index].size();
+      group_keys[group_index] = normalized_keys[current_group_offset];
+    } else {
+      accumulators[group_index] = accumulator;
+      counts[group_index] = value_count;
+      group_keys[group_index] = normalized_keys[current_group_offset];
+    }
+    accumulator = AggregateAccumulator<aggregate_function, AggregateType>{};
+    distinct_values.clear();
+    value_count = 0;
+    current_group_offset += group_size;
+  }
+}
+
+void AggregateDYOD::Morsel::_merge_morsel(std::shared_ptr<Morsel>& other) {
+  /* 
+    * We first create a plan (instructions how to merge the two morsels) to only compare the keys once.
+    * According to this plan every aggregate is then merged separately.
+    * We then create a new list of representative keys from the same merge plan.
+  */
+
+  pmr_vector<MergeStep> merge_plan;
+  merge_plan.reserve(group_count + other->group_count);
+
+  auto source_index = uint64_t{0}, other_index = uint64_t{0};
+  while (source_index < group_count && other_index < other->group_count) {
+    const auto key_compare_result = _compare_keys(group_keys[source_index], other->group_keys[other_index]);
+
+    if (key_compare_result < 0) {
+      merge_plan.emplace_back(source_index, -1);
+      ++source_index;
+    } else if (key_compare_result > 0) {
+      merge_plan.emplace_back(-1, other_index);
+      ++other_index;
+    } else {
+      merge_plan.emplace_back(source_index, other_index);
+      ++source_index;
+      ++other_index;
+    }
+  }
+  while (source_index < group_count) {
+    merge_plan.emplace_back(source_index, -1);
+    ++source_index;
+  }
+  while (other_index < other->group_count) {
+    merge_plan.emplace_back(-1, other_index);
+    ++other_index;
+  }
+
+  auto aggregate_index = uint64_t{0};
+  for (const auto& aggregate : morsel_operator._aggregates) {
+    const auto& pqp_expression = static_cast<const PQPColumnExpression&>(*aggregate->argument());
+    const auto pqp_column_id = pqp_expression.column_id;
+
+    const auto data_type = pqp_column_id == INVALID_COLUMN_ID
+                               ? DataType::Long
+                               : morsel_operator.left_input_table()->column_data_type(pqp_column_id);
+    resolve_data_type(data_type, [&](auto type) {
+      using ColumnDataType = typename decltype(type)::type;
+
+      resolve_window_function(aggregate->window_function, [&](auto window_function_constant) {
+        constexpr auto aggregate_function = decltype(window_function_constant)::value;
+        using AggregateType = typename WindowFunctionTraits<ColumnDataType, aggregate_function>::ReturnType;
+        if constexpr (aggregate_function == WindowFunction::CountDistinct) {
+          _merge_single_aggregate<aggregate_function, ColumnDataType>(other, aggregate_index, merge_plan);
+        } else {
+          _merge_single_aggregate<aggregate_function, AggregateType>(other, aggregate_index, merge_plan);
+        }
+      });
+    });
+    ++aggregate_index;
+  }
+  const auto new_group_count = merge_plan.size();
+  auto merged_group_keys = pmr_vector<NormalizedKey>(new_group_count);
+  for (auto step_index = uint64_t{0}; step_index < new_group_count; ++step_index) {
+    const auto [source_index, other_index] = merge_plan[step_index];
+    if (source_index > -1 && other_index == -1) {
+      merged_group_keys[step_index] = std::move(group_keys[source_index]);
+    } else if (source_index == -1 && other_index > -1) {
+      merged_group_keys[step_index] = std::move(other->group_keys[other_index]);
+    } else {
+      merged_group_keys[step_index] = std::move(group_keys[source_index]);
+    }
+  }
+
+  group_keys = std::move(merged_group_keys);
+  group_count = new_group_count;
+}
+
+template <WindowFunction aggregate_function, typename AggregateType>
+void AggregateDYOD::Morsel::_merge_single_aggregate(std::shared_ptr<Morsel>& other, const uint64_t aggregate_index,
+                                                    const pmr_vector<MergeStep>& merge_plan) {
+  using Results = AggregateResults<aggregate_function, AggregateType>;
+  auto aggregator = WindowFunctionBuilder<AggregateType, AggregateType, aggregate_function>().get_aggregate_function();
+
+  const auto new_group_count = merge_plan.size();
+  auto merged = std::make_shared<Results>(new_group_count);
+  auto source_results = std::static_pointer_cast<Results>(aggregate_results[aggregate_index]);
+  auto other_results = std::static_pointer_cast<Results>(other->aggregate_results[aggregate_index]);
+
+  /*
+   * According to the plan we either move the accumulator from one morsel or we have to combine the results.
+   * This case involves mostly one more aggregation call since SUM,MIN and MAX are asssociative (with a slight
+   * disregard to floating-point arithmetic). There are specializations needed for StandardDeviationSampling
+   * and CountDistinct due to their non-standard nature of accumulators.
+  */
+  for (auto step_index = uint64_t{0}; step_index < new_group_count; ++step_index) {
+    const auto [source_index, other_index] = merge_plan[step_index];
+    if (other_index == -1 && source_index > -1) {
+      merged->accumulators[step_index] = std::move(source_results->accumulators[source_index]);
+      merged->counts[step_index] = source_results->counts[source_index];
+    } else if (source_index == -1 && other_index > -1) {
+      merged->accumulators[step_index] = std::move(other_results->accumulators[other_index]);
+      merged->counts[step_index] = other_results->counts[other_index];
+    } else {
+      /*
+        * We use an extension of Welford's online algorith, however not adjusted for the case where both counts are large
+        * and roughly the same (see https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Parallel_algorithm).
+      */
+      if constexpr (aggregate_function == WindowFunction::StandardDeviationSample) {
+        auto& accumulator_a = source_results->accumulators[source_index];
+        auto& accumulator_b = other_results->accumulators[other_index];
+
+        const auto count_a = accumulator_a[0], count_b = accumulator_b[0];
+        const auto new_count = count_a + count_b;
+        const auto delta_mean = accumulator_b[1] - accumulator_a[1];
+        const auto updated_mean = accumulator_a[1] + delta_mean * (count_b / new_count);
+        const auto updated_squared_distance =
+            accumulator_a[2] + accumulator_b[2] +
+            (delta_mean * delta_mean) * (static_cast<double>(count_a * count_b) / new_count);
+
+        accumulator_a[0] = new_count;
+        accumulator_a[1] = updated_mean;
+        accumulator_a[2] = updated_squared_distance;
+        if (new_count > 1) {
+          // The SQL standard defines VAR_SAMP (which is the basis of STDDEV_SAMP) as NULL if the number of values is 1.
+          const auto variance = updated_squared_distance / (new_count - 1);
+          accumulator_a[3] = std::sqrt(variance);
+        }
+      } else if constexpr (aggregate_function == WindowFunction::CountDistinct) {
+        // For CountDistinct we merge the sorted sets of distinct values with a linear merge.
+        pmr_vector<AggregateType> new_values;
+        const auto& source_values = source_results->accumulators[source_index];
+        const auto& other_values = other_results->accumulators[other_index];
+        new_values.reserve(source_values.size() + other_values.size());
+        std::ranges::set_union(source_values, other_values, std::back_inserter(new_values));
+        // We set these values so that after the update of the count and accumulator that happens
+        // in every case the count is the number of unique values and the accumulator contains
+        // the new set.
+        source_results->counts[source_index] = new_values.size();
+        other_results->counts[other_index] = 0;
+        source_results->accumulators[source_index] = std::move(new_values);
+      } else if (other_results->counts[other_index] != 0) {
+        aggregator(other_results->accumulators[other_index], source_results->counts[source_index],
+                   source_results->accumulators[source_index]);
+      }
+      merged->counts[step_index] = source_results->counts[source_index] + other_results->counts[other_index];
+      merged->accumulators[step_index] = std::move(source_results->accumulators[source_index]);
+    }
+  }
+
+  aggregate_results[aggregate_index] = std::move(merged);
+}
+
+template <WindowFunction aggregate_function, typename AggregateType>
+std::shared_ptr<ValueSegment<AggregateType>> AggregateDYOD::Morsel::_to_value_segment(uint64_t aggregate_index,
+                                                                                      bool nullable) {
+  /*
+   * To convert the accumulated values to output values we have to distinguish the aggregate_functions
+   * as in some cases the values cannot be read straight out of the accumulator, e.g. for AVG, we have to divide the
+   * accumulated value (which is just the sum) by the number of values. We then write these values into vectors
+   * with which we create ValueSegments that can be added to the results table.
+  */
+  using Results = AggregateResults<aggregate_function, AggregateType>;
+  const auto value_count = group_count;
+  auto values = pmr_vector<AggregateType>(value_count);
+  auto null_values = pmr_vector<bool>(value_count);
+  const auto results = std::static_pointer_cast<Results>(aggregate_results[aggregate_index]);
+  const auto& accumulators = results->accumulators;
+  const auto& counts = results->counts;
+
+  for (auto group_index = uint64_t{0}; group_index < group_count; ++group_index) {
+    const auto count = counts[group_index];
+    const auto& accumulator = accumulators[group_index];
+
+    if constexpr (aggregate_function == WindowFunction::StandardDeviationSample) {
+      if (accumulator[0] > 1) {
+        values[group_index] = accumulator[3];
+      } else {
+        null_values[group_index] = true;
+      }
+    } else if constexpr (aggregate_function == WindowFunction::Count) {
+      values[group_index] = static_cast<int64_t>(count);
+    } else if constexpr (aggregate_function == WindowFunction::Avg && std::is_arithmetic_v<AggregateType>) {
+      if (count == 0) {
+        null_values[group_index] = true;
+      } else {
+        values[group_index] = accumulator / static_cast<AggregateType>(count);
+      }
+    } else {
+      if (count == 0) {
+        null_values[group_index] = true;
+      } else {
+        values[group_index] = accumulator;
+      }
+    }
+  }
+
+  if (nullable) {
+    return std::make_shared<ValueSegment<AggregateType>>(std::move(values), std::move(null_values));
+  }
+  return std::make_shared<ValueSegment<AggregateType>>(std::move(values));
+}
+
+template <typename ColumnType>
+std::shared_ptr<ValueSegment<int64_t>> AggregateDYOD::Morsel::_distinct_to_value_segment(
+    const uint64_t aggregate_index) {
+  using Results = AggregateResults<WindowFunction::CountDistinct, ColumnType>;
+  const auto results = std::static_pointer_cast<Results>(aggregate_results[aggregate_index]);
+  const auto& counts = results->counts;
+
+  auto values = pmr_vector<int64_t>(group_count);
+
+  for (auto group_index = uint64_t{0}; group_index < group_count; ++group_index) {
+    values[group_index] = static_cast<int64_t>(counts[group_index]);
+  }
+
+  return std::make_shared<ValueSegment<int64_t>>(std::move(values));
+}
+
+void AggregateDYOD::_on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) {}
+
+void AggregateDYOD::_on_cleanup() {}
+
+template <typename ColumnType, typename AggregateType, WindowFunction aggregate_function>
+std::shared_ptr<ValueSegment<AggregateType>> AggregateDYOD::_aggregate_values_without_groups(
+    const uint64_t aggregate_index) {
+  /*
+   * For the Aggregation without groups we do not need to perform checks for groups. We also
+   * perform the transformation into the proper values and creation of the ValueSegments
+   * right away (unlike with _to_value_segment()) since we already have all the data in one place 
+   * after the aggregation is finished.
+  */
+  const auto& pqp_column = static_cast<const PQPColumnExpression&>(*_aggregates[aggregate_index]->argument());
+  const auto input_column_id = pqp_column.column_id;
+  auto value_count = uint64_t{0};
+
+  auto accumulated_values = pmr_vector<AggregateType>();
+  auto accumulated_null_values = pmr_vector<bool>();
+
+  auto accumulator = AggregateAccumulator<aggregate_function, AggregateType>{};
+  auto is_null = (aggregate_function != WindowFunction::Count && aggregate_function != WindowFunction::CountDistinct);
+  auto aggregator = WindowFunctionBuilder<ColumnType, AggregateType, aggregate_function>().get_aggregate_function();
+  auto distinct_values = std::unordered_set<ColumnType>();
+
+  const auto input_table = left_input_table();
+  const auto chunk_count = input_table->chunk_count();
+
+  if constexpr (aggregate_function == WindowFunction::Count && std::is_arithmetic_v<AggregateType>) {
+    accumulated_values.push_back(input_table->row_count());
+    return std::make_shared<ValueSegment<AggregateType>>(std::move(accumulated_values));
+  }
+
+  for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
+    auto segment = input_table->get_chunk(chunk_id)->get_segment(input_column_id);
+    segment_iterate<ColumnType>(*segment, [&](const auto& position) {
+      is_null = false;
+      const auto& new_value = position.value();
+      if (!position.is_null()) {
+        aggregator(new_value, value_count, accumulator);
+        ++value_count;
+        if constexpr (aggregate_function == WindowFunction::Any) {
+          return;
+        }
+        if constexpr (aggregate_function == WindowFunction::CountDistinct) {
+          distinct_values.insert(new_value);
+        }
+      }
+    });
+  }
+
+  if constexpr (aggregate_function == WindowFunction::Avg && std::is_arithmetic_v<AggregateType>) {
+    if (value_count > 0) {
+      accumulator = accumulator / static_cast<AggregateType>(value_count);
+    }
+  }
+
+  if constexpr (aggregate_function == WindowFunction::CountDistinct && std::is_arithmetic_v<AggregateType>) {
+    accumulator = size(distinct_values);
+  }
+
+  if constexpr (aggregate_function == WindowFunction::StandardDeviationSample && std::is_arithmetic_v<ColumnType>) {
+    if (value_count >= 2) {
+      accumulated_values.push_back(accumulator[3]);
+    } else {
+      // STDDEV_SAMP is undefined for lists with less than two elements
+      is_null = true;
+    }
+  }
+
+  if constexpr (aggregate_function != WindowFunction::StandardDeviationSample) {
+    accumulated_values.push_back(accumulator);
+  }
+
+  accumulated_null_values.push_back(is_null);
+
+  if constexpr (aggregate_function != WindowFunction::Count && aggregate_function != WindowFunction::CountDistinct) {
+    return std::make_shared<ValueSegment<AggregateType>>(std::move(accumulated_values),
+                                                         std::move(accumulated_null_values));
+  } else {
+    return std::make_shared<ValueSegment<AggregateType>>(std::move(accumulated_values));
+  }
+}
+
+template <typename ColumnType>
+void AggregateDYOD::_create_aggregate_column_definitions(boost::hana::basic_type<ColumnType> /*type*/,
+                                                         ColumnID column_index, WindowFunction aggregate_function) {
+  /*
+   * We are aware that the switch looks very repetitive, but we could not find a dynamic solution.
+   * There is a similar switch statement in _on_execute for calling _aggregate_values.
+   * See the comment there for reasoning.
+   */
+  switch (aggregate_function) {
+    case WindowFunction::Min:
+      create_aggregate_column_definitions<ColumnType, WindowFunction::Min>(column_index);
+      break;
+    case WindowFunction::Max:
+      create_aggregate_column_definitions<ColumnType, WindowFunction::Max>(column_index);
+      break;
+    case WindowFunction::Sum:
+      create_aggregate_column_definitions<ColumnType, WindowFunction::Sum>(column_index);
+      break;
+    case WindowFunction::Avg:
+      create_aggregate_column_definitions<ColumnType, WindowFunction::Avg>(column_index);
+      break;
+    case WindowFunction::Count:
+      create_aggregate_column_definitions<ColumnType, WindowFunction::Count>(column_index);
+      break;
+    case WindowFunction::CountDistinct:
+      create_aggregate_column_definitions<ColumnType, WindowFunction::CountDistinct>(column_index);
+      break;
+    case WindowFunction::StandardDeviationSample:
+      create_aggregate_column_definitions<ColumnType, WindowFunction::StandardDeviationSample>(column_index);
+      break;
+    case WindowFunction::Any:
+      create_aggregate_column_definitions<ColumnType, WindowFunction::Any>(column_index);
+      break;
+    default:
+      Fail(std::format("Unsupported aggregate function '{}'.", window_function_to_string.left.at(aggregate_function)));
+  }
+}
+
+template <typename ColumnType, WindowFunction aggregate_function>
+void AggregateDYOD::create_aggregate_column_definitions(ColumnID column_index) {
+  // retrieve type information from the aggregation traits
+  auto result_type = WindowFunctionTraits<ColumnType, aggregate_function>::RESULT_TYPE;
+
+  const auto& aggregate = _aggregates[column_index];
+  const auto& pqp_column = static_cast<const PQPColumnExpression&>(*aggregate->argument());
+  const auto input_column_id = pqp_column.column_id;
+
+  if (result_type == DataType::Null) {
+    // if not specified, it’s the input column’s type
+    result_type = left_input_table()->column_data_type(input_column_id);
+  }
+
+  const auto nullable =
+      (aggregate_function != WindowFunction::Count && aggregate_function != WindowFunction::CountDistinct &&
+       aggregate_function != WindowFunction::Any) ||
+      (aggregate_function == WindowFunction::Any && left_input_table()->column_is_nullable(input_column_id));
+  const auto column_name =
+      aggregate->window_function == WindowFunction::Any ? pqp_column.as_column_name() : aggregate->as_column_name();
+  _output_column_definitions.emplace_back(column_name, result_type, nullable);
+}
+
+}  // namespace hyrise

--- a/src/lib/operators/aggregate_dyod.cpp
+++ b/src/lib/operators/aggregate_dyod.cpp
@@ -679,8 +679,10 @@ void AggregateDYOD::Morsel::aggregate_morsel(const uint64_t aggregate_index) {
     }
 
     if constexpr (aggregate_function == WindowFunction::CountDistinct) {
-      accumulators[group_index] = pmr_vector<ColumnType>(distinct_values.begin(), distinct_values.end());
-      counts[group_index] = accumulators[group_index].size();
+      auto group_distinct_values = pmr_vector<ColumnType>(distinct_values.begin(), distinct_values.end());
+      boost::sort::pdqsort(group_distinct_values.begin(), group_distinct_values.end());
+      counts[group_index] = group_distinct_values.size();
+      accumulators[group_index] = std::move(group_distinct_values);
       group_keys[group_index] = normalized_keys[current_group_offset];
     } else {
       accumulators[group_index] = accumulator;
@@ -942,9 +944,12 @@ std::shared_ptr<ValueSegment<AggregateType>> AggregateDYOD::_aggregate_values_wi
   const auto input_table = left_input_table();
   const auto chunk_count = input_table->chunk_count();
 
+  // This is a special case for the count(*): We can simply return the row count.
   if constexpr (aggregate_function == WindowFunction::Count) {
-    accumulated_values.push_back(input_table->row_count());
-    return std::make_shared<ValueSegment<AggregateType>>(std::move(accumulated_values));
+    if (input_column_id == INVALID_COLUMN_ID) {
+      accumulated_values.push_back(static_cast<AggregateType>(input_table->row_count()));
+      return std::make_shared<ValueSegment<AggregateType>>(std::move(accumulated_values));
+    }
   }
 
   for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
@@ -966,6 +971,10 @@ std::shared_ptr<ValueSegment<AggregateType>> AggregateDYOD::_aggregate_values_wi
     if (value_count > 0) {
       accumulator = accumulator / static_cast<AggregateType>(value_count);
     }
+  }
+
+  if constexpr (aggregate_function == WindowFunction::Count) {
+    accumulator = static_cast<AggregateType>(value_count);
   }
 
   if constexpr (aggregate_function == WindowFunction::CountDistinct && std::is_arithmetic_v<AggregateType>) {

--- a/src/lib/operators/aggregate_dyod.cpp
+++ b/src/lib/operators/aggregate_dyod.cpp
@@ -2,8 +2,9 @@
 
 #include <algorithm>
 #include <cmath>
-#include <cstddef>
 #include <compare>
+#include <concepts>
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <format>
@@ -23,22 +24,22 @@
 #include "all_type_variant.hpp"
 #include "expression/abstract_expression.hpp"
 #include "expression/pqp_column_expression.hpp"
+#include "expression/window_function_expression.hpp"
 #include "hyrise.hpp"
 #include "operators/abstract_aggregate_operator.hpp"
 #include "operators/abstract_operator.hpp"
+#include "operators/aggregate/window_function_traits.hpp"
+#include "resolve_type.hpp"
+#include "scheduler/abstract_task.hpp"
+#include "scheduler/job_task.hpp"
 #include "storage/abstract_segment.hpp"
+#include "storage/chunk.hpp"
 #include "storage/segment_iterate.hpp"
 #include "storage/table.hpp"
 #include "storage/table_column_definition.hpp"
-#include "types.hpp"
-#include "expression/window_function_expression.hpp"
-#include "utils/assert.hpp"
-#include "storage/chunk.hpp"
-#include "resolve_type.hpp"
-#include "operators/aggregate/window_function_traits.hpp"
-#include "scheduler/abstract_task.hpp"
-#include "scheduler/job_task.hpp"
 #include "storage/value_segment.hpp"
+#include "types.hpp"
+#include "utils/assert.hpp"
 
 namespace hyrise {
 
@@ -130,8 +131,7 @@ uint8_t key_data_length_null(const DataType data_type) {
 
 }  // namespace
 
-void AggregateDYOD::_normalize_chunk_groupby(const std::shared_ptr<const Chunk>& input_chunk,
-                                             const uint64_t row_offset,
+void AggregateDYOD::_normalize_chunk_groupby(const std::shared_ptr<const Chunk>& input_chunk, const uint64_t row_offset,
                                              uninitialized_vector<AggregateDYOD::NormalizedKey>& key_vector,
                                              uninitialized_vector<uint8_t>& byte_vector,
                                              pmr_vector<pmr_string>& groupby_strings) {
@@ -249,7 +249,7 @@ std::shared_ptr<const Table> AggregateDYOD::_on_execute() {
     const auto data_type = column_id == INVALID_COLUMN_ID ? DataType::Long : input_table->column_data_type(column_id);
 
     resolve_data_type(data_type, [&, aggregate_index](auto type) {
-      create_aggregate_column_definitions(type, aggregate_index, aggregate->window_function);
+      _create_aggregate_column_definitions(type, aggregate_index, aggregate->window_function);
     });
 
     ++aggregate_index;
@@ -334,173 +334,172 @@ std::shared_ptr<const Table> AggregateDYOD::_on_execute() {
    *      When all morsels have finished, we binary merge the morsels together.
    *      We then write the group and aggregate values into the result table and return.
   */
-    auto key_bytes = uninitialized_vector<uint8_t>(row_count * (_normalized_key_size + _groupby_string_count * 8));
-    auto normalized_keys = uninitialized_vector<NormalizedKey>(row_count);
-    auto groupby_strings = pmr_vector<pmr_string>(row_count * _groupby_string_count);
+  auto key_bytes = uninitialized_vector<uint8_t>(row_count * (_normalized_key_size + _groupby_string_count * 8));
+  auto normalized_keys = uninitialized_vector<NormalizedKey>(row_count);
+  auto groupby_strings = pmr_vector<pmr_string>(row_count * _groupby_string_count);
 
-    const auto chunk_count = input_table->chunk_count();
-    auto chunk_normalization_tasks = std::vector<std::shared_ptr<AbstractTask>>(chunk_count);
+  const auto chunk_count = input_table->chunk_count();
+  auto chunk_normalization_tasks = std::vector<std::shared_ptr<AbstractTask>>(chunk_count);
 
-    auto row_offset = uint64_t{0};
-    for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
-      chunk_normalization_tasks[chunk_id] = std::make_shared<JobTask>([&, chunk_id, row_offset]() {
-        const auto chunk = input_table->get_chunk(chunk_id);
-        _normalize_chunk_groupby(chunk, row_offset, normalized_keys, key_bytes, groupby_strings);
-        _materialize_chunk_aggregates(chunk, row_offset);
-      });
-      row_offset += input_table->get_chunk(chunk_id)->size();
-    }
+  auto row_offset = uint64_t{0};
+  for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
+    chunk_normalization_tasks[chunk_id] = std::make_shared<JobTask>([&, chunk_id, row_offset]() {
+      const auto chunk = input_table->get_chunk(chunk_id);
+      _normalize_chunk_groupby(chunk, row_offset, normalized_keys, key_bytes, groupby_strings);
+      _materialize_chunk_aggregates(chunk, row_offset);
+    });
+    row_offset += input_table->get_chunk(chunk_id)->size();
+  }
 
-    Hyrise::get().scheduler()->schedule_and_wait_for_tasks(chunk_normalization_tasks);
+  Hyrise::get().scheduler()->schedule_and_wait_for_tasks(chunk_normalization_tasks);
 
-    const auto is_multi_threaded = Hyrise::get().is_multi_threaded();
-    // If we run on a single thread we avoid the overhead of splitting everything up into chunks and
-    // still processing them sequentially and perform aggregation over the entire table in one go.
-    // This avoids merging as well, which can be quite expensive with our implementation.
-    const auto desired_morsel_size = is_multi_threaded ? ChunkOffset{10'000} : row_count;
-    const auto morsel_count =
-        is_multi_threaded ? (row_count + desired_morsel_size - 1) / desired_morsel_size : 1;
+  const auto is_multi_threaded = Hyrise::get().is_multi_threaded();
+  // If we run on a single thread we avoid the overhead of splitting everything up into chunks and
+  // still processing them sequentially and perform aggregation over the entire table in one go.
+  // This avoids merging as well, which can be quite expensive with our implementation.
+  const auto desired_morsel_size = is_multi_threaded ? ChunkOffset{10'000} : row_count;
+  const auto morsel_count = is_multi_threaded ? (row_count + desired_morsel_size - 1) / desired_morsel_size : 1;
 
-    auto morsels = std::vector<std::shared_ptr<Morsel>>(morsel_count);
-    auto aggregation_tasks = std::vector<std::shared_ptr<AbstractTask>>{};
-    aggregation_tasks.reserve(morsel_count);
-    auto morsel_range_start = uint64_t{0};
+  auto morsels = std::vector<std::shared_ptr<Morsel>>(morsel_count);
+  auto aggregation_tasks = std::vector<std::shared_ptr<AbstractTask>>{};
+  aggregation_tasks.reserve(morsel_count);
+  auto morsel_range_start = uint64_t{0};
 
-    for (auto& morsel : morsels) {
-      const auto morsel_range_end = std::min(morsel_range_start + desired_morsel_size, input_table->row_count()) - 1;
-      const auto morsel_size = morsel_range_end - morsel_range_start + 1;
-      auto normalized_key_span = std::span<NormalizedKey>(normalized_keys.begin() + morsel_range_start, morsel_size);
+  for (auto& morsel : morsels) {
+    const auto morsel_range_end = std::min(morsel_range_start + desired_morsel_size, input_table->row_count()) - 1;
+    const auto morsel_size = morsel_range_end - morsel_range_start + 1;
+    auto normalized_key_span = std::span<NormalizedKey>(normalized_keys.begin() + morsel_range_start, morsel_size);
 
-      morsel = std::make_shared<Morsel>(*this, morsel_size, morsel_range_start, key_bytes, normalized_key_span,
-                                        groupby_strings);
-      morsel_range_start += desired_morsel_size;
+    morsel = std::make_shared<Morsel>(*this, morsel_size, morsel_range_start, key_bytes, normalized_key_span,
+                                      groupby_strings);
+    morsel_range_start += desired_morsel_size;
 
-      aggregation_tasks.push_back(std::make_shared<JobTask>([&]() {
-        morsel->sort_morsel_range();
+    aggregation_tasks.push_back(std::make_shared<JobTask>([&]() {
+      morsel->sort_morsel_range();
 
-        auto aggregate_index = uint64_t{0};
-        for (const auto& aggregate : _aggregates) {
-          const auto& pqp_expression = static_cast<const PQPColumnExpression&>(*aggregate->argument());
-          const auto pqp_column_id = pqp_expression.column_id;
+      auto aggregate_index = uint64_t{0};
+      for (const auto& aggregate : _aggregates) {
+        const auto& pqp_expression = static_cast<const PQPColumnExpression&>(*aggregate->argument());
+        const auto pqp_column_id = pqp_expression.column_id;
 
-          const auto data_type =
-              pqp_column_id == INVALID_COLUMN_ID ? DataType::Long : input_table->column_data_type(pqp_column_id);
-          resolve_data_type(data_type, [&](auto type) {
-            using ColumnDataType = typename decltype(type)::type;
+        const auto data_type =
+            pqp_column_id == INVALID_COLUMN_ID ? DataType::Long : input_table->column_data_type(pqp_column_id);
+        resolve_data_type(data_type, [&](auto type) {
+          using ColumnDataType = typename decltype(type)::type;
 
-            resolve_window_function(aggregate->window_function, [&](auto window_function_constant) {
-              constexpr auto AGGREGATE_FUNCTION = decltype(window_function_constant)::value;
-              using AggregateType = typename WindowFunctionTraits<ColumnDataType, AGGREGATE_FUNCTION>::ReturnType;
+          resolve_window_function(aggregate->window_function, [&](auto window_function_constant) {
+            constexpr auto AGGREGATE_FUNCTION = decltype(window_function_constant)::value;
+            using AggregateType = typename WindowFunctionTraits<ColumnDataType, AGGREGATE_FUNCTION>::ReturnType;
 
-              morsel->aggregate_morsel<ColumnDataType, AGGREGATE_FUNCTION, AggregateType>(aggregate_index);
-            });
+            morsel->aggregate_morsel<ColumnDataType, AGGREGATE_FUNCTION, AggregateType>(aggregate_index);
           });
-          ++aggregate_index;
-        }
+        });
+        ++aggregate_index;
+      }
+    }));
+  }
+
+  Hyrise::get().scheduler()->schedule_and_wait_for_tasks(aggregation_tasks);
+
+  // We merge the morsel results with a binary strategy. For this we start with a merge distance
+  // of one, where a morsel is merged with the next. We now double the distance, so a morsel gets merged
+  // with one distance two away, and thus contains the merged results of 4 consecutive morsels. We repeat this
+  // process until the first morsel contains all information.
+  for (auto merge_distance = size_t{1}; merge_distance < morsel_count; merge_distance *= 2) {
+    auto merge_tasks = std::vector<std::shared_ptr<AbstractTask>>{};
+    merge_tasks.reserve((morsel_count + merge_distance - 1) / (2 * merge_distance));
+    for (auto morsel_id = size_t{0}; morsel_id + merge_distance < morsel_count; morsel_id += 2 * merge_distance) {
+      merge_tasks.push_back(std::make_shared<JobTask>([&, morsel_id, merge_distance]() {
+        const auto& morsel1 = morsels[morsel_id];
+        auto morsel2 = morsels[morsel_id + merge_distance];
+
+        morsel1->merge_morsel(morsel2);
       }));
     }
 
-    Hyrise::get().scheduler()->schedule_and_wait_for_tasks(aggregation_tasks);
+    Hyrise::get().scheduler()->schedule_and_wait_for_tasks(merge_tasks);
+  }
 
-    // We merge the morsel results with a binary strategy. For this we start with a merge distance
-    // of one, where a morsel is merged with the next. We now double the distance, so a morsel gets merged
-    // with one distance two away, and thus contains the merged results of 4 consecutive morsels. We repeat this
-    // process until the first morsel contains all information.
-    for (auto merge_distance = size_t{1}; merge_distance < morsel_count; merge_distance *= 2) {
-      auto merge_tasks = std::vector<std::shared_ptr<AbstractTask>>{};
-      merge_tasks.reserve((morsel_count + merge_distance - 1) / (2 * merge_distance));
-      for (auto morsel_id = size_t{0}; morsel_id + merge_distance < morsel_count; morsel_id += 2 * merge_distance) {
-        merge_tasks.push_back(std::make_shared<JobTask>([&, morsel_id, merge_distance]() {
-          const auto& morsel1 = morsels[morsel_id];
-          auto morsel2 = morsels[morsel_id + merge_distance];
+  // Our binary merge strategy guarantees that the final results are in the first morsel.
+  const auto final_morsel = morsels[0];
+  const auto value_count = final_morsel->group_count;
 
-          morsel1->merge_morsel(morsel2);
-        }));
+  // Writing the group values to the table
+  // Since we store everything except strings directly in its byte representation in the keys
+  // we simply decode it from there. For strings we decode the index into the global string
+  // buffer and get the string from there.
+  auto group_key_offset = uint64_t{0};
+  auto group_string_offset = uint64_t{0};
+  for (const auto& column_id : _groupby_column_ids) {
+    const auto column_is_nullable = left_input_table()->column_is_nullable(column_id);
+    const auto data_type = left_input_table()->column_data_type(column_id);
+    const auto data_length = key_data_length(data_type);
+    auto value_index = uint64_t{0};
+    resolve_data_type(data_type, [&](auto type) {
+      using ColumnDataType = typename decltype(type)::type;
+
+      auto values = pmr_vector<ColumnDataType>(value_count);
+      auto null_values = pmr_vector<bool>(value_count);
+
+      for (const auto& key : final_morsel->group_keys) {
+        if constexpr (std::is_arithmetic_v<ColumnDataType>) {
+          std::memcpy(&values[value_index], key_bytes.data() + key + group_key_offset, data_length);
+        } else {
+          auto string_index = uint64_t{0};
+          std::memcpy(&string_index, key_bytes.data() + key + _normalized_key_size + (group_string_offset * 8), 8);
+          values[value_index] = groupby_strings[string_index];
+        }
+        null_values[value_index] = key_bytes[key + group_key_offset + data_length] == 0;
+        ++value_index;
       }
 
-      Hyrise::get().scheduler()->schedule_and_wait_for_tasks(merge_tasks);
-    }
+      if (column_is_nullable) {
+        _output_segments.push_back(
+            std::make_shared<ValueSegment<ColumnDataType>>(std::move(values), std::move(null_values)));
+      } else {
+        _output_segments.push_back(std::make_shared<ValueSegment<ColumnDataType>>(std::move(values)));
+      }
+      group_key_offset += key_data_length_null(data_type);
+      if constexpr (std::is_same_v<ColumnDataType, pmr_string>) {
+        ++group_string_offset;
+      }
+    });
+  }
 
-    // Our binary merge strategy guarantees that the final results are in the first morsel.
-    const auto final_morsel = morsels[0];
-    const auto value_count = final_morsel->group_count;
+  aggregate_index = uint64_t{0};
+  for (const auto& aggregate : _aggregates) {
+    const auto& pqp_expression = static_cast<const PQPColumnExpression&>(*aggregate->argument());
+    const auto pqp_column_id = pqp_expression.column_id;
+    const auto data_type =
+        pqp_column_id == INVALID_COLUMN_ID ? DataType::Long : input_table->column_data_type(pqp_column_id);
+    resolve_data_type(data_type, [&](auto type) {
+      using ColumnDataType = typename decltype(type)::type;
+      resolve_window_function(aggregate->window_function, [&](auto window_function_constant) {
+        constexpr auto AGGREGATE_FUNCTION = decltype(window_function_constant)::value;
+        using AggregateType = typename WindowFunctionTraits<ColumnDataType, AGGREGATE_FUNCTION>::ReturnType;
+        const auto nullable =
+            (AGGREGATE_FUNCTION != WindowFunction::Count && AGGREGATE_FUNCTION != WindowFunction::CountDistinct &&
+             AGGREGATE_FUNCTION != WindowFunction::Any) ||
+            (AGGREGATE_FUNCTION == WindowFunction::Any && left_input_table()->column_is_nullable(pqp_column_id));
 
-    // Writing the group values to the table
-    // Since we store everything except strings directly in its byte representation in the keys
-    // we simply decode it from there. For strings we decode the index into the global string
-    // buffer and get the string from there.
-    auto group_key_offset = uint64_t{0};
-    auto group_string_offset = uint64_t{0};
-    for (const auto& column_id : _groupby_column_ids) {
-      const auto column_is_nullable = left_input_table()->column_is_nullable(column_id);
-      const auto data_type = left_input_table()->column_data_type(column_id);
-      const auto data_length = key_data_length(data_type);
-      auto value_index = uint64_t{0};
-      resolve_data_type(data_type, [&](auto type) {
-        using ColumnDataType = typename decltype(type)::type;
-
-        auto values = pmr_vector<ColumnDataType>(value_count);
-        auto null_values = pmr_vector<bool>(value_count);
-
-        for (const auto& key : final_morsel->group_keys) {
-          if constexpr (std::is_arithmetic_v<ColumnDataType>) {
-            std::memcpy(&values[value_index], key_bytes.data() + key + group_key_offset, data_length);
-          } else {
-            auto string_index = uint64_t{0};
-            std::memcpy(&string_index, key_bytes.data() + key + _normalized_key_size + (group_string_offset * 8), 8);
-            values[value_index] = groupby_strings[string_index];
-          }
-          null_values[value_index] = key_bytes[key + group_key_offset + data_length] == 0;
-          ++value_index;
-        }
-
-        if (column_is_nullable) {
-          _output_segments.push_back(
-              std::make_shared<ValueSegment<ColumnDataType>>(std::move(values), std::move(null_values)));
+        // This case is needed here to tell the compiler that to_value_segment will not
+        // be instantiated with StandardDeviationSample and a non-arithmetic type.
+        if constexpr (AGGREGATE_FUNCTION == WindowFunction::StandardDeviationSample &&
+                      !std::is_arithmetic_v<ColumnDataType>) {
+          Fail("Standard Deviation sampling is not supported on non-arithmetic types.");
+        } else if constexpr (AGGREGATE_FUNCTION == WindowFunction::CountDistinct) {
+          _output_segments.push_back(final_morsel->distinct_to_value_segment<ColumnDataType>(aggregate_index));
         } else {
-          _output_segments.push_back(std::make_shared<ValueSegment<ColumnDataType>>(std::move(values)));
-        }
-        group_key_offset += key_data_length_null(data_type);
-        if constexpr (std::is_same_v<ColumnDataType, pmr_string>) {
-          ++group_string_offset;
+          _output_segments.push_back(
+              final_morsel->to_value_segment<AGGREGATE_FUNCTION, AggregateType>(aggregate_index, nullable));
         }
       });
-    }
+    });
+    ++aggregate_index;
+  }
 
-    aggregate_index = uint64_t{0};
-    for (const auto& aggregate : _aggregates) {
-      const auto& pqp_expression = static_cast<const PQPColumnExpression&>(*aggregate->argument());
-      const auto pqp_column_id = pqp_expression.column_id;
-      const auto data_type =
-          pqp_column_id == INVALID_COLUMN_ID ? DataType::Long : input_table->column_data_type(pqp_column_id);
-      resolve_data_type(data_type, [&](auto type) {
-        using ColumnDataType = typename decltype(type)::type;
-        resolve_window_function(aggregate->window_function, [&](auto window_function_constant) {
-          constexpr auto AGGREGATE_FUNCTION = decltype(window_function_constant)::value;
-          using AggregateType = typename WindowFunctionTraits<ColumnDataType, AGGREGATE_FUNCTION>::ReturnType;
-          const auto nullable =
-              (AGGREGATE_FUNCTION != WindowFunction::Count && AGGREGATE_FUNCTION != WindowFunction::CountDistinct &&
-               AGGREGATE_FUNCTION != WindowFunction::Any) ||
-              (AGGREGATE_FUNCTION == WindowFunction::Any && left_input_table()->column_is_nullable(pqp_column_id));
-
-          // This case is needed here to tell the compiler that to_value_segment will not
-          // be instantiated with StandardDeviationSample and a non-arithmetic type.
-          if constexpr (AGGREGATE_FUNCTION == WindowFunction::StandardDeviationSample &&
-                        !std::is_arithmetic_v<ColumnDataType>) {
-            Fail("Standard Deviation sampling is not supported on non-arithmetic types.");
-          } else if constexpr (AGGREGATE_FUNCTION == WindowFunction::CountDistinct) {
-            _output_segments.push_back(final_morsel->distinct_to_value_segment<ColumnDataType>(aggregate_index));
-          } else {
-            _output_segments.push_back(
-                final_morsel->to_value_segment<AGGREGATE_FUNCTION, AggregateType>(aggregate_index, nullable));
-          }
-        });
-      });
-      ++aggregate_index;
-    }
-
-    result_table->append_chunk(_output_segments);
-    return result_table;
+  result_table->append_chunk(_output_segments);
+  return result_table;
 }
 
 std::shared_ptr<AbstractOperator> AggregateDYOD::_on_deep_copy(
@@ -516,7 +515,8 @@ std::weak_ordering AggregateDYOD::Morsel::compare_keys(const NormalizedKey& firs
 
   if (memcmp_result < 0) {
     return std::weak_ordering::less;
-  } else if (memcmp_result > 0) {
+  }
+  if (memcmp_result > 0) {
     return std::weak_ordering::greater;
   }
 
@@ -770,7 +770,7 @@ void AggregateDYOD::Morsel::merge_morsel(std::shared_ptr<Morsel>& other) {
 
 template <WindowFunction aggregate_function, typename AggregateType>
 void AggregateDYOD::Morsel::merge_single_aggregate(std::shared_ptr<Morsel>& other, const uint64_t aggregate_index,
-                                                    const pmr_vector<MergeStep>& merge_plan) {
+                                                   const pmr_vector<MergeStep>& merge_plan) {
   using Results = AggregateResults<aggregate_function, AggregateType>;
   auto aggregator = WindowFunctionBuilder<AggregateType, AggregateType, aggregate_function>().get_aggregate_function();
 
@@ -846,7 +846,7 @@ void AggregateDYOD::Morsel::merge_single_aggregate(std::shared_ptr<Morsel>& othe
 
 template <WindowFunction aggregate_function, typename AggregateType>
 std::shared_ptr<ValueSegment<AggregateType>> AggregateDYOD::Morsel::to_value_segment(uint64_t aggregate_index,
-                                                                                      bool nullable) {
+                                                                                     bool nullable) {
   /*
    * To convert the accumulated values to output values we have to distinguish the aggregate_functions
    * as in some cases the values cannot be read straight out of the accumulator, e.g. for AVG, we have to divide the
@@ -996,22 +996,22 @@ std::shared_ptr<ValueSegment<AggregateType>> AggregateDYOD::_aggregate_values_wi
 }
 
 template <typename ColumnType>
-void AggregateDYOD::create_aggregate_column_definitions(boost::hana::basic_type<ColumnType> /*type*/,
+void AggregateDYOD::_create_aggregate_column_definitions(boost::hana::basic_type<ColumnType> /*type*/,
                                                          ColumnID column_index, WindowFunction aggregate_function) {
   /*
    * We are aware that the switch looks very repetitive, but we could not find a dynamic solution.
    * There is a similar switch statement in _on_execute for calling _aggregate_values.
    * See the comment there for reasoning.
    */
-    resolve_window_function(aggregate_function, [&](auto window_function_constant) {
-      constexpr auto AGGREGATE_FUNCTION = decltype(window_function_constant)::value;
+  resolve_window_function(aggregate_function, [&](auto window_function_constant) {
+    constexpr auto AGGREGATE_FUNCTION = decltype(window_function_constant)::value;
 
-      create_aggregate_column_definitions<ColumnType, AGGREGATE_FUNCTION>(column_index);
-    });
+    _create_aggregate_column_definitions<ColumnType, AGGREGATE_FUNCTION>(column_index);
+  });
 }
 
 template <typename ColumnType, WindowFunction aggregate_function>
-void AggregateDYOD::create_aggregate_column_definitions(ColumnID column_index) {
+void AggregateDYOD::_create_aggregate_column_definitions(ColumnID column_index) {
   // retrieve type information from the aggregation traits
   auto result_type = WindowFunctionTraits<ColumnType, aggregate_function>::RESULT_TYPE;
 

--- a/src/lib/operators/aggregate_dyod.cpp
+++ b/src/lib/operators/aggregate_dyod.cpp
@@ -353,13 +353,13 @@ std::shared_ptr<const Table> AggregateDYOD::_on_execute() {
 
     Hyrise::get().scheduler()->schedule_and_wait_for_tasks(chunk_normalization_tasks);
 
-    constexpr auto DESIRED_MORSEL_SIZE = ChunkOffset{2};
     const auto is_multi_threaded = Hyrise::get().is_multi_threaded();
     // If we run on a single thread we avoid the overhead of splitting everything up into chunks and
     // still processing them sequentially and perform aggregation over the entire table in one go.
     // This avoids merging as well, which can be quite expensive with our implementation.
+    const auto desired_morsel_size = is_multi_threaded ? ChunkOffset{10'000} : row_count;
     const auto morsel_count =
-        is_multi_threaded ? (normalized_keys.size() + DESIRED_MORSEL_SIZE - 1) / DESIRED_MORSEL_SIZE : 1;
+        is_multi_threaded ? (row_count + desired_morsel_size - 1) / desired_morsel_size : 1;
 
     auto morsels = std::vector<std::shared_ptr<Morsel>>(morsel_count);
     auto aggregation_tasks = std::vector<std::shared_ptr<AbstractTask>>{};
@@ -367,13 +367,13 @@ std::shared_ptr<const Table> AggregateDYOD::_on_execute() {
     auto morsel_range_start = uint64_t{0};
 
     for (auto& morsel : morsels) {
-      const auto morsel_range_end = std::min(morsel_range_start + DESIRED_MORSEL_SIZE, input_table->row_count()) - 1;
+      const auto morsel_range_end = std::min(morsel_range_start + desired_morsel_size, input_table->row_count()) - 1;
       const auto morsel_size = morsel_range_end - morsel_range_start + 1;
       auto normalized_key_span = std::span<NormalizedKey>(normalized_keys.begin() + morsel_range_start, morsel_size);
 
       morsel = std::make_shared<Morsel>(*this, morsel_size, morsel_range_start, key_bytes, normalized_key_span,
                                         groupby_strings);
-      morsel_range_start += DESIRED_MORSEL_SIZE;
+      morsel_range_start += desired_morsel_size;
 
       aggregation_tasks.push_back(std::make_shared<JobTask>([&]() {
         morsel->sort_morsel_range();
@@ -1004,9 +1004,9 @@ void AggregateDYOD::create_aggregate_column_definitions(boost::hana::basic_type<
    * See the comment there for reasoning.
    */
     resolve_window_function(aggregate_function, [&](auto window_function_constant) {
-      constexpr auto AggregateFunction = decltype(window_function_constant)::value;
+      constexpr auto AGGREGATE_FUNCTION = decltype(window_function_constant)::value;
 
-      create_aggregate_column_definitions<ColumnType, AggregateFunction>(column_index);
+      create_aggregate_column_definitions<ColumnType, AGGREGATE_FUNCTION>(column_index);
     });
 }
 

--- a/src/lib/operators/aggregate_dyod.cpp
+++ b/src/lib/operators/aggregate_dyod.cpp
@@ -1,19 +1,13 @@
 #include "aggregate_dyod.hpp"
 
 #include <algorithm>
-#include <array>
-#include <atomic>
-#include <chrono>
 #include <cmath>
 #include <cstddef>
+#include <compare>
 #include <cstdint>
+#include <cstring>
 #include <format>
-#include <functional>
-#include <limits>
 #include <memory>
-#include <memory_resource>
-#include <numeric>
-#include <ranges>
 #include <span>
 #include <string>
 #include <type_traits>
@@ -37,17 +31,21 @@
 #include "storage/table.hpp"
 #include "storage/table_column_definition.hpp"
 #include "types.hpp"
+#include "expression/window_function_expression.hpp"
+#include "utils/assert.hpp"
+#include "storage/chunk.hpp"
+#include "resolve_type.hpp"
+#include "operators/aggregate/window_function_traits.hpp"
+#include "scheduler/abstract_task.hpp"
+#include "scheduler/job_task.hpp"
+#include "storage/value_segment.hpp"
 
 namespace hyrise {
 
 AggregateDYOD::AggregateDYOD(const std::shared_ptr<AbstractOperator>& input_operator,
                              const std::vector<std::shared_ptr<WindowFunctionExpression>>& aggregates,
                              const std::vector<ColumnID>& groupby_column_ids)
-    : AbstractAggregateOperator(input_operator, aggregates, groupby_column_ids) {
-  _groupby_string_count = std::ranges::count_if(_groupby_column_ids, [&](auto column_id) {
-    return left_input_table()->column_data_type(column_id) == DataType::String;
-  });
-}
+    : AbstractAggregateOperator(input_operator, aggregates, groupby_column_ids) {}
 
 const std::string& AggregateDYOD::name() const {
   static const auto name = std::string{"AggregateDYOD"};
@@ -58,11 +56,13 @@ template <typename ColumnDataType, typename AggregateType>
 class WindowFunctionBuilder<ColumnDataType, AggregateType, WindowFunction::Any> {
  public:
   auto get_aggregate_function() {
-    return [](const ColumnDataType& new_value, const size_t aggregate_count, AggregateType& accumulator) {
+    return [](const ColumnDataType& new_value, const size_t /*aggregate_count*/, AggregateType& accumulator) {
       accumulator = new_value;
     };
   }
 };
+
+namespace {
 
 template <typename Functor>
 void resolve_window_function(const WindowFunction window_function, const Functor& functor) {
@@ -96,21 +96,28 @@ void resolve_window_function(const WindowFunction window_function, const Functor
   }
 }
 
-namespace {
-template <typename DataType>
-void _normalize_numerical(const DataType value, const bool is_null, uint8_t* byte_ptr) {
+template <typename T>
+concept arithmetic = std::integral<T> || std::floating_point<T>;
+
+// We normalize the input value, which is required to be an arithmetic data type
+// by copying the byte representation into the key buffer. We then add an extra byte
+// to signal whether the value is null. Since we write sizeof(value) bytes for the normalized
+// value and reserve this size + 1, the address in the last line will not be out of bounds.
+template <arithmetic DataType>
+void normalize_numerical(const DataType value, const bool is_null, uint8_t* key_buffer) {
   const auto* const bytes = reinterpret_cast<const std::uint8_t*>(&value);
-  std::memcpy(byte_ptr, bytes, sizeof(value));
-  *(byte_ptr + sizeof(value)) = is_null ? 0 : 255;
+  std::memcpy(key_buffer, bytes, sizeof(value));
+  *(key_buffer + sizeof(value)) = is_null ? 0 : 255;
 }
 
-const auto MAX_STRING_KEY_LENGTH = uint64_t{8};
+const auto max_string_key_length = uint64_t{8};
 
-void _normalize_string(const pmr_string& value, const bool is_null, uint8_t* byte_ptr) {
-  const auto write_length = std::min(MAX_STRING_KEY_LENGTH, uint64_t{value.length()});
-  std::memcpy(byte_ptr, value.data(), write_length);
-  std::memset(byte_ptr + write_length, 0, MAX_STRING_KEY_LENGTH - write_length);
-  *(byte_ptr + MAX_STRING_KEY_LENGTH) = is_null ? 0 : 255;
+void normalize_string(const pmr_string& value, const bool is_null, uint8_t* key_buffer) {
+  const auto write_length = std::min(max_string_key_length, uint64_t{value.length()});
+  // Since the string is never read as such we do not have to ensure null termination.
+  std::memcpy(key_buffer, value.data(), write_length);  // NOLINT(bugprone-not-null-terminated-result)
+  std::memset(key_buffer + write_length, 0, max_string_key_length - write_length);
+  *(key_buffer + max_string_key_length) = is_null ? 0 : 255;
 }
 
 uint8_t key_data_length(const DataType data_type) {
@@ -123,7 +130,7 @@ uint8_t key_data_length_null(const DataType data_type) {
 
 }  // namespace
 
-void AggregateDYOD::_normalize_chunk_groupby(const std::shared_ptr<const Chunk>& input_chunk, const ChunkID chunk_id,
+void AggregateDYOD::_normalize_chunk_groupby(const std::shared_ptr<const Chunk>& input_chunk,
                                              const uint64_t row_offset,
                                              uninitialized_vector<AggregateDYOD::NormalizedKey>& key_vector,
                                              uninitialized_vector<uint8_t>& byte_vector,
@@ -138,18 +145,18 @@ void AggregateDYOD::_normalize_chunk_groupby(const std::shared_ptr<const Chunk>&
       using ColumnDataType = typename decltype(type)::type;
       const auto segment = input_chunk->get_segment(column_id);
       auto row_id = uint64_t{0};
-      segment_iterate<ColumnDataType>(*segment, [&](auto position) {
+      segment_iterate<ColumnDataType>(*segment, [&](const auto& position) {
         const auto byte_index =
-            (row_offset + row_id) * (_normalized_key_size + _groupby_string_count * 8) + byte_offset;
-        auto base_byte = byte_vector.data() + byte_index - byte_offset;
+            ((row_offset + row_id) * (_normalized_key_size + _groupby_string_count * 8)) + byte_offset;
+        auto* base_byte = byte_vector.data() + byte_index - byte_offset;
         auto* byte_representation = byte_vector.data() + byte_index;
         if constexpr (std::is_arithmetic_v<ColumnDataType>) {
           const auto value = position.is_null() ? ColumnDataType{0} : position.value();
-          _normalize_numerical<ColumnDataType>(value, position.is_null(), byte_representation);
+          normalize_numerical<ColumnDataType>(value, position.is_null(), byte_representation);
         } else if constexpr (std::is_same_v<ColumnDataType, pmr_string>) {
           // For strings we additionally need to store the whole string value in the groupy_strings vector
           const auto value = position.is_null() ? "" : position.value();
-          _normalize_string(value, position.is_null(), byte_representation);
+          normalize_string(value, position.is_null(), byte_representation);
           const auto string_index = (row_offset * _groupby_string_count) + (groupby_string_index * chunk_size) + row_id;
           // We store the index to the string at the back of the key, which we do not use for comparisons
           std::memcpy(base_byte + _normalized_key_size + (groupby_string_index * 8), &string_index,
@@ -199,6 +206,10 @@ std::shared_ptr<const Table> AggregateDYOD::_on_execute() {
 
   _validate_aggregates();
 
+  _groupby_string_count = std::ranges::count_if(_groupby_column_ids, [&](auto column_id) {
+    return left_input_table()->column_data_type(column_id) == DataType::String;
+  });
+
   const auto input_table = left_input_table();
   const auto row_count = input_table->row_count();
 
@@ -238,13 +249,13 @@ std::shared_ptr<const Table> AggregateDYOD::_on_execute() {
     const auto data_type = column_id == INVALID_COLUMN_ID ? DataType::Long : input_table->column_data_type(column_id);
 
     resolve_data_type(data_type, [&, aggregate_index](auto type) {
-      _create_aggregate_column_definitions(type, aggregate_index, aggregate->window_function);
+      create_aggregate_column_definitions(type, aggregate_index, aggregate->window_function);
     });
 
     ++aggregate_index;
   }
 
-  // Create a MaterializedColumn of the concrete type for each column some aggregte refers to
+  // Create a MaterializedColumn of the concrete type for each column some aggregate refers to
   const auto num_unique_aggregate_columns = _unique_aggregate_columns.size();
   _materialized_aggregate_columns.resize(num_unique_aggregate_columns);
   for (auto position = uint64_t{0}; position < num_unique_aggregate_columns; ++position) {
@@ -282,7 +293,7 @@ std::shared_ptr<const Table> AggregateDYOD::_on_execute() {
   /*
    * We distinguish two cases:
    *  1. There are no columns to group by:
-   *    In this case the aggregation only needs to iterate over each column and aggregte with the respective function,
+   *    In this case the aggregation only needs to iterate over each column and aggregate with the respective function,
    *    resulting in a table with a single row
   */
   if (_groupby_column_ids.empty()) {
@@ -299,19 +310,19 @@ std::shared_ptr<const Table> AggregateDYOD::_on_execute() {
         using ColumnDataType = typename decltype(type)::type;
 
         resolve_window_function(aggregate->window_function, [&](auto window_function_constant) {
-          constexpr auto aggregate_function = decltype(window_function_constant)::value;
-          using AggregateType = typename WindowFunctionTraits<ColumnDataType, aggregate_function>::ReturnType;
+          constexpr auto AGGREGATE_FUNCTION = decltype(window_function_constant)::value;
+          using AggregateType = typename WindowFunctionTraits<ColumnDataType, AGGREGATE_FUNCTION>::ReturnType;
 
           aggregate_values[aggregate_index] =
-              _aggregate_values_without_groups<ColumnDataType, AggregateType, aggregate_function>(aggregate_index);
+              _aggregate_values_without_groups<ColumnDataType, AggregateType, AGGREGATE_FUNCTION>(aggregate_index);
         });
       });
       ++aggregate_index;
     }
     result_table->append_chunk(aggregate_values);
     return result_table;
-  } else {
-    /*  
+  }
+  /*  
    * 2. There are columns to group by:
    *      In this case, we initialize vectors to hold the bytes for NormalizedKeys, pointers to these keys
    *      and all strings in the group-by columns. These need to be stored seperately as we do not want to
@@ -323,8 +334,6 @@ std::shared_ptr<const Table> AggregateDYOD::_on_execute() {
    *      When all morsels have finished, we binary merge the morsels together.
    *      We then write the group and aggregate values into the result table and return.
   */
-    const auto row_count = input_table->row_count();
-
     auto key_bytes = uninitialized_vector<uint8_t>(row_count * (_normalized_key_size + _groupby_string_count * 8));
     auto normalized_keys = uninitialized_vector<NormalizedKey>(row_count);
     auto groupby_strings = pmr_vector<pmr_string>(row_count * _groupby_string_count);
@@ -336,7 +345,7 @@ std::shared_ptr<const Table> AggregateDYOD::_on_execute() {
     for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
       chunk_normalization_tasks[chunk_id] = std::make_shared<JobTask>([&, chunk_id, row_offset]() {
         const auto chunk = input_table->get_chunk(chunk_id);
-        _normalize_chunk_groupby(chunk, chunk_id, row_offset, normalized_keys, key_bytes, groupby_strings);
+        _normalize_chunk_groupby(chunk, row_offset, normalized_keys, key_bytes, groupby_strings);
         _materialize_chunk_aggregates(chunk, row_offset);
       });
       row_offset += input_table->get_chunk(chunk_id)->size();
@@ -344,31 +353,30 @@ std::shared_ptr<const Table> AggregateDYOD::_on_execute() {
 
     Hyrise::get().scheduler()->schedule_and_wait_for_tasks(chunk_normalization_tasks);
 
-    constexpr auto DESIRED_MORSEL_SIZE = ChunkOffset{10'000};
+    constexpr auto DESIRED_MORSEL_SIZE = ChunkOffset{2};
     const auto is_multi_threaded = Hyrise::get().is_multi_threaded();
-    // const auto is_multi_threaded = false;
+    // If we run on a single thread we avoid the overhead of splitting everything up into chunks and
+    // still processing them sequentially and perform aggregation over the entire table in one go.
+    // This avoids merging as well, which can be quite expensive with our implementation.
     const auto morsel_count =
         is_multi_threaded ? (normalized_keys.size() + DESIRED_MORSEL_SIZE - 1) / DESIRED_MORSEL_SIZE : 1;
 
     auto morsels = std::vector<std::shared_ptr<Morsel>>(morsel_count);
+    auto aggregation_tasks = std::vector<std::shared_ptr<AbstractTask>>{};
+    aggregation_tasks.reserve(morsel_count);
+    auto morsel_range_start = uint64_t{0};
 
-    auto morsel_index = uint64_t{0};
     for (auto& morsel : morsels) {
-      const auto morsel_range_start = morsel_index * DESIRED_MORSEL_SIZE;
       const auto morsel_range_end = std::min(morsel_range_start + DESIRED_MORSEL_SIZE, input_table->row_count()) - 1;
       const auto morsel_size = morsel_range_end - morsel_range_start + 1;
       auto normalized_key_span = std::span<NormalizedKey>(normalized_keys.begin() + morsel_range_start, morsel_size);
 
       morsel = std::make_shared<Morsel>(*this, morsel_size, morsel_range_start, key_bytes, normalized_key_span,
                                         groupby_strings);
-      ++morsel_index;
-    }
-    auto aggregation_tasks = std::vector<std::shared_ptr<AbstractTask>>{};
-    aggregation_tasks.reserve(morsel_count);
+      morsel_range_start += DESIRED_MORSEL_SIZE;
 
-    for (auto& morsel : morsels) {
       aggregation_tasks.push_back(std::make_shared<JobTask>([&]() {
-        morsel->_sort_morsel_range();
+        morsel->sort_morsel_range();
 
         auto aggregate_index = uint64_t{0};
         for (const auto& aggregate : _aggregates) {
@@ -381,10 +389,10 @@ std::shared_ptr<const Table> AggregateDYOD::_on_execute() {
             using ColumnDataType = typename decltype(type)::type;
 
             resolve_window_function(aggregate->window_function, [&](auto window_function_constant) {
-              constexpr auto aggregate_function = decltype(window_function_constant)::value;
-              using AggregateType = typename WindowFunctionTraits<ColumnDataType, aggregate_function>::ReturnType;
+              constexpr auto AGGREGATE_FUNCTION = decltype(window_function_constant)::value;
+              using AggregateType = typename WindowFunctionTraits<ColumnDataType, AGGREGATE_FUNCTION>::ReturnType;
 
-              morsel->_aggregate_morsel<ColumnDataType, aggregate_function, AggregateType>(aggregate_index);
+              morsel->aggregate_morsel<ColumnDataType, AGGREGATE_FUNCTION, AggregateType>(aggregate_index);
             });
           });
           ++aggregate_index;
@@ -394,15 +402,19 @@ std::shared_ptr<const Table> AggregateDYOD::_on_execute() {
 
     Hyrise::get().scheduler()->schedule_and_wait_for_tasks(aggregation_tasks);
 
+    // We merge the morsel results with a binary strategy. For this we start with a merge distance
+    // of one, where a morsel is merged with the next. We now double the distance, so a morsel gets merged
+    // with one distance two away, and thus contains the merged results of 4 consecutive morsels. We repeat this
+    // process until the first morsel contains all information.
     for (auto merge_distance = size_t{1}; merge_distance < morsel_count; merge_distance *= 2) {
       auto merge_tasks = std::vector<std::shared_ptr<AbstractTask>>{};
       merge_tasks.reserve((morsel_count + merge_distance - 1) / (2 * merge_distance));
       for (auto morsel_id = size_t{0}; morsel_id + merge_distance < morsel_count; morsel_id += 2 * merge_distance) {
         merge_tasks.push_back(std::make_shared<JobTask>([&, morsel_id, merge_distance]() {
-          auto morsel1 = morsels[morsel_id];
+          const auto& morsel1 = morsels[morsel_id];
           auto morsel2 = morsels[morsel_id + merge_distance];
 
-          morsel1->_merge_morsel(morsel2);
+          morsel1->merge_morsel(morsel2);
         }));
       }
 
@@ -455,7 +467,7 @@ std::shared_ptr<const Table> AggregateDYOD::_on_execute() {
       });
     }
 
-    auto aggregate_index = uint64_t{0};
+    aggregate_index = uint64_t{0};
     for (const auto& aggregate : _aggregates) {
       const auto& pqp_expression = static_cast<const PQPColumnExpression&>(*aggregate->argument());
       const auto pqp_column_id = pqp_expression.column_id;
@@ -464,24 +476,23 @@ std::shared_ptr<const Table> AggregateDYOD::_on_execute() {
       resolve_data_type(data_type, [&](auto type) {
         using ColumnDataType = typename decltype(type)::type;
         resolve_window_function(aggregate->window_function, [&](auto window_function_constant) {
-          constexpr auto aggregate_function = decltype(window_function_constant)::value;
-          using AggregateType = typename WindowFunctionTraits<ColumnDataType, aggregate_function>::ReturnType;
+          constexpr auto AGGREGATE_FUNCTION = decltype(window_function_constant)::value;
+          using AggregateType = typename WindowFunctionTraits<ColumnDataType, AGGREGATE_FUNCTION>::ReturnType;
           const auto nullable =
-              (aggregate_function != WindowFunction::Count && aggregate_function != WindowFunction::CountDistinct &&
-               aggregate_function != WindowFunction::Any) ||
-              (aggregate_function == WindowFunction::Any && left_input_table()->column_is_nullable(pqp_column_id));
+              (AGGREGATE_FUNCTION != WindowFunction::Count && AGGREGATE_FUNCTION != WindowFunction::CountDistinct &&
+               AGGREGATE_FUNCTION != WindowFunction::Any) ||
+              (AGGREGATE_FUNCTION == WindowFunction::Any && left_input_table()->column_is_nullable(pqp_column_id));
 
-          // This case is needed here to tell the compiler that _to_value_segment will not
+          // This case is needed here to tell the compiler that to_value_segment will not
           // be instantiated with StandardDeviationSample and a non-arithmetic type.
-          if constexpr (aggregate_function == WindowFunction::StandardDeviationSample &&
+          if constexpr (AGGREGATE_FUNCTION == WindowFunction::StandardDeviationSample &&
                         !std::is_arithmetic_v<ColumnDataType>) {
             Fail("Standard Deviation sampling is not supported on non-arithmetic types.");
-            return;
-          } else if constexpr (aggregate_function == WindowFunction::CountDistinct) {
-            _output_segments.push_back(final_morsel->_distinct_to_value_segment<ColumnDataType>(aggregate_index));
+          } else if constexpr (AGGREGATE_FUNCTION == WindowFunction::CountDistinct) {
+            _output_segments.push_back(final_morsel->distinct_to_value_segment<ColumnDataType>(aggregate_index));
           } else {
             _output_segments.push_back(
-                final_morsel->_to_value_segment<aggregate_function, AggregateType>(aggregate_index, nullable));
+                final_morsel->to_value_segment<AGGREGATE_FUNCTION, AggregateType>(aggregate_index, nullable));
           }
         });
       });
@@ -490,7 +501,6 @@ std::shared_ptr<const Table> AggregateDYOD::_on_execute() {
 
     result_table->append_chunk(_output_segments);
     return result_table;
-  }
 }
 
 std::shared_ptr<AbstractOperator> AggregateDYOD::_on_deep_copy(
@@ -500,7 +510,7 @@ std::shared_ptr<AbstractOperator> AggregateDYOD::_on_deep_copy(
   return std::make_shared<AggregateDYOD>(copied_left_input, _aggregates, _groupby_column_ids);
 }
 
-std::weak_ordering AggregateDYOD::Morsel::_compare_keys(const NormalizedKey& first, const NormalizedKey& second) {
+std::weak_ordering AggregateDYOD::Morsel::compare_keys(const NormalizedKey& first, const NormalizedKey& second) const {
   const auto key_size = morsel_operator._normalized_key_size;
   const auto memcmp_result = memcmp(&key_bytes[first], &key_bytes[second], key_size);
 
@@ -508,23 +518,25 @@ std::weak_ordering AggregateDYOD::Morsel::_compare_keys(const NormalizedKey& fir
     return std::weak_ordering::less;
   } else if (memcmp_result > 0) {
     return std::weak_ordering::greater;
-  } else {
-    for (auto index = uint64_t{0}; index < morsel_operator._groupby_string_count; ++index) {
-      auto index1 = uint64_t{0}, index2 = uint64_t{0};
-      std::memcpy(&index1, key_bytes.data() + first + key_size + (index * 8), 8);
-      std::memcpy(&index2, key_bytes.data() + second + key_size + (index * 8), 8);
-      // We use the <=> operator to directly get an ordering of the compared strings.
-      const auto strcmp_result = groupby_strings[index1] <=> groupby_strings[index2];
-      if (strcmp_result == 0) {
-        continue;
-      }
-      return strcmp_result;
-    }
   }
+
+  for (auto index = uint64_t{0}; index < morsel_operator._groupby_string_count; ++index) {
+    auto index1 = uint64_t{0};
+    auto index2 = uint64_t{0};
+    std::memcpy(&index1, key_bytes.data() + first + key_size + (index * 8), 8);
+    std::memcpy(&index2, key_bytes.data() + second + key_size + (index * 8), 8);
+    // We use the <=> operator to directly get an ordering of the compared strings.
+    const auto strcmp_result = groupby_strings[index1] <=> groupby_strings[index2];
+    if (strcmp_result == 0) {
+      continue;
+    }
+    return strcmp_result;
+  }
+
   return std::weak_ordering::equivalent;
 }
 
-void AggregateDYOD::Morsel::_sort_morsel_range() {
+void AggregateDYOD::Morsel::sort_morsel_range() {
   /*
    * To sort the morsel we sort indices of the rows according to the normalized keys.
    * With these indices we can then reorder the MaterializedColumns for the aggregates
@@ -535,23 +547,23 @@ void AggregateDYOD::Morsel::_sort_morsel_range() {
   auto sort_values = std::vector<std::pair<NormalizedKey, uint64_t>>(row_count);
   for (auto index = uint64_t{0}; index < row_count; ++index) {
     auto& [key, sort_index] = sort_values[index];
-    key = std::move(normalized_keys[index]);
+    key = normalized_keys[index];
     sort_index = index;
   }
 
   boost::sort::pdqsort(sort_values.begin(), sort_values.end(), [&](auto first_key, auto second_key) {
-    return _compare_keys(first_key.first, second_key.first) < 0;
+    return compare_keys(first_key.first, second_key.first) < 0;
   });
 
   auto sorted_indices = std::vector<uint64_t>();
   sorted_indices.reserve(row_count);
   for (auto index = uint64_t{0}; index < row_count; ++index) {
     auto& [key, sort_index] = sort_values[index];
-    normalized_keys[index] = std::move(key);
+    normalized_keys[index] = key;
     sorted_indices.push_back(sort_index);
   }
 
-  auto& unique_aggregate_columns = morsel_operator._unique_aggregate_columns;
+  const auto& unique_aggregate_columns = morsel_operator._unique_aggregate_columns;
   const auto num_unique_aggregate_columns = unique_aggregate_columns.size();
   for (auto position = uint64_t{0}; position < num_unique_aggregate_columns; ++position) {
     const auto column_id = unique_aggregate_columns[position];
@@ -589,7 +601,7 @@ void AggregateDYOD::Morsel::_sort_morsel_range() {
   auto current_group_size = uint64_t{0};
   for (auto row_index = uint64_t{0}; row_index < row_count - 1; ++row_index) {
     ++current_group_size;
-    if (_compare_keys(normalized_keys[row_index], normalized_keys[row_index + 1]) != 0) {
+    if (compare_keys(normalized_keys[row_index], normalized_keys[row_index + 1]) != 0) {
       group_sizes.push_back(current_group_size);
       group_keys.push_back(normalized_keys[row_index]);
       current_group_size = 0;
@@ -601,7 +613,7 @@ void AggregateDYOD::Morsel::_sort_morsel_range() {
 }
 
 template <typename ColumnType, WindowFunction aggregate_function, typename AggregateType>
-void AggregateDYOD::Morsel::_aggregate_morsel(const uint64_t aggregate_index) {
+void AggregateDYOD::Morsel::aggregate_morsel(const uint64_t aggregate_index) {
   const auto& pqp_column =
       static_cast<const PQPColumnExpression&>(*morsel_operator._aggregates[aggregate_index]->argument());
   const auto input_column_id = pqp_column.column_id;
@@ -661,9 +673,6 @@ void AggregateDYOD::Morsel::_aggregate_morsel(const uint64_t aggregate_index) {
 
       aggregator(value, value_count, accumulator);
       ++value_count;
-      if constexpr (aggregate_function == WindowFunction::Any) {
-        continue;
-      }
       if constexpr (aggregate_function == WindowFunction::CountDistinct) {
         distinct_values.insert(value);
       }
@@ -685,7 +694,7 @@ void AggregateDYOD::Morsel::_aggregate_morsel(const uint64_t aggregate_index) {
   }
 }
 
-void AggregateDYOD::Morsel::_merge_morsel(std::shared_ptr<Morsel>& other) {
+void AggregateDYOD::Morsel::merge_morsel(std::shared_ptr<Morsel>& other) {
   /* 
     * We first create a plan (instructions how to merge the two morsels) to only compare the keys once.
     * According to this plan every aggregate is then merged separately.
@@ -695,9 +704,10 @@ void AggregateDYOD::Morsel::_merge_morsel(std::shared_ptr<Morsel>& other) {
   pmr_vector<MergeStep> merge_plan;
   merge_plan.reserve(group_count + other->group_count);
 
-  auto source_index = uint64_t{0}, other_index = uint64_t{0};
+  auto source_index = uint64_t{0};
+  auto other_index = uint64_t{0};
   while (source_index < group_count && other_index < other->group_count) {
-    const auto key_compare_result = _compare_keys(group_keys[source_index], other->group_keys[other_index]);
+    const auto key_compare_result = compare_keys(group_keys[source_index], other->group_keys[other_index]);
 
     if (key_compare_result < 0) {
       merge_plan.emplace_back(source_index, -1);
@@ -732,12 +742,12 @@ void AggregateDYOD::Morsel::_merge_morsel(std::shared_ptr<Morsel>& other) {
       using ColumnDataType = typename decltype(type)::type;
 
       resolve_window_function(aggregate->window_function, [&](auto window_function_constant) {
-        constexpr auto aggregate_function = decltype(window_function_constant)::value;
-        using AggregateType = typename WindowFunctionTraits<ColumnDataType, aggregate_function>::ReturnType;
-        if constexpr (aggregate_function == WindowFunction::CountDistinct) {
-          _merge_single_aggregate<aggregate_function, ColumnDataType>(other, aggregate_index, merge_plan);
+        constexpr auto AGGREGATE_FUNCTION = decltype(window_function_constant)::value;
+        using AggregateType = typename WindowFunctionTraits<ColumnDataType, AGGREGATE_FUNCTION>::ReturnType;
+        if constexpr (AGGREGATE_FUNCTION == WindowFunction::CountDistinct) {
+          merge_single_aggregate<AGGREGATE_FUNCTION, ColumnDataType>(other, aggregate_index, merge_plan);
         } else {
-          _merge_single_aggregate<aggregate_function, AggregateType>(other, aggregate_index, merge_plan);
+          merge_single_aggregate<AGGREGATE_FUNCTION, AggregateType>(other, aggregate_index, merge_plan);
         }
       });
     });
@@ -747,12 +757,10 @@ void AggregateDYOD::Morsel::_merge_morsel(std::shared_ptr<Morsel>& other) {
   auto merged_group_keys = pmr_vector<NormalizedKey>(new_group_count);
   for (auto step_index = uint64_t{0}; step_index < new_group_count; ++step_index) {
     const auto [source_index, other_index] = merge_plan[step_index];
-    if (source_index > -1 && other_index == -1) {
-      merged_group_keys[step_index] = std::move(group_keys[source_index]);
-    } else if (source_index == -1 && other_index > -1) {
-      merged_group_keys[step_index] = std::move(other->group_keys[other_index]);
+    if (source_index == -1 && other_index > -1) {
+      merged_group_keys[step_index] = other->group_keys[other_index];
     } else {
-      merged_group_keys[step_index] = std::move(group_keys[source_index]);
+      merged_group_keys[step_index] = group_keys[source_index];
     }
   }
 
@@ -761,7 +769,7 @@ void AggregateDYOD::Morsel::_merge_morsel(std::shared_ptr<Morsel>& other) {
 }
 
 template <WindowFunction aggregate_function, typename AggregateType>
-void AggregateDYOD::Morsel::_merge_single_aggregate(std::shared_ptr<Morsel>& other, const uint64_t aggregate_index,
+void AggregateDYOD::Morsel::merge_single_aggregate(std::shared_ptr<Morsel>& other, const uint64_t aggregate_index,
                                                     const pmr_vector<MergeStep>& merge_plan) {
   using Results = AggregateResults<aggregate_function, AggregateType>;
   auto aggregator = WindowFunctionBuilder<AggregateType, AggregateType, aggregate_function>().get_aggregate_function();
@@ -794,13 +802,14 @@ void AggregateDYOD::Morsel::_merge_single_aggregate(std::shared_ptr<Morsel>& oth
         auto& accumulator_a = source_results->accumulators[source_index];
         auto& accumulator_b = other_results->accumulators[other_index];
 
-        const auto count_a = accumulator_a[0], count_b = accumulator_b[0];
+        const auto count_a = accumulator_a[0];
+        const auto count_b = accumulator_b[0];
         const auto new_count = count_a + count_b;
         const auto delta_mean = accumulator_b[1] - accumulator_a[1];
-        const auto updated_mean = accumulator_a[1] + delta_mean * (count_b / new_count);
+        const auto updated_mean = accumulator_a[1] + (delta_mean * (count_b / new_count));
         const auto updated_squared_distance =
             accumulator_a[2] + accumulator_b[2] +
-            (delta_mean * delta_mean) * (static_cast<double>(count_a * count_b) / new_count);
+            ((delta_mean * delta_mean) * (static_cast<double>(count_a * count_b) / new_count));
 
         accumulator_a[0] = new_count;
         accumulator_a[1] = updated_mean;
@@ -836,7 +845,7 @@ void AggregateDYOD::Morsel::_merge_single_aggregate(std::shared_ptr<Morsel>& oth
 }
 
 template <WindowFunction aggregate_function, typename AggregateType>
-std::shared_ptr<ValueSegment<AggregateType>> AggregateDYOD::Morsel::_to_value_segment(uint64_t aggregate_index,
+std::shared_ptr<ValueSegment<AggregateType>> AggregateDYOD::Morsel::to_value_segment(uint64_t aggregate_index,
                                                                                       bool nullable) {
   /*
    * To convert the accumulated values to output values we have to distinguish the aggregate_functions
@@ -886,7 +895,7 @@ std::shared_ptr<ValueSegment<AggregateType>> AggregateDYOD::Morsel::_to_value_se
 }
 
 template <typename ColumnType>
-std::shared_ptr<ValueSegment<int64_t>> AggregateDYOD::Morsel::_distinct_to_value_segment(
+std::shared_ptr<ValueSegment<int64_t>> AggregateDYOD::Morsel::distinct_to_value_segment(
     const uint64_t aggregate_index) {
   using Results = AggregateResults<WindowFunction::CountDistinct, ColumnType>;
   const auto results = std::static_pointer_cast<Results>(aggregate_results[aggregate_index]);
@@ -903,7 +912,11 @@ std::shared_ptr<ValueSegment<int64_t>> AggregateDYOD::Morsel::_distinct_to_value
 
 void AggregateDYOD::_on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) {}
 
-void AggregateDYOD::_on_cleanup() {}
+void AggregateDYOD::_on_cleanup() {
+  _aggregate_column_position.clear();
+  _unique_aggregate_columns.clear();
+  _materialized_aggregate_columns.clear();
+}
 
 template <typename ColumnType, typename AggregateType, WindowFunction aggregate_function>
 std::shared_ptr<ValueSegment<AggregateType>> AggregateDYOD::_aggregate_values_without_groups(
@@ -911,7 +924,7 @@ std::shared_ptr<ValueSegment<AggregateType>> AggregateDYOD::_aggregate_values_wi
   /*
    * For the Aggregation without groups we do not need to perform checks for groups. We also
    * perform the transformation into the proper values and creation of the ValueSegments
-   * right away (unlike with _to_value_segment()) since we already have all the data in one place 
+   * right away (unlike with to_value_segment()) since we already have all the data in one place 
    * after the aggregation is finished.
   */
   const auto& pqp_column = static_cast<const PQPColumnExpression&>(*_aggregates[aggregate_index]->argument());
@@ -929,7 +942,7 @@ std::shared_ptr<ValueSegment<AggregateType>> AggregateDYOD::_aggregate_values_wi
   const auto input_table = left_input_table();
   const auto chunk_count = input_table->chunk_count();
 
-  if constexpr (aggregate_function == WindowFunction::Count && std::is_arithmetic_v<AggregateType>) {
+  if constexpr (aggregate_function == WindowFunction::Count) {
     accumulated_values.push_back(input_table->row_count());
     return std::make_shared<ValueSegment<AggregateType>>(std::move(accumulated_values));
   }
@@ -937,14 +950,11 @@ std::shared_ptr<ValueSegment<AggregateType>> AggregateDYOD::_aggregate_values_wi
   for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
     auto segment = input_table->get_chunk(chunk_id)->get_segment(input_column_id);
     segment_iterate<ColumnType>(*segment, [&](const auto& position) {
-      is_null = false;
       const auto& new_value = position.value();
       if (!position.is_null()) {
+        is_null = false;
         aggregator(new_value, value_count, accumulator);
         ++value_count;
-        if constexpr (aggregate_function == WindowFunction::Any) {
-          return;
-        }
         if constexpr (aggregate_function == WindowFunction::CountDistinct) {
           distinct_values.insert(new_value);
         }
@@ -986,41 +996,18 @@ std::shared_ptr<ValueSegment<AggregateType>> AggregateDYOD::_aggregate_values_wi
 }
 
 template <typename ColumnType>
-void AggregateDYOD::_create_aggregate_column_definitions(boost::hana::basic_type<ColumnType> /*type*/,
+void AggregateDYOD::create_aggregate_column_definitions(boost::hana::basic_type<ColumnType> /*type*/,
                                                          ColumnID column_index, WindowFunction aggregate_function) {
   /*
    * We are aware that the switch looks very repetitive, but we could not find a dynamic solution.
    * There is a similar switch statement in _on_execute for calling _aggregate_values.
    * See the comment there for reasoning.
    */
-  switch (aggregate_function) {
-    case WindowFunction::Min:
-      create_aggregate_column_definitions<ColumnType, WindowFunction::Min>(column_index);
-      break;
-    case WindowFunction::Max:
-      create_aggregate_column_definitions<ColumnType, WindowFunction::Max>(column_index);
-      break;
-    case WindowFunction::Sum:
-      create_aggregate_column_definitions<ColumnType, WindowFunction::Sum>(column_index);
-      break;
-    case WindowFunction::Avg:
-      create_aggregate_column_definitions<ColumnType, WindowFunction::Avg>(column_index);
-      break;
-    case WindowFunction::Count:
-      create_aggregate_column_definitions<ColumnType, WindowFunction::Count>(column_index);
-      break;
-    case WindowFunction::CountDistinct:
-      create_aggregate_column_definitions<ColumnType, WindowFunction::CountDistinct>(column_index);
-      break;
-    case WindowFunction::StandardDeviationSample:
-      create_aggregate_column_definitions<ColumnType, WindowFunction::StandardDeviationSample>(column_index);
-      break;
-    case WindowFunction::Any:
-      create_aggregate_column_definitions<ColumnType, WindowFunction::Any>(column_index);
-      break;
-    default:
-      Fail(std::format("Unsupported aggregate function '{}'.", window_function_to_string.left.at(aggregate_function)));
-  }
+    resolve_window_function(aggregate_function, [&](auto window_function_constant) {
+      constexpr auto AggregateFunction = decltype(window_function_constant)::value;
+
+      create_aggregate_column_definitions<ColumnType, AggregateFunction>(column_index);
+    });
 }
 
 template <typename ColumnType, WindowFunction aggregate_function>
@@ -1037,6 +1024,9 @@ void AggregateDYOD::create_aggregate_column_definitions(ColumnID column_index) {
     result_type = left_input_table()->column_data_type(input_column_id);
   }
 
+  // Count (Distinct) columns are never nullable as there is always an available count and an ANY column
+  // can only be nullable as long as the column it is referring to was also nullable. All other aggregations
+  // resolve the first conjunction to true and are thus always nullable.
   const auto nullable =
       (aggregate_function != WindowFunction::Count && aggregate_function != WindowFunction::CountDistinct &&
        aggregate_function != WindowFunction::Any) ||

--- a/src/lib/operators/aggregate_dyod.cpp
+++ b/src/lib/operators/aggregate_dyod.cpp
@@ -146,8 +146,9 @@ void AggregateDYOD::_normalize_chunk_groupby(const std::shared_ptr<const Chunk>&
       const auto segment = input_chunk->get_segment(column_id);
       auto row_id = uint64_t{0};
       segment_iterate<ColumnDataType>(*segment, [&](const auto& position) {
-        const auto byte_index =
-            ((row_offset + row_id) * (_normalized_key_size + _groupby_string_count * 8)) + byte_offset;
+        const auto absolute_row_id = row_offset + row_id;
+        const auto key_size_with_strings = _normalized_key_size + (_groupby_string_count * 8);
+        const auto byte_index = (absolute_row_id * key_size_with_strings) + byte_offset;
         auto* base_byte = byte_vector.data() + byte_index - byte_offset;
         auto* byte_representation = byte_vector.data() + byte_index;
         if constexpr (std::is_arithmetic_v<ColumnDataType>) {

--- a/src/lib/operators/aggregate_dyod.hpp
+++ b/src/lib/operators/aggregate_dyod.hpp
@@ -23,6 +23,16 @@
 
 namespace hyrise {
 
+/*
+  Our Aggregation operator is sorting based. For the GROUP-BY columns, we create a byte
+  representation per row so that we may compare these bytes to compare two rows. For strings
+  we copy a prefix of the string into these bytes and store the whole string in a global buffer.
+  After this, we materialize all values of the required aggregate columns into continguous, unencoded
+  vectors. We then divide these vectors into blocks called morsels. Each morsel sorts its assigned rows
+  and performs all aggregations on them. When all morsels have finished, their results are merged.
+  Finally the results are written into a single chunk of the output table.
+*/
+
 class AggregateDYOD : public AbstractAggregateOperator {
  public:
   AggregateDYOD(const std::shared_ptr<AbstractOperator>& input_operator,
@@ -106,7 +116,7 @@ class AggregateDYOD : public AbstractAggregateOperator {
   */
   struct Morsel : public hyrise::Noncopyable {
     // We use a reference to the operator to avoid passing more fields
-    // like the Table, AggregateColumns, UniqueAggregtaeColumns etc.
+    // like the Table, AggregateColumns, UniqueAggregateColumns etc.
     const AggregateDYOD& morsel_operator;
     const uint64_t row_count;
     const uint64_t initial_row_offset;
@@ -118,7 +128,7 @@ class AggregateDYOD : public AbstractAggregateOperator {
     uint64_t group_count;
     std::vector<uint64_t> group_sizes;
 
-    Morsel(AggregateDYOD& init_morsel_operator, uint64_t init_row_count, uint64_t init_row_offset,
+    Morsel(const AggregateDYOD& init_morsel_operator, const uint64_t init_row_count, const uint64_t init_row_offset,
            std::span<const uint8_t> init_key_bytes, std::span<NormalizedKey> init_normalized_keys,
            std::span<pmr_string> init_groupby_strings)
         : morsel_operator(init_morsel_operator),
@@ -126,20 +136,21 @@ class AggregateDYOD : public AbstractAggregateOperator {
           initial_row_offset(init_row_offset),
           key_bytes(init_key_bytes),
           normalized_keys(init_normalized_keys),
-          groupby_strings(init_groupby_strings) {
+          groupby_strings(init_groupby_strings),
+          group_count(0) {
       aggregate_results.resize(init_morsel_operator._aggregates.size());
     }
 
     pmr_vector<NormalizedKey> group_keys;
 
-    // Contains the aggregation results. Is filled by _aggregate_morsel().
+    // Contains the aggregation results. Is filled by aggregate_morsel().
     pmr_vector<std::shared_ptr<BaseAggregateResults>> aggregate_results;
 
-    void _sort_morsel_range();
-    std::weak_ordering _compare_keys(const NormalizedKey& first, const NormalizedKey& second);
+    void sort_morsel_range();
+    std::weak_ordering compare_keys(const NormalizedKey& first, const NormalizedKey& second) const;
 
     template <typename ColumnType, WindowFunction aggregate_function, typename AggregateType>
-    void _aggregate_morsel(const uint64_t aggregate_index);
+    void aggregate_morsel(const uint64_t aggregate_index);
 
     // Used for the merging of another morsel.
     // If one of these indices is -1 then there is no element referring to the same group as the other,
@@ -149,27 +160,27 @@ class AggregateDYOD : public AbstractAggregateOperator {
       int64_t other_index;
     };
 
-    void _merge_morsel(std::shared_ptr<Morsel>& other);
+    void merge_morsel(std::shared_ptr<Morsel>& other);
 
     template <WindowFunction aggregate_function, typename AggregateType>
-    void _merge_single_aggregate(std::shared_ptr<Morsel>& other, const uint64_t aggregate_index,
+    void merge_single_aggregate(std::shared_ptr<Morsel>& other, const uint64_t aggregate_index,
                                  const pmr_vector<MergeStep>& merge_plan);
 
     template <WindowFunction aggregate_function, typename AggregateType>
-    std::shared_ptr<ValueSegment<AggregateType>> _to_value_segment(uint64_t aggregte_index, bool nullable);
+    std::shared_ptr<ValueSegment<AggregateType>> to_value_segment(const uint64_t aggregate_index, bool nullable);
 
     template <typename ColumnType>
-    std::shared_ptr<ValueSegment<int64_t>> _distinct_to_value_segment(uint64_t aggregate_index);
+    std::shared_ptr<ValueSegment<int64_t>> distinct_to_value_segment(const uint64_t aggregate_index);
   };
 
-  void _normalize_chunk_groupby(const std::shared_ptr<const Chunk>& input_chunk, const ChunkID chunk_id,
+  void _normalize_chunk_groupby(const std::shared_ptr<const Chunk>& input_chunk,
                                 const uint64_t row_offset, uninitialized_vector<NormalizedKey>& key_vector,
                                 uninitialized_vector<uint8_t>& byte_vector, pmr_vector<pmr_string>& groupby_strings);
 
   void _materialize_chunk_aggregates(const std::shared_ptr<const Chunk>& input_chunk, const uint64_t row_offset);
 
   template <typename ColumnType, typename AggregateType, WindowFunction aggregate_function>
-  std::shared_ptr<ValueSegment<AggregateType>> _aggregate_values_without_groups(uint64_t aggregate_index);
+  std::shared_ptr<ValueSegment<AggregateType>> _aggregate_values_without_groups(const uint64_t aggregate_index);
 
   void _on_cleanup() override;
 
@@ -177,7 +188,7 @@ class AggregateDYOD : public AbstractAggregateOperator {
   void create_aggregate_column_definitions(ColumnID column_index);
 
   template <typename ColumnType>
-  void _create_aggregate_column_definitions(boost::hana::basic_type<ColumnType> /*type*/, ColumnID column_index,
+  void create_aggregate_column_definitions(boost::hana::basic_type<ColumnType> /*type*/, ColumnID column_index,
                                             WindowFunction aggregate_function);
 
   uint64_t _groupby_string_count = 0;

--- a/src/lib/operators/aggregate_dyod.hpp
+++ b/src/lib/operators/aggregate_dyod.hpp
@@ -1,0 +1,190 @@
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "uninitialized_vector.hpp"
+
+#include "abstract_aggregate_operator.hpp"
+#include "abstract_read_only_operator.hpp"
+#include "aggregate/window_function_traits.hpp"
+#include "all_type_variant.hpp"
+#include "expression/window_function_expression.hpp"
+#include "resolve_type.hpp"
+#include "storage/reference_segment.hpp"
+#include "storage/value_segment.hpp"
+#include "types.hpp"
+#include "utils/assert.hpp"
+
+namespace hyrise {
+
+class AggregateDYOD : public AbstractAggregateOperator {
+ public:
+  AggregateDYOD(const std::shared_ptr<AbstractOperator>& input_operator,
+                const std::vector<std::shared_ptr<WindowFunctionExpression>>& aggregates,
+                const std::vector<ColumnID>& groupby_column_ids);
+
+  const std::string& name() const override;
+
+ protected:
+  template <WindowFunction aggregate_function, typename AggregateType>
+  using AggregateAccumulator = std::conditional_t<aggregate_function == WindowFunction::StandardDeviationSample,
+                                                  StandardDeviationSampleData, AggregateType>;
+
+  std::shared_ptr<const Table> _on_execute() override;
+
+  std::shared_ptr<AbstractOperator> _on_deep_copy(
+      const std::shared_ptr<AbstractOperator>& copied_left_input,
+      const std::shared_ptr<AbstractOperator>& copied_right_input,
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
+
+  void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
+
+  using NormalizedKey = uint64_t;
+
+  /*
+    BaseAggregateResults provides a superclass to the templated versions of AggregteResults
+    so that we can store pointers to AggregateResults of different types in the same vector.
+  */
+  struct BaseAggregateResults {
+    virtual ~BaseAggregateResults() = default;
+  };
+
+  /*
+    AggregateResults holds a vector of accumulators for aggregate_function for each group of
+    a Morsel it is held in. It additionally stores the sizes for each group.
+  */
+  template <WindowFunction aggregate_function, typename AggregateType>
+  struct AggregateResults : public BaseAggregateResults {
+    explicit AggregateResults(const uint64_t group_count) : accumulators(group_count), counts(group_count) {}
+
+    pmr_vector<AggregateAccumulator<aggregate_function, AggregateType>> accumulators;
+    pmr_vector<uint64_t> counts;
+  };
+
+  /*
+    This specialization for the CountDistinct function is needed as this requires a non-standard type of
+    accumulator, namely, each group contains a vector of the unique values in this group.
+  */
+  template <typename ColumnType>
+  struct AggregateResults<WindowFunction::CountDistinct, ColumnType> : public BaseAggregateResults {
+    explicit AggregateResults(const uint64_t group_count) : accumulators(group_count), counts(group_count) {}
+
+    pmr_vector<pmr_vector<ColumnType>> accumulators;
+    pmr_vector<uint64_t> counts;
+  };
+
+  /*
+    BaseMaterializedColumn provides a superclass to the templated versions of MaterializedColumn
+    so that we can store pointers to MaterializedColumns of different types in the same vector.
+  */
+  struct BaseMaterializedColumn {
+    virtual ~BaseMaterializedColumn() = default;
+  };
+
+  /*
+    A MaterializedColumn holds values of type ColumnType and one byte for each value indicating
+    whether it is null. This is basically only the core of a ValueSegment.
+  */
+  template <typename ColumnDataType>
+  struct MaterializedColumn : public BaseMaterializedColumn {
+    explicit MaterializedColumn(const size_t row_count) : values(row_count), null_values(row_count) {}
+
+    pmr_vector<ColumnDataType> values;
+    pmr_vector<uint8_t> null_values;
+  };
+
+  /*
+    A Morsel refers to a contiguous subset of rows in the input table of the operator.
+    It can independently sort the rows according to the normalized keys, aggregate columns
+    and merge other morsels into itself to combine their results.
+  */
+  struct Morsel : public hyrise::Noncopyable {
+    // We use a reference to the operator to avoid passing more fields
+    // like the Table, AggregateColumns, UniqueAggregtaeColumns etc.
+    const AggregateDYOD& morsel_operator;
+    const uint64_t row_count;
+    const uint64_t initial_row_offset;
+
+    std::span<const uint8_t> key_bytes;
+    std::span<NormalizedKey> normalized_keys;
+    std::span<pmr_string> groupby_strings;
+
+    uint64_t group_count;
+    std::vector<uint64_t> group_sizes;
+
+    Morsel(AggregateDYOD& init_morsel_operator, uint64_t init_row_count, uint64_t init_row_offset,
+           std::span<const uint8_t> init_key_bytes, std::span<NormalizedKey> init_normalized_keys,
+           std::span<pmr_string> init_groupby_strings)
+        : morsel_operator(init_morsel_operator),
+          row_count(init_row_count),
+          initial_row_offset(init_row_offset),
+          key_bytes(init_key_bytes),
+          normalized_keys(init_normalized_keys),
+          groupby_strings(init_groupby_strings) {
+      aggregate_results.resize(init_morsel_operator._aggregates.size());
+    }
+
+    pmr_vector<NormalizedKey> group_keys;
+
+    // Contains the aggregation results. Is filled by _aggregate_morsel().
+    pmr_vector<std::shared_ptr<BaseAggregateResults>> aggregate_results;
+
+    void _sort_morsel_range();
+    std::weak_ordering _compare_keys(const NormalizedKey& first, const NormalizedKey& second);
+
+    template <typename ColumnType, WindowFunction aggregate_function, typename AggregateType>
+    void _aggregate_morsel(const uint64_t aggregate_index);
+
+    // Used for the merging of another morsel.
+    // If one of these indices is -1 then there is no element referring to the same group as the other,
+    // non-negative index.
+    struct MergeStep {
+      int64_t source_index;
+      int64_t other_index;
+    };
+
+    void _merge_morsel(std::shared_ptr<Morsel>& other);
+
+    template <WindowFunction aggregate_function, typename AggregateType>
+    void _merge_single_aggregate(std::shared_ptr<Morsel>& other, const uint64_t aggregate_index,
+                                 const pmr_vector<MergeStep>& merge_plan);
+
+    template <WindowFunction aggregate_function, typename AggregateType>
+    std::shared_ptr<ValueSegment<AggregateType>> _to_value_segment(uint64_t aggregte_index, bool nullable);
+
+    template <typename ColumnType>
+    std::shared_ptr<ValueSegment<int64_t>> _distinct_to_value_segment(uint64_t aggregate_index);
+  };
+
+  void _normalize_chunk_groupby(const std::shared_ptr<const Chunk>& input_chunk, const ChunkID chunk_id,
+                                const uint64_t row_offset, uninitialized_vector<NormalizedKey>& key_vector,
+                                uninitialized_vector<uint8_t>& byte_vector, pmr_vector<pmr_string>& groupby_strings);
+
+  void _materialize_chunk_aggregates(const std::shared_ptr<const Chunk>& input_chunk, const uint64_t row_offset);
+
+  template <typename ColumnType, typename AggregateType, WindowFunction aggregate_function>
+  std::shared_ptr<ValueSegment<AggregateType>> _aggregate_values_without_groups(uint64_t aggregate_index);
+
+  void _on_cleanup() override;
+
+  template <typename ColumnType, WindowFunction aggregate_function>
+  void create_aggregate_column_definitions(ColumnID column_index);
+
+  template <typename ColumnType>
+  void _create_aggregate_column_definitions(boost::hana::basic_type<ColumnType> /*type*/, ColumnID column_index,
+                                            WindowFunction aggregate_function);
+
+  uint64_t _groupby_string_count = 0;
+  uint64_t _normalized_key_size = 0;
+
+  std::unordered_map<ColumnID, uint64_t> _aggregate_column_position;
+  std::vector<ColumnID> _unique_aggregate_columns;
+  std::vector<std::shared_ptr<BaseMaterializedColumn>> _materialized_aggregate_columns;
+};
+}  // namespace hyrise

--- a/src/lib/operators/aggregate_dyod.hpp
+++ b/src/lib/operators/aggregate_dyod.hpp
@@ -190,8 +190,8 @@ class AggregateDYOD : public AbstractAggregateOperator {
   void _create_aggregate_column_definitions(boost::hana::basic_type<ColumnType> /*type*/, ColumnID column_index,
                                             WindowFunction aggregate_function);
 
-  uint64_t _groupby_string_count = 0;
-  uint64_t _normalized_key_size = 0;
+  uint64_t _groupby_string_count{0};
+  uint64_t _normalized_key_size{0};
 
   std::unordered_map<ColumnID, uint64_t> _aggregate_column_position;
   std::vector<ColumnID> _unique_aggregate_columns;

--- a/src/lib/operators/aggregate_dyod.hpp
+++ b/src/lib/operators/aggregate_dyod.hpp
@@ -2,6 +2,7 @@
 
 #include <map>
 #include <memory>
+#include <span>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>

--- a/src/lib/operators/aggregate_dyod.hpp
+++ b/src/lib/operators/aggregate_dyod.hpp
@@ -125,7 +125,7 @@ class AggregateDYOD : public AbstractAggregateOperator {
     std::span<NormalizedKey> normalized_keys;
     std::span<pmr_string> groupby_strings;
 
-    uint64_t group_count;
+    uint64_t group_count{0};
     std::vector<uint64_t> group_sizes;
 
     Morsel(const AggregateDYOD& init_morsel_operator, const uint64_t init_row_count, const uint64_t init_row_offset,
@@ -136,8 +136,7 @@ class AggregateDYOD : public AbstractAggregateOperator {
           initial_row_offset(init_row_offset),
           key_bytes(init_key_bytes),
           normalized_keys(init_normalized_keys),
-          groupby_strings(init_groupby_strings),
-          group_count(0) {
+          groupby_strings(init_groupby_strings) {
       aggregate_results.resize(init_morsel_operator._aggregates.size());
     }
 
@@ -164,7 +163,7 @@ class AggregateDYOD : public AbstractAggregateOperator {
 
     template <WindowFunction aggregate_function, typename AggregateType>
     void merge_single_aggregate(std::shared_ptr<Morsel>& other, const uint64_t aggregate_index,
-                                 const pmr_vector<MergeStep>& merge_plan);
+                                const pmr_vector<MergeStep>& merge_plan);
 
     template <WindowFunction aggregate_function, typename AggregateType>
     std::shared_ptr<ValueSegment<AggregateType>> to_value_segment(const uint64_t aggregate_index, bool nullable);
@@ -173,8 +172,8 @@ class AggregateDYOD : public AbstractAggregateOperator {
     std::shared_ptr<ValueSegment<int64_t>> distinct_to_value_segment(const uint64_t aggregate_index);
   };
 
-  void _normalize_chunk_groupby(const std::shared_ptr<const Chunk>& input_chunk,
-                                const uint64_t row_offset, uninitialized_vector<NormalizedKey>& key_vector,
+  void _normalize_chunk_groupby(const std::shared_ptr<const Chunk>& input_chunk, const uint64_t row_offset,
+                                uninitialized_vector<NormalizedKey>& key_vector,
                                 uninitialized_vector<uint8_t>& byte_vector, pmr_vector<pmr_string>& groupby_strings);
 
   void _materialize_chunk_aggregates(const std::shared_ptr<const Chunk>& input_chunk, const uint64_t row_offset);
@@ -185,10 +184,10 @@ class AggregateDYOD : public AbstractAggregateOperator {
   void _on_cleanup() override;
 
   template <typename ColumnType, WindowFunction aggregate_function>
-  void create_aggregate_column_definitions(ColumnID column_index);
+  void _create_aggregate_column_definitions(ColumnID column_index);
 
   template <typename ColumnType>
-  void create_aggregate_column_definitions(boost::hana::basic_type<ColumnType> /*type*/, ColumnID column_index,
+  void _create_aggregate_column_definitions(boost::hana::basic_type<ColumnType> /*type*/, ColumnID column_index,
                                             WindowFunction aggregate_function);
 
   uint64_t _groupby_string_count = 0;

--- a/src/lib/scheduler/node_queue_scheduler.cpp
+++ b/src/lib/scheduler/node_queue_scheduler.cpp
@@ -19,7 +19,6 @@
 #include "shutdown_task.hpp"
 #include "task_queue.hpp"
 #include "types.hpp"
-#include "uid_allocator.hpp"
 #include "utils/assert.hpp"
 #include "worker.hpp"
 

--- a/src/test/lib/logical_query_plan/lqp_translator_test.cpp
+++ b/src/test/lib/logical_query_plan/lqp_translator_test.cpp
@@ -39,7 +39,7 @@
 #include "logical_query_plan/validate_node.hpp"
 #include "logical_query_plan/window_node.hpp"
 #include "operators/abstract_operator.hpp"
-#include "operators/aggregate_hash.hpp"
+#include "operators/aggregate_dyod.hpp"
 #include "operators/change_meta_table.hpp"
 #include "operators/export.hpp"
 #include "operators/get_table.hpp"
@@ -717,7 +717,7 @@ TEST_F(LQPTranslatorTest, AggregateNodeSimple) {
   /**
    * Check PQP.
    */
-  const auto aggregate_op = std::dynamic_pointer_cast<AggregateHash>(op);
+  const auto aggregate_op = std::dynamic_pointer_cast<AggregateDYOD>(op);
   ASSERT_TRUE(aggregate_op);
   ASSERT_EQ(aggregate_op->aggregates().size(), 2);
   ASSERT_EQ(aggregate_op->groupby_column_ids().size(), 1);

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -27,25 +27,6 @@ target_include_directories(
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/zstd/lib>
 )
 
-# Perf-CPP
-add_subdirectory(perf-cpp)
-add_library(perf-cpp-wrapper INTERFACE)
-target_link_libraries(perf-cpp-wrapper INTERFACE perf-cpp)
-target_include_directories(perf-cpp-wrapper INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/perf-cpp/include)
-target_compile_options(perf-cpp-wrapper INTERFACE -Wno-deprecated-copy-with-dtor -Wno-extra-semi-stmt -Wno-newline-eof)
-
-# Perfetto
-add_library(perfetto STATIC
-    perfetto/sdk/perfetto.cc
-)
-target_include_directories(perfetto PUBLIC perfetto/sdk)
-target_compile_definitions(perfetto PUBLIC PERFETTO_IMPLEMENTATION)
-
-# Create wrapper
-add_library(perfetto-wrapper INTERFACE)
-target_link_libraries(perfetto-wrapper INTERFACE perfetto)
-target_link_libraries(perfetto-wrapper INTERFACE dl pthread rt)
-
 # Build sql-parser library
 set(PARSER_DIR sql-parser)
 


### PR DESCRIPTION
@geromequa @JeanneAue 

**System**
<details>
<summary>nemea - click to expand</summary>

| property | value |
| -- | -- |
| Hostname | nemea |
| CPU | Intel(R) Xeon(R) Platinum 8180 CPU @ 2.50GHz |
| Memory | 978GB |
| numactl | nodebind: 2  |
| numactl | membind: 2  |
</details>

**Commit Info and Build Time**
| commit | date | message | build time |
| -- | -- | -- | -- |
| 42a0a16ab | 13.08.2026 10:04 | exclude STDDEV_SAMP queries | real 561.45 user 4430.41 sys 149.90|
| ba0e82d3e | 17.08.2026 12:44 | fix _groupby_string_count assignment | real 565.19 user 4559.75 sys 160.60|


**hyriseBenchmarkTPCH - single-threaded, SF 10.0**
<details>
<summary>
Sum of avg. item runtimes: +7%
 ||
Geometric mean of throughput changes: +9%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Daniel.Lindner/hyrise/clang20-release/benchmark_all_results/hyriseBenchmarkTPCH_42a0a16abc91e7288ee71f123842740cff2a7bc2_st.json | /home/Daniel.Lindner/hyrise/clang20-release/benchmark_all_results/hyriseBenchmarkTPCH_ba0e82d3e88c4b7f26dd9f9f44b58ed5437ae1d6_st.json |
 +--------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 42a0a16abc91e7288ee71f123842740cff2a7bc2-dirty                                                                                         | ba0e82d3e88c4b7f26dd9f9f44b58ed5437ae1d6-dirty                                                                                         |
 |  benchmark_mode          | Ordered                                                                                                                                | Ordered                                                                                                                                |
 |  build_type              | release                                                                                                                                | release                                                                                                                                |
 |  chunk_indexes           | False                                                                                                                                  | False                                                                                                                                  |
 |  chunk_size              | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                 | 1                                                                                                                                      | 1                                                                                                                                      |
 |  clustering              | None                                                                                                                                   | None                                                                                                                                   |
 |  compiler                | clang 20.1.2                                                                                                                           | clang 20.1.2                                                                                                                           |
 |  cores                   | 0                                                                                                                                      | 0                                                                                                                                      |
 |  data_preparation_cores  | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                    | 2026-08-13 10:20:01                                                                                                                    | 2026-08-17 12:54:36                                                                                                                    |
 |  encoding                | {'default': 'Automatic'}                                                                                                               | {'default': 'Automatic'}                                                                                                               |
 |  max_duration            | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                | 50                                                                                                                                     | 50                                                                                                                                     |
 |  scale_factor            | 10.0                                                                                                                                   | 10.0                                                                                                                                   |
 |  time_unit               | ns                                                                                                                                     | ns                                                                                                                                     |
 |  use_prepared_statements | False                                                                                                                                  | False                                                                                                                                  |
 |  using_scheduler         | False                                                                                                                                  | False                                                                                                                                  |
 |  verify                  | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration         | 1000000000                                                                                                                             | 1000000000                                                                                                                             |
 +--------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+----------+--------++----------+----------+--------+----------------------+
 | Item     || Latency (ms/iter)   | Change || Throughput (iter/s) | Change |              p-value |
 |          ||      old |      new |        ||      old |      new |        |                      |
 +----------++----------+----------+--------++----------+----------+--------+----------------------+
-| TPC-H 01 ||  6104.06 |  9300.54 |  +52%  ||     0.15 |     0.10 |  -33%  | (run time too short) |
+| TPC-H 02 ||    36.78 |    33.13 |  -10%˄ ||    27.19 |    30.18 |  +11%˄ | (run time too short) |
+| TPC-H 03 ||  1162.93 |  1094.53 |   -6%˄ ||     0.86 |     0.91 |   +6%˄ | (run time too short) |
+| TPC-H 04 ||  1340.83 |  1241.18 |   -7%  ||     0.73 |     0.80 |   +9%  | (run time too short) |
 | TPC-H 05 ||  1904.98 |  1864.78 |   -2%  ||     0.52 |     0.53 |   +3%  |               0.0055 |
-| TPC-H 06 ||   264.28 |   278.97 |   +6%˄ ||     3.78 |     3.58 |   -5%˄ | (run time too short) |
+| TPC-H 07 ||   757.90 |   716.31 |   -5%˄ ||     1.32 |     1.40 |   +6%˄ | (run time too short) |
+| TPC-H 08 ||   450.34 |   405.00 |  -10%˄ ||     2.22 |     2.47 |  +11%˄ | (run time too short) |
 | TPC-H 09 ||  4691.33 |  4803.95 |   +2%  ||     0.20 |     0.20 |   +0%  | (run time too short) |
-| TPC-H 10 ||  1281.31 |  2020.79 |  +58%  ||     0.77 |     0.48 |  -37%  | (run time too short) |
+| TPC-H 11 ||    63.17 |    34.63 |  -45%˄ ||    15.83 |    28.88 |  +82%˄ | (run time too short) |
 | TPC-H 12 ||   961.90 |   947.89 |   -1%˄ ||     1.04 |     1.05 |   +1%˄ | (run time too short) |
+| TPC-H 13 ||  4099.80 |  3669.65 |  -10%  ||     0.23 |     0.27 |  +14%  | (run time too short) |
 | TPC-H 14 ||   469.01 |   470.42 |   +0%˄ ||     2.13 |     2.13 |   -0%˄ | (run time too short) |
+| TPC-H 15 ||   247.71 |   236.33 |   -5%˄ ||     4.04 |     4.23 |   +5%˄ | (run time too short) |
+| TPC-H 16 ||   467.16 |   403.55 |  -14%˄ ||     2.14 |     2.48 |  +16%˄ | (run time too short) |
+| TPC-H 17 ||   149.24 |   116.80 |  -22%˄ ||     6.70 |     8.56 |  +28%˄ | (run time too short) |
+| TPC-H 18 ||  1837.39 |   658.09 |  -64%˄ ||     0.53 |     1.52 | +185%˄ | (run time too short) |
 | TPC-H 19 ||   183.71 |   182.33 |   -1%˄ ||     5.44 |     5.48 |   +1%˄ | (run time too short) |
+| TPC-H 20 ||   337.55 |   294.25 |  -13%˄ ||     2.96 |     3.40 |  +15%˄ | (run time too short) |
-| TPC-H 21 ||  3315.06 |  3390.93 |   +2%  ||     0.30 |     0.28 |   -6%  | (run time too short) |
 | TPC-H 22 ||   387.31 |   393.16 |   +2%˄ ||     2.58 |     2.54 |   -1%˄ | (run time too short) |
 +----------++----------+----------+--------++----------+----------+--------+----------------------+
-| Sum      || 30513.76 | 32557.19 |   +7%  ||          |          |        |                      |
+| Geomean  ||          |          |        ||          |          |   +9%  |                      |
 +----------++----------+----------+--------++----------+----------+--------+----------------------+
 |    Notes || ˄ Execution stopped due to max runs reached                                         |
 +----------++----------+----------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkTPCH - single-threaded, SF 0.01**
<details>
<summary>
Sum of avg. item runtimes: +9%
 ||
Geometric mean of throughput changes: -9%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Daniel.Lindner/hyrise/clang20-release/benchmark_all_results/hyriseBenchmarkTPCH_42a0a16abc91e7288ee71f123842740cff2a7bc2_st_s01.json | /home/Daniel.Lindner/hyrise/clang20-release/benchmark_all_results/hyriseBenchmarkTPCH_ba0e82d3e88c4b7f26dd9f9f44b58ed5437ae1d6_st_s01.json |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 42a0a16abc91e7288ee71f123842740cff2a7bc2-dirty                                                                                             | ba0e82d3e88c4b7f26dd9f9f44b58ed5437ae1d6-dirty                                                                                             |
 |  benchmark_mode          | Ordered                                                                                                                                    | Ordered                                                                                                                                    |
 |  build_type              | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_indexes           | False                                                                                                                                      | False                                                                                                                                      |
 |  chunk_size              | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients                 | 1                                                                                                                                          | 1                                                                                                                                          |
 |  clustering              | None                                                                                                                                       | None                                                                                                                                       |
 |  compiler                | clang 20.1.2                                                                                                                               | clang 20.1.2                                                                                                                               |
 |  cores                   | 0                                                                                                                                          | 0                                                                                                                                          |
 |  data_preparation_cores  | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date                    | 2026-08-13 10:35:08                                                                                                                        | 2026-08-17 13:09:11                                                                                                                        |
 |  encoding                | {'default': 'Automatic'}                                                                                                                   | {'default': 'Automatic'}                                                                                                                   |
 |  max_duration            | 60000000000                                                                                                                                | 60000000000                                                                                                                                |
 |  max_runs                | 50                                                                                                                                         | 50                                                                                                                                         |
 |  scale_factor            | 0.009999999776482582                                                                                                                       | 0.009999999776482582                                                                                                                       |
 |  time_unit               | ns                                                                                                                                         | ns                                                                                                                                         |
 |  use_prepared_statements | False                                                                                                                                      | False                                                                                                                                      |
 |  using_scheduler         | False                                                                                                                                      | False                                                                                                                                      |
 |  verify                  | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration         | 1000000000                                                                                                                                 | 1000000000                                                                                                                                 |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |          ||      old |     new |        ||      old |      new |        |                      |
 +----------++----------+---------+--------++----------+----------+--------+----------------------+
 | TPC-H 01 ||     4.90 |    4.89 |   -0%˄ ||   204.06 |   204.24 |   +0%˄ | (run time too short) |
-| TPC-H 02 ||     2.92 |    3.34 |  +14%˄ ||   341.89 |   299.23 |  -12%˄ | (run time too short) |
-| TPC-H 03 ||     0.50 |    0.52 |   +5%˄ ||  2008.59 |  1903.67 |   -5%˄ | (run time too short) |
 | TPC-H 04 ||     0.44 |    0.45 |   +2%˄ ||  2253.91 |  2204.93 |   -2%˄ | (run time too short) |
 | TPC-H 05 ||     1.02 |    1.00 |   -2%˄ ||   981.40 |  1000.00 |   +2%˄ | (run time too short) |
 | TPC-H 06 ||     0.29 |    0.29 |   +1%˄ ||  3486.99 |  3437.07 |   -1%˄ | (run time too short) |
-| TPC-H 07 ||     8.72 |    9.52 |   +9%˄ ||   114.62 |   105.01 |   -8%˄ | (run time too short) |
-| TPC-H 08 ||     3.61 |    3.77 |   +5%˄ ||   277.27 |   265.15 |   -4%˄ | (run time too short) |
-| TPC-H 09 ||     3.05 |    3.32 |   +9%˄ ||   327.21 |   300.63 |   -8%˄ | (run time too short) |
-| TPC-H 10 ||     0.66 |    1.42 | +116%˄ ||  1519.20 |   703.57 |  -54%˄ | (run time too short) |
-| TPC-H 11 ||     0.19 |    0.20 |  +10%˄ ||  5374.35 |  4891.80 |   -9%˄ | (run time too short) |
-| TPC-H 12 ||     0.63 |    0.66 |   +5%˄ ||  1580.10 |  1506.23 |   -5%˄ | (run time too short) |
-| TPC-H 13 ||     1.85 |    2.44 |  +32%˄ ||   539.35 |   409.55 |  -24%˄ | (run time too short) |
 | TPC-H 14 ||     0.41 |    0.42 |   +1%˄ ||  2418.31 |  2382.77 |   -1%˄ | (run time too short) |
-| TPC-H 15 ||     1.25 |    1.47 |  +18%˄ ||   800.47 |   679.72 |  -15%˄ | (run time too short) |
-| TPC-H 16 ||     1.73 |    1.89 |   +9%˄ ||   576.35 |   528.90 |   -8%˄ | (run time too short) |
+| TPC-H 17 ||     0.66 |    0.58 |  -12%˄ ||  1508.20 |  1705.88 |  +13%˄ | (run time too short) |
-| TPC-H 18 ||     1.15 |    1.56 |  +35%˄ ||   865.05 |   639.58 |  -26%˄ | (run time too short) |
 | TPC-H 19 ||     4.11 |    4.14 |   +1%˄ ||   243.28 |   241.40 |   -1%˄ | (run time too short) |
 | TPC-H 20 ||     2.38 |    2.36 |   -1%˄ ||   420.66 |   423.89 |   +1%˄ | (run time too short) |
+| TPC-H 21 ||     1.00 |    0.94 |   -6%˄ ||  1001.32 |  1063.87 |   +6%˄ | (run time too short) |
-| TPC-H 22 ||     1.05 |    1.11 |   +6%˄ ||   950.11 |   897.70 |   -6%˄ | (run time too short) |
 +----------++----------+---------+--------++----------+----------+--------+----------------------+
-| Sum      ||    42.52 |   46.32 |   +9%  ||          |          |        |                      |
-| Geomean  ||          |         |        ||          |          |   -9%  |                      |
 +----------++----------+---------+--------++----------+----------+--------+----------------------+
 |    Notes || ˄ Execution stopped due to max runs reached                                        |
 +----------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkTPCH - multi-threaded, ordered, 1 client, 28 cores, SF 10.0**
<details>
<summary>
Sum of avg. item runtimes: +18%
 ||
Geometric mean of throughput changes: -2%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Daniel.Lindner/hyrise/clang20-release/benchmark_all_results/hyriseBenchmarkTPCH_42a0a16abc91e7288ee71f123842740cff2a7bc2_mt_ordered.json | /home/Daniel.Lindner/hyrise/clang20-release/benchmark_all_results/hyriseBenchmarkTPCH_ba0e82d3e88c4b7f26dd9f9f44b58ed5437ae1d6_mt_ordered.json |
 +-------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 42a0a16abc91e7288ee71f123842740cff2a7bc2-dirty                                                                                                 | ba0e82d3e88c4b7f26dd9f9f44b58ed5437ae1d6-dirty                                                                                                 |
 |  benchmark_mode               | Ordered                                                                                                                                        | Ordered                                                                                                                                        |
 |  build_type                   | release                                                                                                                                        | release                                                                                                                                        |
 |  chunk_indexes                | False                                                                                                                                          | False                                                                                                                                          |
 |  chunk_size                   | 65535                                                                                                                                          | 65535                                                                                                                                          |
 |  clients                      | 1                                                                                                                                              | 1                                                                                                                                              |
 |  clustering                   | None                                                                                                                                           | None                                                                                                                                           |
 |  compiler                     | clang 20.1.2                                                                                                                                   | clang 20.1.2                                                                                                                                   |
 |  cores                        | 28                                                                                                                                             | 28                                                                                                                                             |
 |  data_preparation_cores       | 0                                                                                                                                              | 0                                                                                                                                              |
 |  date                         | 2026-08-13 10:35:32                                                                                                                            | 2026-08-17 13:09:36                                                                                                                            |
 |  encoding                     | {'default': 'Automatic'}                                                                                                                       | {'default': 'Automatic'}                                                                                                                       |
 |  max_duration                 | 60000000000                                                                                                                                    | 60000000000                                                                                                                                    |
 |  max_runs                     | 50                                                                                                                                             | 50                                                                                                                                             |
 |  scale_factor                 | 10.0                                                                                                                                           | 10.0                                                                                                                                           |
 |  time_unit                    | ns                                                                                                                                             | ns                                                                                                                                             |
 |  use_prepared_statements      | False                                                                                                                                          | False                                                                                                                                          |
 |  using_scheduler              | True                                                                                                                                           | True                                                                                                                                           |
 |  utilized_cores_per_numa_node | [0, 0, 28]                                                                                                                                     | [0, 0, 28]                                                                                                                                     |
 |  verify                       | False                                                                                                                                          | False                                                                                                                                          |
 |  warmup_duration              | 1000000000                                                                                                                                     | 1000000000                                                                                                                                     |
 +-------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+----------+--------++----------+----------+--------+----------------------+
 | Item     || Latency (ms/iter)   | Change || Throughput (iter/s) | Change |              p-value |
 |          ||      old |      new |        ||      old |      new |        |                      |
 +----------++----------+----------+--------++----------+----------+--------+----------------------+
-| TPC-H 01 ||  4452.32 |  5686.46 |  +28%  ||     0.22 |     0.17 |  -23%  | (run time too short) |
-| TPC-H 02 ||    45.84 |    51.28 |  +12%˄ ||    21.74 |    19.43 |  -11%˄ | (run time too short) |
+| TPC-H 03 ||   377.77 |   341.29 |  -10%˄ ||     2.65 |     2.93 |  +11%˄ | (run time too short) |
+| TPC-H 04 ||   263.69 |   250.67 |   -5%˄ ||     3.79 |     3.99 |   +5%˄ | (run time too short) |
 | TPC-H 05 ||   287.40 |   291.26 |   +1%˄ ||     3.48 |     3.43 |   -1%˄ | (run time too short) |
 | TPC-H 06 ||    42.35 |    43.08 |   +2%˄ ||    23.52 |    23.12 |   -2%˄ | (run time too short) |
 | TPC-H 07 ||   301.35 |   294.88 |   -2%˄ ||     3.32 |     3.39 |   +2%˄ | (run time too short) |
 | TPC-H 08 ||   173.06 |   179.78 |   +4%˄ ||     5.77 |     5.56 |   -4%˄ | (run time too short) |
-| TPC-H 09 ||   637.39 |   786.43 |  +23%˄ ||     1.57 |     1.27 |  -19%˄ | (run time too short) |
-| TPC-H 10 ||   428.80 |  1042.40 | +143%˄ ||     2.33 |     0.96 |  -59%˄ | (run time too short) |
-| TPC-H 11 ||    67.24 |    72.14 |   +7%˄ ||    14.84 |    13.83 |   -7%˄ | (run time too short) |
 | TPC-H 12 ||   314.90 |   307.43 |   -2%˄ ||     3.17 |     3.25 |   +2%˄ | (run time too short) |
+| TPC-H 13 ||  1197.62 |   425.86 |  -64%˄ ||     0.83 |     2.35 | +181%˄ | (run time too short) |
 | TPC-H 14 ||   152.57 |   155.45 |   +2%˄ ||     6.55 |     6.43 |   -2%˄ | (run time too short) |
+| TPC-H 15 ||   109.96 |    97.54 |  -11%˄ ||     9.08 |    10.24 |  +13%˄ | (run time too short) |
+| TPC-H 16 ||   395.05 |   353.23 |  -11%˄ ||     2.53 |     2.83 |  +12%˄ | (run time too short) |
-| TPC-H 17 ||    92.61 |   100.35 |   +8%˄ ||    10.77 |     9.95 |   -8%˄ | (run time too short) |
-| TPC-H 18 ||  2232.87 |  3414.45 |  +53%  ||     0.43 |     0.28 |  -35%  | (run time too short) |
-| TPC-H 19 ||   115.48 |   127.34 |  +10%˄ ||     8.65 |     7.84 |   -9%˄ | (run time too short) |
+| TPC-H 20 ||   194.01 |   156.79 |  -19%˄ ||     5.15 |     6.37 |  +24%˄ | (run time too short) |
 | TPC-H 21 ||   556.05 |   577.49 |   +4%˄ ||     1.80 |     1.73 |   -4%˄ | (run time too short) |
+| TPC-H 22 ||    77.19 |    68.16 |  -12%˄ ||    12.93 |    14.64 |  +13%˄ | (run time too short) |
 +----------++----------+----------+--------++----------+----------+--------+----------------------+
-| Sum      || 12515.53 | 14823.77 |  +18%  ||          |          |        |                      |
 | Geomean  ||          |          |        ||          |          |   -2%  |                      |
 +----------++----------+----------+--------++----------+----------+--------+----------------------+
 |    Notes || ˄ Execution stopped due to max runs reached                                         |
 +----------++----------+----------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkTPCH - multi-threaded, shuffled, 28 clients, 28 cores, SF 10.0**
<details>
<summary>
Sum of avg. item runtimes: +92%
 ||
Geometric mean of throughput changes: -48%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Daniel.Lindner/hyrise/clang20-release/benchmark_all_results/hyriseBenchmarkTPCH_42a0a16abc91e7288ee71f123842740cff2a7bc2_mt.json | /home/Daniel.Lindner/hyrise/clang20-release/benchmark_all_results/hyriseBenchmarkTPCH_ba0e82d3e88c4b7f26dd9f9f44b58ed5437ae1d6_mt.json |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 42a0a16abc91e7288ee71f123842740cff2a7bc2-dirty                                                                                         | ba0e82d3e88c4b7f26dd9f9f44b58ed5437ae1d6-dirty                                                                                         |
 |  benchmark_mode               | Shuffled                                                                                                                               | Shuffled                                                                                                                               |
 |  build_type                   | release                                                                                                                                | release                                                                                                                                |
 |  chunk_indexes                | False                                                                                                                                  | False                                                                                                                                  |
 |  chunk_size                   | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                      | 28                                                                                                                                     | 28                                                                                                                                     |
 |  clustering                   | None                                                                                                                                   | None                                                                                                                                   |
 |  compiler                     | clang 20.1.2                                                                                                                           | clang 20.1.2                                                                                                                           |
 |  cores                        | 28                                                                                                                                     | 28                                                                                                                                     |
 |  data_preparation_cores       | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                         | 2026-08-13 10:44:33                                                                                                                    | 2026-08-17 13:18:43                                                                                                                    |
 |  encoding                     | {'default': 'Automatic'}                                                                                                               | {'default': 'Automatic'}                                                                                                               |
 |  max_duration                 | 1200000000000                                                                                                                          | 1200000000000                                                                                                                          |
 |  max_runs                     | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor                 | 10.0                                                                                                                                   | 10.0                                                                                                                                   |
 |  time_unit                    | ns                                                                                                                                     | ns                                                                                                                                     |
 |  use_prepared_statements      | False                                                                                                                                  | False                                                                                                                                  |
 |  using_scheduler              | True                                                                                                                                   | True                                                                                                                                   |
 |  utilized_cores_per_numa_node | [0, 0, 28]                                                                                                                             | [0, 0, 28]                                                                                                                             |
 |  verify                       | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration              | 0                                                                                                                                      | 0                                                                                                                                      |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+----------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)   | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |      new |        ||      old |      new |        |         |
 +----------++----------+----------+--------++----------+----------+--------+---------+
-| TPC-H 01 ||  6387.94 | 12548.42 |  +96%  ||     0.62 |     0.32 |  -49%  |  0.0000 |
-| TPC-H 02 ||   354.83 |   574.17 |  +62%  ||     0.62 |     0.32 |  -48%  |  0.1599 |
-| TPC-H 03 ||  2283.95 |  4168.31 |  +83%  ||     0.62 |     0.32 |  -48%  |  0.0000 |
-| TPC-H 04 ||  1930.13 |  3378.32 |  +75%  ||     0.62 |     0.32 |  -49%  |  0.0000 |
-| TPC-H 05 ||  3243.02 |  5713.06 |  +76%  ||     0.62 |     0.32 |  -48%  |  0.0000 |
-| TPC-H 06 ||   528.37 |   656.47 |  +24%  ||     0.62 |     0.32 |  -48%  |  0.0742 |
-| TPC-H 07 ||  2339.22 |  3881.33 |  +66%  ||     0.62 |     0.32 |  -48%  |  0.0000 |
-| TPC-H 08 ||  1488.14 |  2038.41 |  +37%  ||     0.62 |     0.32 |  -48%  |  0.0049 |
-| TPC-H 09 ||  3884.63 |  7518.11 |  +94%  ||     0.62 |     0.32 |  -49%  |  0.0000 |
-| TPC-H 10 ||  2811.74 |  5826.87 | +107%  ||     0.62 |     0.32 |  -48%  |  0.0000 |
-| TPC-H 11 ||   416.03 |   929.39 | +123%  ||     0.62 |     0.32 |  -48%  |  0.0000 |
-| TPC-H 12 ||  1875.47 |  3126.94 |  +67%  ||     0.62 |     0.32 |  -48%  |  0.0000 |
-| TPC-H 13 ||  3286.74 |  5239.61 |  +59%  ||     0.62 |     0.32 |  -48%  |  0.0000 |
-| TPC-H 14 ||   878.63 |  1190.89 |  +36%  ||     0.62 |     0.32 |  -48%  |  0.0126 |
-| TPC-H 15 ||   534.65 |  1898.54 | +255%  ||     0.62 |     0.32 |  -48%  |  0.0000 |
-| TPC-H 16 ||  1612.72 |  2965.23 |  +84%  ||     0.62 |     0.32 |  -48%  |  0.0000 |
-| TPC-H 17 ||   531.23 |   695.02 |  +31%  ||     0.62 |     0.32 |  -48%  |  0.0738 |
-| TPC-H 18 ||  3496.13 | 12258.11 | +251%  ||     0.62 |     0.32 |  -48%  |  0.0000 |
-| TPC-H 19 ||   708.14 |  1054.38 |  +49%  ||     0.62 |     0.32 |  -48%  |  0.0051 |
-| TPC-H 20 ||   882.34 |  1429.47 |  +62%  ||     0.62 |     0.32 |  -48%  |  0.0010 |
-| TPC-H 21 ||  4461.07 |  7659.50 |  +72%  ||     0.62 |     0.32 |  -48%  |  0.0000 |
-| TPC-H 22 ||   843.94 |  1212.06 |  +44%  ||     0.62 |     0.32 |  -48%  |  0.0030 |
 +----------++----------+----------+--------++----------+----------+--------+---------+
-| Sum      || 44779.06 | 85962.60 |  +92%  ||          |          |        |         |
-| Geomean  ||          |          |        ||          |          |  -48%  |         |
 +----------++----------+----------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCDS - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -17%
 ||
Geometric mean of throughput changes: +14%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter               | /home/Daniel.Lindner/hyrise/clang20-release/benchmark_all_results/hyriseBenchmarkTPCDS_42a0a16abc91e7288ee71f123842740cff2a7bc2_st.json | /home/Daniel.Lindner/hyrise/clang20-release/benchmark_all_results/hyriseBenchmarkTPCDS_ba0e82d3e88c4b7f26dd9f9f44b58ed5437ae1d6_st.json |
 +-------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH               | 42a0a16abc91e7288ee71f123842740cff2a7bc2-dirty                                                                                          | ba0e82d3e88c4b7f26dd9f9f44b58ed5437ae1d6-dirty                                                                                          |
 |  benchmark_mode         | Ordered                                                                                                                                 | Ordered                                                                                                                                 |
 |  build_type             | release                                                                                                                                 | release                                                                                                                                 |
 |  chunk_indexes          | False                                                                                                                                   | False                                                                                                                                   |
 |  chunk_size             | 65535                                                                                                                                   | 65535                                                                                                                                   |
 |  clients                | 1                                                                                                                                       | 1                                                                                                                                       |
 |  compiler               | clang 20.1.2                                                                                                                            | clang 20.1.2                                                                                                                            |
 |  cores                  | 0                                                                                                                                       | 0                                                                                                                                       |
 |  data_preparation_cores | 0                                                                                                                                       | 0                                                                                                                                       |
 |  date                   | 2026-08-13 11:06:00                                                                                                                     | 2026-08-17 13:40:48                                                                                                                     |
 |  encoding               | {'default': 'Automatic'}                                                                                                                | {'default': 'Automatic'}                                                                                                                |
 |  max_duration           | 60000000000                                                                                                                             | 60000000000                                                                                                                             |
 |  max_runs               | 50                                                                                                                                      | 50                                                                                                                                      |
 |  time_unit              | ns                                                                                                                                      | ns                                                                                                                                      |
 |  using_scheduler        | False                                                                                                                                   | False                                                                                                                                   |
 |  verify                 | False                                                                                                                                   | False                                                                                                                                   |
 |  warmup_duration        | 1000000000                                                                                                                              | 1000000000                                                                                                                              |
 +-------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+---------+----------------------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) |  Change |              p-value |
 |         ||      old |      new |        ||      old |      new |         |                      |
 +---------++----------+----------+--------++----------+----------+---------+----------------------+
+| 01      ||   192.46 |    47.64 |  -75%˄ ||     5.20 |    20.99 |  +304%˄ | (run time too short) |
+| 03      ||    63.53 |    44.84 |  -29%˄ ||    15.74 |    22.30 |   +42%˄ | (run time too short) |
-| 06      ||   187.74 |   208.62 |  +11%˄ ||     5.33 |     4.79 |   -10%˄ | (run time too short) |
 | 07      ||   268.78 |   275.53 |   +3%˄ ||     3.72 |     3.63 |    -2%˄ | (run time too short) |
+| 09      ||   908.77 |   833.91 |   -8%˄ ||     1.10 |     1.20 |    +9%˄ | (run time too short) |
-| 10      ||   162.27 |   183.92 |  +13%˄ ||     6.16 |     5.44 |   -12%˄ | (run time too short) |
-| 13      ||   529.15 |   562.68 |   +6%˄ ||     1.89 |     1.78 |    -6%˄ | (run time too short) |
 | 15      ||   112.00 |   110.44 |   -1%˄ ||     8.93 |     9.05 |    +1%˄ | (run time too short) |
+| 16      ||    86.19 |    67.34 |  -22%˄ ||    11.60 |    14.85 |   +28%˄ | (run time too short) |
-| 19      ||    99.97 |   122.12 |  +22%˄ ||    10.00 |     8.19 |   -18%˄ | (run time too short) |
-| 25      ||   175.18 |   191.88 |  +10%˄ ||     5.71 |     5.21 |    -9%˄ | (run time too short) |
+| 26      ||   124.70 |   105.25 |  -16%˄ ||     8.02 |     9.50 |   +18%˄ | (run time too short) |
 | 28      ||   895.72 |   921.97 |   +3%˄ ||     1.12 |     1.08 |    -3%˄ | (run time too short) |
-| 29      ||   450.89 |   481.39 |   +7%˄ ||     2.22 |     2.08 |    -6%˄ | (run time too short) |
+| 31      ||  1350.74 |  1217.60 |  -10%  ||     0.73 |     0.82 |   +11%  |               0.0000 |
+| 32      ||    46.09 |    34.27 |  -26%˄ ||    21.70 |    29.18 |   +34%˄ | (run time too short) |
+| 34      ||   187.00 |   173.81 |   -7%˄ ||     5.35 |     5.75 |    +8%˄ | (run time too short) |
+| 35      ||   578.71 |   508.19 |  -12%˄ ||     1.73 |     1.97 |   +14%˄ | (run time too short) |
+| 37      ||   722.65 |   668.41 |   -8%˄ ||     1.38 |     1.50 |    +8%˄ | (run time too short) |
 | 41      ||   273.12 |   273.56 |   +0%˄ ||     3.66 |     3.66 |    -0%˄ | (run time too short) |
-| 42      ||    88.83 |    99.43 |  +12%˄ ||    11.26 |    10.06 |   -11%˄ | (run time too short) |
-| 43      ||   901.42 |  1009.89 |  +12%˄ ||     1.11 |     0.99 |   -11%˄ | (run time too short) |
-| 45      ||   100.86 |   106.87 |   +6%˄ ||     9.91 |     9.36 |    -6%˄ | (run time too short) |
 | 48      ||  1033.02 |  1046.45 |   +1%˄ ||     0.97 |     0.96 |    -1%˄ | (run time too short) |
+| 50      ||   138.69 |   125.51 |  -10%˄ ||     7.21 |     7.97 |   +11%˄ | (run time too short) |
-| 52      ||    83.01 |   100.32 |  +21%˄ ||    12.05 |     9.97 |   -17%˄ | (run time too short) |
-| 55      ||    79.62 |    98.29 |  +23%˄ ||    12.56 |    10.17 |   -19%˄ | (run time too short) |
-| 62      ||   515.44 |   618.27 |  +20%˄ ||     1.94 |     1.62 |   -17%˄ | (run time too short) |
+| 65      ||  1566.07 |   240.43 |  -85%˄ ||     0.63 |     4.16 |  +557%˄ | (run time too short) |
-| 69      ||   165.16 |   177.60 |   +8%˄ ||     6.05 |     5.63 |    -7%˄ | (run time too short) |
-| 73      ||    89.67 |   107.46 |  +20%˄ ||    11.15 |     9.31 |   -17%˄ | (run time too short) |
+| 79      ||   419.01 |   274.05 |  -35%˄ ||     2.39 |     3.65 |   +53%˄ | (run time too short) |
+| 81      ||   128.13 |    67.28 |  -47%˄ ||     7.80 |    14.86 |   +90%˄ | (run time too short) |
+| 82      ||   744.62 |   688.78 |   -7%˄ ||     1.34 |     1.45 |    +8%˄ | (run time too short) |
 | 83      ||    34.68 |    36.19 |   +4%˄ ||    28.83 |    27.63 |    -4%˄ | (run time too short) |
-| 84      ||     9.64 |    10.81 |  +12%˄ ||   103.67 |    92.54 |   -11%˄ | (run time too short) |
 | 85      ||   189.48 |   194.60 |   +3%˄ ||     5.28 |     5.14 |    -3%˄ | (run time too short) |
-| 88      ||   731.12 |   870.77 |  +19%˄ ||     1.37 |     1.15 |   -16%˄ | (run time too short) |
 | 91      ||    14.63 |    14.16 |   -3%˄ ||    68.36 |    70.64 |    +3%˄ | (run time too short) |
-| 92      ||    25.37 |    26.68 |   +5%˄ ||    39.42 |    37.47 |    -5%˄ | (run time too short) |
 | 93      ||  2521.99 |  2499.19 |   -1%  ||     0.38 |     0.40 |    +4%  | (run time too short) |
 | 94      ||    44.96 |    43.72 |   -3%˄ ||    22.24 |    22.87 |    +3%˄ | (run time too short) |
-| 95      ||  4826.77 |  5091.52 |   +5%  ||     0.20 |     0.18 |    -8%  | (run time too short) |
-| 96      ||    73.49 |    91.25 |  +24%˄ ||    13.61 |    10.96 |   -19%˄ | (run time too short) |
+| 97      ||  3742.37 |   301.00 |  -92%˄ ||     0.27 |     3.32 | +1146%˄ | (run time too short) |
-| 99      ||  1035.10 |  1232.29 |  +19%˄ ||     0.97 |     0.80 |   -17%˄ | (run time too short) |
 +---------++----------+----------+--------++----------+----------+---------+----------------------+
+| Sum     || 26718.81 | 22206.16 |  -17%  ||          |          |         |                      |
+| Geomean ||          |          |        ||          |          |   +14%  |                      |
 +---------++----------+----------+--------++----------+----------+---------+----------------------+
 |   Notes || ˄ Execution stopped due to max runs reached                                          |
 +---------++----------+----------+--------++----------+----------+---------+----------------------+
```
</details>


**hyriseBenchmarkTPCDS - multi-threaded, ordered, 1 client, 28 cores**
<details>
<summary>
Sum of avg. item runtimes: -9%
 ||
Geometric mean of throughput changes: +1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+-------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Daniel.Lindner/hyrise/clang20-release/benchmark_all_results/hyriseBenchmarkTPCDS_42a0a16abc91e7288ee71f123842740cff2a7bc2_mt_ordered.json | /home/Daniel.Lindner/hyrise/clang20-release/benchmark_all_results/hyriseBenchmarkTPCDS_ba0e82d3e88c4b7f26dd9f9f44b58ed5437ae1d6_mt_ordered.json |
 +-------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 42a0a16abc91e7288ee71f123842740cff2a7bc2-dirty                                                                                                  | ba0e82d3e88c4b7f26dd9f9f44b58ed5437ae1d6-dirty                                                                                                  |
 |  benchmark_mode               | Ordered                                                                                                                                         | Ordered                                                                                                                                         |
 |  build_type                   | release                                                                                                                                         | release                                                                                                                                         |
 |  chunk_indexes                | False                                                                                                                                           | False                                                                                                                                           |
 |  chunk_size                   | 65535                                                                                                                                           | 65535                                                                                                                                           |
 |  clients                      | 1                                                                                                                                               | 1                                                                                                                                               |
 |  compiler                     | clang 20.1.2                                                                                                                                    | clang 20.1.2                                                                                                                                    |
 |  cores                        | 28                                                                                                                                              | 28                                                                                                                                              |
 |  data_preparation_cores       | 0                                                                                                                                               | 0                                                                                                                                               |
 |  date                         | 2026-08-13 11:23:10                                                                                                                             | 2026-08-17 13:56:13                                                                                                                             |
 |  encoding                     | {'default': 'Automatic'}                                                                                                                        | {'default': 'Automatic'}                                                                                                                        |
 |  max_duration                 | 60000000000                                                                                                                                     | 60000000000                                                                                                                                     |
 |  max_runs                     | 50                                                                                                                                              | 50                                                                                                                                              |
 |  time_unit                    | ns                                                                                                                                              | ns                                                                                                                                              |
 |  using_scheduler              | True                                                                                                                                            | True                                                                                                                                            |
 |  utilized_cores_per_numa_node | [0, 0, 28]                                                                                                                                      | [0, 0, 28]                                                                                                                                      |
 |  verify                       | False                                                                                                                                           | False                                                                                                                                           |
 |  warmup_duration              | 1000000000                                                                                                                                      | 1000000000                                                                                                                                      |
 +-------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |         ||      old |     new |        ||      old |      new |        |                      |
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
+| 01      ||   203.30 |  166.27 |  -18%˄ ||     4.92 |     6.01 |  +22%˄ | (run time too short) |
-| 03      ||    43.57 |   47.68 |   +9%˄ ||    22.86 |    20.90 |   -9%˄ | (run time too short) |
 | 06      ||   174.48 |  172.54 |   -1%˄ ||     5.73 |     5.79 |   +1%˄ | (run time too short) |
+| 07      ||   152.28 |  128.77 |  -15%˄ ||     6.56 |     7.75 |  +18%˄ | (run time too short) |
+| 09      ||   105.94 |   88.88 |  -16%˄ ||     9.42 |    11.23 |  +19%˄ | (run time too short) |
-| 10      ||    53.08 |   58.77 |  +11%˄ ||    18.78 |    16.97 |  -10%˄ | (run time too short) |
 | 13      ||   256.48 |  251.53 |   -2%˄ ||     3.90 |     3.97 |   +2%˄ | (run time too short) |
 | 15      ||    68.39 |   71.21 |   +4%˄ ||    14.58 |    14.01 |   -4%˄ | (run time too short) |
-| 16      ||    41.63 |   50.17 |  +20%˄ ||    23.93 |    19.87 |  -17%˄ | (run time too short) |
+| 19      ||    84.64 |   80.04 |   -5%˄ ||    11.79 |    12.46 |   +6%˄ | (run time too short) |
 | 25      ||   111.02 |  109.23 |   -2%˄ ||     9.00 |     9.15 |   +2%˄ | (run time too short) |
+| 26      ||    72.81 |   69.06 |   -5%˄ ||    13.70 |    14.44 |   +5%˄ | (run time too short) |
-| 28      ||   103.34 |  112.68 |   +9%˄ ||     9.66 |     8.86 |   -8%˄ | (run time too short) |
+| 29      ||   125.17 |  119.18 |   -5%˄ ||     7.98 |     8.38 |   +5%˄ | (run time too short) |
+| 31      ||   396.91 |  188.78 |  -52%˄ ||     2.52 |     5.29 | +110%˄ | (run time too short) |
-| 32      ||    35.35 |   49.15 |  +39%˄ ||    28.17 |    20.28 |  -28%˄ | (run time too short) |
-| 34      ||    89.08 |   95.31 |   +7%˄ ||    11.21 |    10.47 |   -7%˄ | (run time too short) |
+| 35      ||   338.62 |  288.53 |  -15%˄ ||     2.95 |     3.46 |  +17%˄ | (run time too short) |
-| 37      ||   149.38 |  175.19 |  +17%˄ ||     6.69 |     5.70 |  -15%˄ | (run time too short) |
 | 41      ||   318.60 |  317.69 |   -0%˄ ||     3.14 |     3.15 |   +0%˄ | (run time too short) |
 | 42      ||    69.35 |   70.79 |   +2%˄ ||    14.39 |    14.09 |   -2%˄ | (run time too short) |
 | 43      ||   339.67 |  327.03 |   -4%˄ ||     2.94 |     3.06 |   +4%˄ | (run time too short) |
 | 45      ||    83.27 |   85.64 |   +3%˄ ||    11.99 |    11.66 |   -3%˄ | (run time too short) |
 | 48      ||   250.41 |  248.33 |   -1%˄ ||     3.99 |     4.02 |   +1%˄ | (run time too short) |
-| 50      ||    92.39 |  105.81 |  +15%˄ ||    10.80 |     9.44 |  -13%˄ | (run time too short) |
 | 52      ||    70.05 |   67.40 |   -4%˄ ||    14.24 |    14.80 |   +4%˄ | (run time too short) |
-| 55      ||    65.99 |   71.98 |   +9%˄ ||    15.12 |    13.86 |   -8%˄ | (run time too short) |
+| 62      ||   271.11 |  249.09 |   -8%˄ ||     3.69 |     4.01 |   +9%˄ | (run time too short) |
+| 65      ||  1241.04 |  985.62 |  -21%˄ ||     0.80 |     1.01 |  +27%˄ | (run time too short) |
 | 69      ||    84.53 |   82.79 |   -2%˄ ||    11.81 |    12.06 |   +2%˄ | (run time too short) |
-| 73      ||    74.63 |   84.75 |  +14%˄ ||    13.37 |    11.78 |  -12%˄ | (run time too short) |
+| 79      ||   400.32 |  286.33 |  -28%˄ ||     2.50 |     3.49 |  +40%˄ | (run time too short) |
-| 81      ||   176.99 |  204.62 |  +16%˄ ||     5.64 |     4.88 |  -13%˄ | (run time too short) |
-| 82      ||   193.39 |  214.48 |  +11%˄ ||     5.17 |     4.66 |  -10%˄ | (run time too short) |
-| 83      ||    40.25 |   48.41 |  +20%˄ ||    24.74 |    20.58 |  -17%˄ | (run time too short) |
-| 84      ||    12.51 |   13.74 |  +10%˄ ||    78.91 |    71.96 |   -9%˄ | (run time too short) |
-| 85      ||    80.03 |   85.29 |   +7%˄ ||    12.48 |    11.71 |   -6%˄ | (run time too short) |
 | 88      ||    96.26 |   96.49 |   +0%˄ ||    10.38 |    10.35 |   -0%˄ | (run time too short) |
 | 91      ||    16.84 |   16.71 |   -1%˄ ||    58.92 |    59.33 |   +1%˄ | (run time too short) |
-| 92      ||    35.41 |   40.81 |  +15%˄ ||    28.12 |    24.40 |  -13%˄ | (run time too short) |
 | 93      ||   211.54 |  203.51 |   -4%˄ ||     4.72 |     4.91 |   +4%˄ | (run time too short) |
-| 94      ||    47.39 |   54.86 |  +16%˄ ||    21.03 |    18.17 |  -14%˄ | (run time too short) |
 | 95      ||   412.10 |  405.91 |   -2%˄ ||     2.43 |     2.46 |   +2%˄ | (run time too short) |
 | 96      ||    57.20 |   54.96 |   -4%˄ ||    17.43 |    18.15 |   +4%˄ | (run time too short) |
+| 97      ||  1227.46 | 1070.53 |  -13%˄ ||     0.80 |     0.93 |  +17%˄ | (run time too short) |
+| 99      ||   518.39 |  488.89 |   -6%˄ ||     1.93 |     2.04 |   +6%˄ | (run time too short) |
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
+| Sum     ||  9092.63 | 8305.40 |   -9%  ||          |          |        |                      |
 | Geomean ||          |         |        ||          |          |   +1%  |                      |
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
 |   Notes || ˄ Execution stopped due to max runs reached                                        |
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkTPCDS - multi-threaded, shuffled, 28 clients, 28 cores**
<details>
<summary>
Sum of avg. item runtimes: +15%
 ||
Geometric mean of throughput changes: -13%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Daniel.Lindner/hyrise/clang20-release/benchmark_all_results/hyriseBenchmarkTPCDS_42a0a16abc91e7288ee71f123842740cff2a7bc2_mt.json | /home/Daniel.Lindner/hyrise/clang20-release/benchmark_all_results/hyriseBenchmarkTPCDS_ba0e82d3e88c4b7f26dd9f9f44b58ed5437ae1d6_mt.json |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 42a0a16abc91e7288ee71f123842740cff2a7bc2-dirty                                                                                          | ba0e82d3e88c4b7f26dd9f9f44b58ed5437ae1d6-dirty                                                                                          |
 |  benchmark_mode               | Shuffled                                                                                                                                | Shuffled                                                                                                                                |
 |  build_type                   | release                                                                                                                                 | release                                                                                                                                 |
 |  chunk_indexes                | False                                                                                                                                   | False                                                                                                                                   |
 |  chunk_size                   | 65535                                                                                                                                   | 65535                                                                                                                                   |
 |  clients                      | 28                                                                                                                                      | 28                                                                                                                                      |
 |  compiler                     | clang 20.1.2                                                                                                                            | clang 20.1.2                                                                                                                            |
 |  cores                        | 28                                                                                                                                      | 28                                                                                                                                      |
 |  data_preparation_cores       | 0                                                                                                                                       | 0                                                                                                                                       |
 |  date                         | 2026-08-13 11:31:58                                                                                                                     | 2026-08-17 14:04:19                                                                                                                     |
 |  encoding                     | {'default': 'Automatic'}                                                                                                                | {'default': 'Automatic'}                                                                                                                |
 |  max_duration                 | 1200000000000                                                                                                                           | 1200000000000                                                                                                                           |
 |  max_runs                     | -1                                                                                                                                      | -1                                                                                                                                      |
 |  time_unit                    | ns                                                                                                                                      | ns                                                                                                                                      |
 |  using_scheduler              | True                                                                                                                                    | True                                                                                                                                    |
 |  utilized_cores_per_numa_node | [0, 0, 28]                                                                                                                              | [0, 0, 28]                                                                                                                              |
 |  verify                       | False                                                                                                                                   | False                                                                                                                                   |
 |  warmup_duration              | 0                                                                                                                                       | 0                                                                                                                                       |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |      new |        ||      old |      new |        |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
-| 01      ||   630.16 |   958.65 |  +52%  ||     0.67 |     0.58 |  -13%  |  0.0000 |
-| 03      ||   193.03 |   189.20 |   -2%  ||     0.67 |     0.58 |  -13%  |  0.9057 |
-| 06      ||   723.06 |   822.20 |  +14%  ||     0.67 |     0.58 |  -13%  |  0.1405 |
-| 07      ||   721.41 |   867.49 |  +20%  ||     0.67 |     0.58 |  -13%  |  0.0170 |
+| 09      ||   560.19 |   506.91 |  -10%  ||     0.67 |     0.58 |  -13%  |  0.2173 |
+| 10      ||   531.31 |   492.27 |   -7%  ||     0.67 |     0.58 |  -13%  |  0.4266 |
-| 13      ||  1464.46 |  1417.41 |   -3%  ||     0.67 |     0.58 |  -13%  |  0.5296 |
-| 15      ||   494.35 |   560.22 |  +13%  ||     0.67 |     0.58 |  -13%  |  0.2294 |
-| 16      ||   416.18 |   399.41 |   -4%  ||     0.67 |     0.58 |  -13%  |  0.7053 |
-| 19      ||   424.03 |   488.08 |  +15%  ||     0.67 |     0.58 |  -13%  |  0.0891 |
+| 25      ||   770.02 |   729.88 |   -5%  ||     0.67 |     0.58 |  -13%  |  0.5653 |
-| 26      ||   464.90 |   494.43 |   +6%  ||     0.67 |     0.58 |  -13%  |  0.4929 |
-| 28      ||   746.61 |   848.73 |  +14%  ||     0.67 |     0.58 |  -13%  |  0.1403 |
-| 29      ||   901.13 |  1014.92 |  +13%  ||     0.67 |     0.58 |  -13%  |  0.1101 |
-| 31      ||  1768.26 |  2212.20 |  +25%  ||     0.67 |     0.58 |  -13%  |  0.0000 |
-| 32      ||   197.57 |   328.36 |  +66%  ||     0.67 |     0.58 |  -13%  |  0.0000 |
-| 34      ||   506.32 |   709.72 |  +40%  ||     0.67 |     0.58 |  -13%  |  0.0000 |
-| 35      ||  1644.55 |  1889.82 |  +15%  ||     0.67 |     0.58 |  -13%  |  0.0096 |
-| 37      ||   744.10 |   867.55 |  +17%  ||     0.67 |     0.58 |  -13%  |  0.0027 |
-| 41      ||  3576.61 |  4165.57 |  +16%  ||     0.67 |     0.58 |  -13%  |  0.0002 |
-| 42      ||   283.80 |   398.67 |  +40%  ||     0.67 |     0.58 |  -13%  |  0.0012 |
-| 43      ||  1338.03 |  1642.63 |  +23%  ||     0.67 |     0.58 |  -13%  |  0.0000 |
-| 45      ||   641.09 |   666.38 |   +4%  ||     0.67 |     0.58 |  -13%  |  0.6660 |
-| 48      ||  1698.28 |  1766.16 |   +4%  ||     0.67 |     0.58 |  -13%  |  0.4188 |
-| 50      ||   524.59 |   635.85 |  +21%  ||     0.67 |     0.58 |  -13%  |  0.0194 |
-| 52      ||   333.93 |   347.04 |   +4%  ||     0.67 |     0.58 |  -13%  |  0.7020 |
-| 55      ||   283.99 |   384.65 |  +35%  ||     0.67 |     0.58 |  -13%  |  0.0106 |
-| 62      ||   959.87 |  1357.84 |  +41%  ||     0.67 |     0.58 |  -13%  |  0.0000 |
-| 65      ||  2881.65 |  3186.05 |  +11%  ||     0.67 |     0.58 |  -13%  |  0.0003 |
-| 69      ||   753.97 |   817.69 |   +8%  ||     0.67 |     0.58 |  -13%  |  0.3718 |
-| 73      ||   366.50 |   493.69 |  +35%  ||     0.67 |     0.58 |  -13%  |  0.0082 |
-| 79      ||  1147.23 |  1305.74 |  +14%  ||     0.67 |     0.58 |  -13%  |  0.0183 |
-| 81      ||   599.73 |   913.41 |  +52%  ||     0.67 |     0.58 |  -13%  |  0.0000 |
-| 82      ||   837.30 |  1047.04 |  +25%  ||     0.67 |     0.58 |  -13%  |  0.0000 |
-| 83      ||   331.77 |   350.39 |   +6%  ||     0.67 |     0.58 |  -13%  |  0.7355 |
-| 84      ||   113.62 |   134.92 |  +19%  ||     0.67 |     0.58 |  -13%  |  0.4285 |
-| 85      ||   827.96 |   993.50 |  +20%  ||     0.67 |     0.58 |  -13%  |  0.0165 |
-| 88      ||  1275.84 |  1289.41 |   +1%  ||     0.67 |     0.58 |  -13%  |  0.8796 |
+| 91      ||   198.50 |   181.92 |   -8%  ||     0.67 |     0.58 |  -13%  |  0.6055 |
-| 92      ||   185.77 |   321.31 |  +73%  ||     0.67 |     0.58 |  -13%  |  0.0001 |
-| 93      ||  1484.90 |  1800.08 |  +21%  ||     0.67 |     0.58 |  -13%  |  0.0001 |
-| 94      ||   346.30 |   358.70 |   +4%  ||     0.67 |     0.58 |  -13%  |  0.7969 |
-| 95      ||  1756.35 |  1897.41 |   +8%  ||     0.67 |     0.58 |  -12%  |  0.0787 |
-| 96      ||   253.87 |   264.67 |   +4%  ||     0.67 |     0.58 |  -13%  |  0.7193 |
-| 97      ||  3539.25 |  3554.97 |   +0%  ||     0.67 |     0.58 |  -13%  |  0.8802 |
-| 99      ||  1356.10 |  1813.97 |  +34%  ||     0.67 |     0.58 |  -13%  |  0.0000 |
 +---------++----------+----------+--------++----------+----------+--------+---------+
-| Sum     || 41798.45 | 47887.11 |  +15%  ||          |          |        |         |
-| Geomean ||          |          |        ||          |          |  -13%  |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCC - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: +1%
 ||
Geometric mean of throughput changes: +0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter               | /home/Daniel.Lindner/hyrise/clang20-release/benchmark_all_results/hyriseBenchmarkTPCC_42a0a16abc91e7288ee71f123842740cff2a7bc2_st.json | /home/Daniel.Lindner/hyrise/clang20-release/benchmark_all_results/hyriseBenchmarkTPCC_ba0e82d3e88c4b7f26dd9f9f44b58ed5437ae1d6_st.json |
 +-------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH               | 42a0a16abc91e7288ee71f123842740cff2a7bc2-dirty                                                                                         | ba0e82d3e88c4b7f26dd9f9f44b58ed5437ae1d6-dirty                                                                                         |
 |  benchmark_mode         | Shuffled                                                                                                                               | Shuffled                                                                                                                               |
 |  build_type             | release                                                                                                                                | release                                                                                                                                |
 |  chunk_indexes          | False                                                                                                                                  | False                                                                                                                                  |
 |  chunk_size             | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                | 1                                                                                                                                      | 1                                                                                                                                      |
 |  compiler               | clang 20.1.2                                                                                                                           | clang 20.1.2                                                                                                                           |
 |  cores                  | 0                                                                                                                                      | 0                                                                                                                                      |
 |  data_preparation_cores | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                   | 2026-08-13 11:52:13                                                                                                                    | 2026-08-17 14:24:32                                                                                                                    |
 |  encoding               | {'default': 'Automatic'}                                                                                                               | {'default': 'Automatic'}                                                                                                               |
 |  max_duration           | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs               | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor           | 10                                                                                                                                     | 10                                                                                                                                     |
 |  time_unit              | ns                                                                                                                                     | ns                                                                                                                                     |
 |  using_scheduler        | False                                                                                                                                  | False                                                                                                                                  |
 |  verify                 | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration        | 0                                                                                                                                      | 0                                                                                                                                      |
 +-------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |              ||      old |     new |        ||      old |      new |        |         |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
-| Delivery     ||    25.59 |   25.83 |   +1%  ||     4.95 |     4.70 |   -5%  |  0.0004 |
 | New-Order    ||    12.54 |   12.64 |   +1%  ||    59.37 |    58.92 |   -1%  |  0.2667 |
 | Order-Status ||     1.16 |    1.18 |   +1%  ||     4.83 |     4.85 |   +0%  |  0.0837 |
 | Payment      ||     2.03 |    2.05 |   +1%  ||    54.50 |    56.27 |   +3%  |  0.0992 |
 | Stock-Level  ||     1.93 |    1.97 |   +2%  ||     4.95 |     5.17 |   +4%  |  0.0536 |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Sum          ||    43.27 |   43.67 |   +1%  ||          |          |        |         |
 | Geomean      ||          |         |        ||          |          |   +0%  |         |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCC - multi-threaded, shuffled, 28 clients, 10 warehouses, 28 cores (high contention)**
<details>
<summary>
Sum of avg. item runtimes: -0%
 ||
Geometric mean of throughput changes: +0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+-------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Daniel.Lindner/hyrise/clang20-release/benchmark_all_results/hyriseBenchmarkTPCC_42a0a16abc91e7288ee71f123842740cff2a7bc2_mt_highcont.json | /home/Daniel.Lindner/hyrise/clang20-release/benchmark_all_results/hyriseBenchmarkTPCC_ba0e82d3e88c4b7f26dd9f9f44b58ed5437ae1d6_mt_highcont.json |
 +-------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 42a0a16abc91e7288ee71f123842740cff2a7bc2-dirty                                                                                                  | ba0e82d3e88c4b7f26dd9f9f44b58ed5437ae1d6-dirty                                                                                                  |
 |  benchmark_mode               | Shuffled                                                                                                                                        | Shuffled                                                                                                                                        |
 |  build_type                   | release                                                                                                                                         | release                                                                                                                                         |
 |  chunk_indexes                | False                                                                                                                                           | False                                                                                                                                           |
 |  chunk_size                   | 65535                                                                                                                                           | 65535                                                                                                                                           |
 |  clients                      | 28                                                                                                                                              | 28                                                                                                                                              |
 |  compiler                     | clang 20.1.2                                                                                                                                    | clang 20.1.2                                                                                                                                    |
 |  cores                        | 28                                                                                                                                              | 28                                                                                                                                              |
 |  data_preparation_cores       | 0                                                                                                                                               | 0                                                                                                                                               |
 |  date                         | 2026-08-13 11:53:19                                                                                                                             | 2026-08-17 14:25:38                                                                                                                             |
 |  encoding                     | {'default': 'Automatic'}                                                                                                                        | {'default': 'Automatic'}                                                                                                                        |
 |  max_duration                 | 600000000000                                                                                                                                    | 600000000000                                                                                                                                    |
 |  max_runs                     | -1                                                                                                                                              | -1                                                                                                                                              |
 |  scale_factor                 | 10                                                                                                                                              | 10                                                                                                                                              |
 |  time_unit                    | ns                                                                                                                                              | ns                                                                                                                                              |
 |  using_scheduler              | True                                                                                                                                            | True                                                                                                                                            |
 |  utilized_cores_per_numa_node | [0, 0, 28]                                                                                                                                      | [0, 0, 28]                                                                                                                                      |
 |  verify                       | False                                                                                                                                           | False                                                                                                                                           |
 |  warmup_duration              | 0                                                                                                                                               | 0                                                                                                                                               |
 +-------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |              ||      old |     new |        ||      old |      new |        |         |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Delivery     ||    79.50 |   78.90 |   -1%  ||    35.34 |    35.33 |   -0%  |  0.1178 |
 |    unsucc.:  ||     1.83 |    1.78 |   -3%  ||    13.52 |    13.33 |   -1%  |         |
 | New-Order    ||    49.37 |   49.76 |   +1%  ||   417.65 |   414.50 |   -1%  |  0.0001 |
 |    unsucc.:  ||     6.38 |    6.36 |   -0%  ||   130.20 |   129.30 |   -1%  |         |
 | Order-Status ||     4.02 |    4.02 |   +0%  ||    48.35 |    49.00 |   +1%  |  0.9238 |
 | Payment      ||     7.70 |    7.80 |   +1%  ||   304.19 |   303.20 |   -0%  |  0.0028 |
 |    unsucc.:  ||     3.27 |    3.26 |   -0%  ||   218.42 |   218.21 |   -0%  |         |
 | Stock-Level  ||     8.82 |    8.83 |   +0%  ||    48.54 |    48.85 |   +1%  |  0.9575 |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Sum          ||   149.41 |  149.32 |   -0%  ||          |          |        |         |
 | Geomean      ||          |         |        ||          |          |   +0%  |         |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCC - multi-threaded, shuffled, 10 clients, 10 warehouses, 28 cores (low contention)**
<details>
<summary>
Sum of avg. item runtimes: +0%
 ||
Geometric mean of throughput changes: +1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Daniel.Lindner/hyrise/clang20-release/benchmark_all_results/hyriseBenchmarkTPCC_42a0a16abc91e7288ee71f123842740cff2a7bc2_mt_lowcont.json | /home/Daniel.Lindner/hyrise/clang20-release/benchmark_all_results/hyriseBenchmarkTPCC_ba0e82d3e88c4b7f26dd9f9f44b58ed5437ae1d6_mt_lowcont.json |
 +-------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 42a0a16abc91e7288ee71f123842740cff2a7bc2-dirty                                                                                                 | ba0e82d3e88c4b7f26dd9f9f44b58ed5437ae1d6-dirty                                                                                                 |
 |  benchmark_mode               | Shuffled                                                                                                                                       | Shuffled                                                                                                                                       |
 |  build_type                   | release                                                                                                                                        | release                                                                                                                                        |
 |  chunk_indexes                | False                                                                                                                                          | False                                                                                                                                          |
 |  chunk_size                   | 65535                                                                                                                                          | 65535                                                                                                                                          |
 |  clients                      | 10                                                                                                                                             | 10                                                                                                                                             |
 |  compiler                     | clang 20.1.2                                                                                                                                   | clang 20.1.2                                                                                                                                   |
 |  cores                        | 28                                                                                                                                             | 28                                                                                                                                             |
 |  data_preparation_cores       | 0                                                                                                                                              | 0                                                                                                                                              |
 |  date                         | 2026-08-13 12:03:27                                                                                                                            | 2026-08-17 14:35:46                                                                                                                            |
 |  encoding                     | {'default': 'Automatic'}                                                                                                                       | {'default': 'Automatic'}                                                                                                                       |
 |  max_duration                 | 600000000000                                                                                                                                   | 600000000000                                                                                                                                   |
 |  max_runs                     | -1                                                                                                                                             | -1                                                                                                                                             |
 |  scale_factor                 | 10                                                                                                                                             | 10                                                                                                                                             |
 |  time_unit                    | ns                                                                                                                                             | ns                                                                                                                                             |
 |  using_scheduler              | True                                                                                                                                           | True                                                                                                                                           |
 |  utilized_cores_per_numa_node | [0, 0, 28]                                                                                                                                     | [0, 0, 28]                                                                                                                                     |
 |  verify                       | False                                                                                                                                          | False                                                                                                                                          |
 |  warmup_duration              | 0                                                                                                                                              | 0                                                                                                                                              |
 +-------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |              ||      old |     new |        ||      old |      new |        |         |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Delivery     ||    48.68 |   48.87 |   +0%  ||    22.49 |    22.97 |   +2%  |  0.0124 |
 |    unsucc.:  ||     0.92 |    0.78 |  -15%  ||     2.43 |     2.61 |   +7%  |         |
 | New-Order    ||    27.18 |   27.13 |   -0%  ||   262.38 |   261.39 |   -0%  |  0.1186 |
 |    unsucc.:  ||     2.67 |    2.60 |   -3%  ||    23.92 |    23.89 |   -0%  |         |
 | Order-Status ||     3.12 |    3.19 |   +2%  ||    25.21 |    25.73 |   +2%  |  0.0001 |
 | Payment      ||     6.29 |    6.36 |   +1%  ||   221.80 |   221.07 |   -0%  |  0.0000 |
 |    unsucc.:  ||     1.81 |    1.79 |   -1%  ||    51.62 |    51.65 |   +0%  |         |
 | Stock-Level  ||     4.93 |    4.97 |   +1%  ||    25.42 |    25.32 |   -0%  |  0.2635 |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Sum          ||    90.20 |   90.51 |   +0%  ||          |          |        |         |
 | Geomean      ||          |         |        ||          |          |   +1%  |         |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkJoinOrder - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -4%
 ||
Geometric mean of throughput changes: +9%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter               | /home/Daniel.Lindner/hyrise/clang20-release/benchmark_all_results/hyriseBenchmarkJoinOrder_42a0a16abc91e7288ee71f123842740cff2a7bc2_st.json | /home/Daniel.Lindner/hyrise/clang20-release/benchmark_all_results/hyriseBenchmarkJoinOrder_ba0e82d3e88c4b7f26dd9f9f44b58ed5437ae1d6_st.json |
 +-------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH               | 42a0a16abc91e7288ee71f123842740cff2a7bc2-dirty                                                                                              | ba0e82d3e88c4b7f26dd9f9f44b58ed5437ae1d6-dirty                                                                                              |
 |  benchmark_mode         | Ordered                                                                                                                                     | Ordered                                                                                                                                     |
 |  build_type             | release                                                                                                                                     | release                                                                                                                                     |
 |  chunk_indexes          | False                                                                                                                                       | False                                                                                                                                       |
 |  chunk_size             | 65535                                                                                                                                       | 65535                                                                                                                                       |
 |  clients                | 1                                                                                                                                           | 1                                                                                                                                           |
 |  compiler               | clang 20.1.2                                                                                                                                | clang 20.1.2                                                                                                                                |
 |  cores                  | 0                                                                                                                                           | 0                                                                                                                                           |
 |  data_preparation_cores | 0                                                                                                                                           | 0                                                                                                                                           |
 |  date                   | 2026-08-13 12:13:34                                                                                                                         | 2026-08-17 14:45:53                                                                                                                         |
 |  encoding               | {'default': 'Automatic'}                                                                                                                    | {'default': 'Automatic'}                                                                                                                    |
 |  max_duration           | 60000000000                                                                                                                                 | 60000000000                                                                                                                                 |
 |  max_runs               | 50                                                                                                                                          | 50                                                                                                                                          |
 |  time_unit              | ns                                                                                                                                          | ns                                                                                                                                          |
 |  using_scheduler        | False                                                                                                                                       | False                                                                                                                                       |
 |  verify                 | False                                                                                                                                       | False                                                                                                                                       |
 |  warmup_duration        | 1000000000                                                                                                                                  | 1000000000                                                                                                                                  |
 +-------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change |              p-value |
 |         ||      old |      new |        ||      old |      new |        |                      |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 | 10a     ||    98.30 |    96.28 |   -2%˄ ||    10.17 |    10.39 |   +2%˄ | (run time too short) |
 | 10b     ||    51.34 |    49.89 |   -3%˄ ||    19.48 |    20.04 |   +3%˄ | (run time too short) |
 | 10c     ||   281.05 |   285.22 |   +1%˄ ||     3.56 |     3.51 |   -1%˄ | (run time too short) |
+| 11a     ||    26.40 |    23.55 |  -11%˄ ||    37.87 |    42.45 |  +12%˄ | (run time too short) |
+| 11b     ||    26.65 |    23.43 |  -12%˄ ||    37.52 |    42.67 |  +14%˄ | (run time too short) |
+| 11c     ||    20.72 |    16.35 |  -21%˄ ||    48.25 |    61.17 |  +27%˄ | (run time too short) |
+| 11d     ||    22.75 |    17.75 |  -22%˄ ||    43.96 |    56.35 |  +28%˄ | (run time too short) |
 | 12a     ||    86.78 |    85.43 |   -2%˄ ||    11.52 |    11.71 |   +2%˄ | (run time too short) |
+| 12b     ||    39.51 |    26.44 |  -33%˄ ||    25.31 |    37.82 |  +49%˄ | (run time too short) |
 | 12c     ||   138.58 |   138.49 |   -0%˄ ||     7.22 |     7.22 |   +0%˄ | (run time too short) |
+| 13a     ||   162.92 |   151.19 |   -7%˄ ||     6.14 |     6.61 |   +8%˄ | (run time too short) |
+| 13b     ||   215.60 |   205.36 |   -5%˄ ||     4.64 |     4.87 |   +5%˄ | (run time too short) |
+| 13c     ||    48.31 |    34.28 |  -29%˄ ||    20.70 |    29.17 |  +41%˄ | (run time too short) |
 | 13d     ||   428.61 |   440.41 |   +3%˄ ||     2.33 |     2.27 |   -3%˄ | (run time too short) |
 | 14a     ||   127.20 |   127.16 |   -0%˄ ||     7.86 |     7.86 |   +0%˄ | (run time too short) |
 | 14b     ||    64.64 |    62.03 |   -4%˄ ||    15.47 |    16.12 |   +4%˄ | (run time too short) |
 | 14c     ||   182.84 |   181.04 |   -1%˄ ||     5.47 |     5.52 |   +1%˄ | (run time too short) |
+| 15a     ||    48.03 |    45.27 |   -6%˄ ||    20.82 |    22.09 |   +6%˄ | (run time too short) |
+| 15b     ||    53.40 |    50.55 |   -5%˄ ||    18.73 |    19.78 |   +6%˄ | (run time too short) |
+| 15c     ||    40.82 |    36.10 |  -12%˄ ||    24.49 |    27.70 |  +13%˄ | (run time too short) |
+| 15d     ||    38.16 |    33.35 |  -13%˄ ||    26.20 |    29.99 |  +14%˄ | (run time too short) |
+| 16a     ||   110.00 |    82.13 |  -25%˄ ||     9.09 |    12.18 |  +34%˄ | (run time too short) |
 | 16b     ||  1740.38 |  1760.18 |   +1%  ||     0.57 |     0.57 |   +0%  |               0.1590 |
+| 16c     ||   250.60 |   221.00 |  -12%˄ ||     3.99 |     4.52 |  +13%˄ | (run time too short) |
+| 16d     ||   219.52 |   192.70 |  -12%˄ ||     4.56 |     5.19 |  +14%˄ | (run time too short) |
+| 17a     ||   372.14 |   351.51 |   -6%˄ ||     2.69 |     2.84 |   +6%˄ | (run time too short) |
+| 17b     ||   303.52 |   284.03 |   -6%˄ ||     3.29 |     3.52 |   +7%˄ | (run time too short) |
+| 17c     ||   286.07 |   266.96 |   -7%˄ ||     3.50 |     3.75 |   +7%˄ | (run time too short) |
+| 17d     ||   350.74 |   328.14 |   -6%˄ ||     2.85 |     3.05 |   +7%˄ | (run time too short) |
 | 17e     ||  1300.51 |  1320.63 |   +2%  ||     0.77 |     0.75 |   -2%  |               0.0002 |
 | 17f     ||   754.55 |   737.54 |   -2%˄ ||     1.33 |     1.36 |   +2%˄ | (run time too short) |
+| 18a     ||   134.40 |   123.93 |   -8%˄ ||     7.44 |     8.07 |   +8%˄ | (run time too short) |
 | 18b     ||    92.18 |    92.26 |   +0%˄ ||    10.85 |    10.84 |   -0%˄ | (run time too short) |
 | 18c     ||   166.34 |   165.64 |   -0%˄ ||     6.01 |     6.04 |   +0%˄ | (run time too short) |
+| 19a     ||   205.93 |   193.93 |   -6%˄ ||     4.86 |     5.16 |   +6%˄ | (run time too short) |
+| 19b     ||   171.15 |   161.29 |   -6%˄ ||     5.84 |     6.20 |   +6%˄ | (run time too short) |
+| 19c     ||   242.13 |   231.18 |   -5%˄ ||     4.13 |     4.33 |   +5%˄ | (run time too short) |
 | 19d     ||   540.71 |   523.98 |   -3%˄ ||     1.85 |     1.91 |   +3%˄ | (run time too short) |
+| 1a      ||    10.47 |     7.54 |  -28%˄ ||    95.50 |   132.54 |  +39%˄ | (run time too short) |
+| 1b      ||    16.04 |    13.20 |  -18%˄ ||    62.32 |    75.72 |  +22%˄ | (run time too short) |
 | 1c      ||    13.88 |    13.56 |   -2%˄ ||    72.04 |    73.72 |   +2%˄ | (run time too short) |
+| 1d      ||     9.98 |     7.08 |  -29%˄ ||   100.16 |   141.19 |  +41%˄ | (run time too short) |
+| 20a     ||   505.59 |   480.62 |   -5%˄ ||     1.98 |     2.08 |   +5%˄ | (run time too short) |
+| 20b     ||   538.50 |   512.41 |   -5%˄ ||     1.86 |     1.95 |   +5%˄ | (run time too short) |
+| 20c     ||   324.67 |   297.27 |   -8%˄ ||     3.08 |     3.36 |   +9%˄ | (run time too short) |
+| 21a     ||    38.22 |    35.39 |   -7%˄ ||    26.16 |    28.26 |   +8%˄ | (run time too short) |
+| 21b     ||    30.44 |    27.97 |   -8%˄ ||    32.85 |    35.75 |   +9%˄ | (run time too short) |
+| 21c     ||    35.72 |    32.66 |   -9%˄ ||    28.00 |    30.62 |   +9%˄ | (run time too short) |
 | 22a     ||   153.13 |   148.71 |   -3%˄ ||     6.53 |     6.72 |   +3%˄ | (run time too short) |
 | 22b     ||   137.72 |   135.66 |   -1%˄ ||     7.26 |     7.37 |   +2%˄ | (run time too short) |
 | 22c     ||   204.31 |   201.41 |   -1%˄ ||     4.89 |     4.96 |   +1%˄ | (run time too short) |
 | 22d     ||   312.22 |   307.84 |   -1%˄ ||     3.20 |     3.25 |   +1%˄ | (run time too short) |
+| 23a     ||    43.17 |    38.63 |  -11%˄ ||    23.16 |    25.89 |  +12%˄ | (run time too short) |
+| 23b     ||    46.74 |    42.05 |  -10%˄ ||    21.40 |    23.78 |  +11%˄ | (run time too short) |
+| 23c     ||    45.59 |    41.22 |  -10%˄ ||    21.93 |    24.26 |  +11%˄ | (run time too short) |
+| 24a     ||   210.02 |   195.81 |   -7%˄ ||     4.76 |     5.11 |   +7%˄ | (run time too short) |
+| 24b     ||   201.46 |   187.33 |   -7%˄ ||     4.96 |     5.34 |   +8%˄ | (run time too short) |
 | 25a     ||    86.82 |    83.92 |   -3%˄ ||    11.52 |    11.92 |   +3%˄ | (run time too short) |
+| 25b     ||    59.14 |    55.35 |   -6%˄ ||    16.91 |    18.07 |   +7%˄ | (run time too short) |
 | 25c     ||   206.45 |   202.28 |   -2%˄ ||     4.84 |     4.94 |   +2%˄ | (run time too short) |
+| 26a     ||   130.93 |   105.29 |  -20%˄ ||     7.64 |     9.50 |  +24%˄ | (run time too short) |
+| 26b     ||   110.55 |    84.60 |  -23%˄ ||     9.05 |    11.82 |  +31%˄ | (run time too short) |
+| 26c     ||   226.11 |   202.38 |  -10%˄ ||     4.42 |     4.94 |  +12%˄ | (run time too short) |
+| 27a     ||    34.23 |    31.57 |   -8%˄ ||    29.22 |    31.68 |   +8%˄ | (run time too short) |
+| 27b     ||    28.61 |    25.91 |   -9%˄ ||    34.95 |    38.59 |  +10%˄ | (run time too short) |
+| 27c     ||    35.93 |    33.11 |   -8%˄ ||    27.83 |    30.20 |   +9%˄ | (run time too short) |
 | 28a     ||   176.57 |   175.76 |   -0%˄ ||     5.66 |     5.69 |   +0%˄ | (run time too short) |
 | 28b     ||    57.39 |    55.22 |   -4%˄ ||    17.42 |    18.11 |   +4%˄ | (run time too short) |
 | 28c     ||   149.31 |   146.92 |   -2%˄ ||     6.70 |     6.81 |   +2%˄ | (run time too short) |
+| 29a     ||   181.65 |   165.82 |   -9%˄ ||     5.51 |     6.03 |  +10%˄ | (run time too short) |
 | 29b     ||   694.71 |   688.88 |   -1%˄ ||     1.44 |     1.45 |   +1%˄ | (run time too short) |
+| 29c     ||   211.60 |   195.22 |   -8%˄ ||     4.73 |     5.12 |   +8%˄ | (run time too short) |
+| 2a      ||    25.84 |    21.34 |  -17%˄ ||    38.69 |    46.85 |  +21%˄ | (run time too short) |
+| 2b      ||    24.50 |    19.92 |  -19%˄ ||    40.82 |    50.20 |  +23%˄ | (run time too short) |
+| 2c      ||    21.94 |    17.77 |  -19%˄ ||    45.57 |    56.26 |  +23%˄ | (run time too short) |
+| 2d      ||    42.78 |    38.60 |  -10%˄ ||    23.37 |    25.91 |  +11%˄ | (run time too short) |
 | 30a     ||    81.29 |    78.31 |   -4%˄ ||    12.30 |    12.77 |   +4%˄ | (run time too short) |
 | 30b     ||    85.86 |    82.37 |   -4%˄ ||    11.65 |    12.14 |   +4%˄ | (run time too short) |
 | 30c     ||   138.16 |   136.04 |   -2%˄ ||     7.24 |     7.35 |   +2%˄ | (run time too short) |
+| 31a     ||    71.47 |    66.53 |   -7%˄ ||    13.99 |    15.03 |   +7%˄ | (run time too short) |
+| 31b     ||    70.32 |    66.78 |   -5%˄ ||    14.22 |    14.98 |   +5%˄ | (run time too short) |
+| 31c     ||    82.20 |    77.37 |   -6%˄ ||    12.17 |    12.93 |   +6%˄ | (run time too short) |
+| 32a     ||    12.93 |     9.82 |  -24%˄ ||    77.35 |   101.87 |  +32%˄ | (run time too short) |
+| 32b     ||    24.78 |    21.79 |  -12%˄ ||    40.35 |    45.89 |  +14%˄ | (run time too short) |
+| 33a     ||    34.16 |    30.25 |  -11%˄ ||    29.27 |    33.05 |  +13%˄ | (run time too short) |
+| 33b     ||    24.17 |    19.45 |  -20%˄ ||    41.37 |    51.40 |  +24%˄ | (run time too short) |
+| 33c     ||    39.04 |    35.07 |  -10%˄ ||    25.61 |    28.51 |  +11%˄ | (run time too short) |
+| 3a      ||    51.41 |    49.08 |   -5%˄ ||    19.45 |    20.37 |   +5%˄ | (run time too short) |
+| 3b      ||    18.35 |    15.63 |  -15%˄ ||    54.50 |    63.98 |  +17%˄ | (run time too short) |
 | 3c      ||   187.57 |   185.12 |   -1%˄ ||     5.33 |     5.40 |   +1%˄ | (run time too short) |
 | 4a      ||   117.61 |   117.24 |   -0%˄ ||     8.50 |     8.53 |   +0%˄ | (run time too short) |
+| 4b      ||    17.73 |    15.20 |  -14%˄ ||    56.41 |    65.80 |  +17%˄ | (run time too short) |
 | 4c      ||   161.41 |   167.64 |   +4%˄ ||     6.20 |     5.96 |   -4%˄ | (run time too short) |
 | 5a      ||    37.48 |    37.59 |   +0%˄ ||    26.68 |    26.60 |   -0%˄ | (run time too short) |
 | 5b      ||    42.17 |    42.64 |   +1%˄ ||    23.71 |    23.45 |   -1%˄ | (run time too short) |
 | 5c      ||    76.03 |    76.47 |   +1%˄ ||    13.15 |    13.08 |   -1%˄ | (run time too short) |
+| 6a      ||   138.30 |   112.07 |  -19%˄ ||     7.23 |     8.92 |  +23%˄ | (run time too short) |
+| 6b      ||   147.20 |   121.54 |  -17%˄ ||     6.79 |     8.23 |  +21%˄ | (run time too short) |
+| 6c      ||   132.33 |   106.49 |  -20%˄ ||     7.56 |     9.39 |  +24%˄ | (run time too short) |
+| 6d      ||   343.20 |   319.88 |   -7%˄ ||     2.91 |     3.13 |   +7%˄ | (run time too short) |
+| 6e      ||   135.04 |   109.33 |  -19%˄ ||     7.41 |     9.15 |  +24%˄ | (run time too short) |
+| 6f      ||   565.55 |   530.84 |   -6%˄ ||     1.77 |     1.88 |   +7%˄ | (run time too short) |
+| 7a      ||   113.84 |    91.85 |  -19%˄ ||     8.78 |    10.89 |  +24%˄ | (run time too short) |
+| 7b      ||   108.55 |    86.34 |  -20%˄ ||     9.21 |    11.58 |  +26%˄ | (run time too short) |
+| 7c      ||   284.21 |   258.57 |   -9%˄ ||     3.52 |     3.87 |  +10%˄ | (run time too short) |
 | 8a      ||   161.51 |   160.34 |   -1%˄ ||     6.19 |     6.24 |   +1%˄ | (run time too short) |
 | 8b      ||   160.37 |   159.34 |   -1%˄ ||     6.24 |     6.28 |   +1%˄ | (run time too short) |
 | 8c      ||  1559.27 |  1550.83 |   -1%  ||     0.63 |     0.63 |   +0%  | (run time too short) |
+| 8d      ||   446.10 |   415.99 |   -7%˄ ||     2.24 |     2.40 |   +7%˄ | (run time too short) |
 | 9a      ||   187.64 |   184.70 |   -2%˄ ||     5.33 |     5.41 |   +2%˄ | (run time too short) |
 | 9b      ||   125.87 |   125.32 |   -0%˄ ||     7.94 |     7.98 |   +0%˄ | (run time too short) |
 | 9c      ||   218.26 |   214.82 |   -2%˄ ||     4.58 |     4.65 |   +2%˄ | (run time too short) |
 | 9d      ||   359.52 |   353.61 |   -2%˄ ||     2.78 |     2.83 |   +2%˄ | (run time too short) |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 | Sum     || 21387.33 | 20475.07 |   -4%  ||          |          |        |                      |
+| Geomean ||          |          |        ||          |          |   +9%  |                      |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 |   Notes || ˄ Execution stopped due to max runs reached                                         |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkJoinOrder - multi-threaded, ordered, 1 client, 28 cores**
<details>
<summary>
Sum of avg. item runtimes: +6%
 ||
Geometric mean of throughput changes: -5%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+-----------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Daniel.Lindner/hyrise/clang20-release/benchmark_all_results/hyriseBenchmarkJoinOrder_42a0a16abc91e7288ee71f123842740cff2a7bc2_mt_ordered.json | /home/Daniel.Lindner/hyrise/clang20-release/benchmark_all_results/hyriseBenchmarkJoinOrder_ba0e82d3e88c4b7f26dd9f9f44b58ed5437ae1d6_mt_ordered.json |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 42a0a16abc91e7288ee71f123842740cff2a7bc2-dirty                                                                                                      | ba0e82d3e88c4b7f26dd9f9f44b58ed5437ae1d6-dirty                                                                                                      |
 |  benchmark_mode               | Ordered                                                                                                                                             | Ordered                                                                                                                                             |
 |  build_type                   | release                                                                                                                                             | release                                                                                                                                             |
 |  chunk_indexes                | False                                                                                                                                               | False                                                                                                                                               |
 |  chunk_size                   | 65535                                                                                                                                               | 65535                                                                                                                                               |
 |  clients                      | 1                                                                                                                                                   | 1                                                                                                                                                   |
 |  compiler                     | clang 20.1.2                                                                                                                                        | clang 20.1.2                                                                                                                                        |
 |  cores                        | 28                                                                                                                                                  | 28                                                                                                                                                  |
 |  data_preparation_cores       | 0                                                                                                                                                   | 0                                                                                                                                                   |
 |  date                         | 2026-08-13 12:33:02                                                                                                                                 | 2026-08-17 15:04:30                                                                                                                                 |
 |  encoding                     | {'default': 'Automatic'}                                                                                                                            | {'default': 'Automatic'}                                                                                                                            |
 |  max_duration                 | 60000000000                                                                                                                                         | 60000000000                                                                                                                                         |
 |  max_runs                     | 50                                                                                                                                                  | 50                                                                                                                                                  |
 |  time_unit                    | ns                                                                                                                                                  | ns                                                                                                                                                  |
 |  using_scheduler              | True                                                                                                                                                | True                                                                                                                                                |
 |  utilized_cores_per_numa_node | [0, 0, 28]                                                                                                                                          | [0, 0, 28]                                                                                                                                          |
 |  verify                       | False                                                                                                                                               | False                                                                                                                                               |
 |  warmup_duration              | 1000000000                                                                                                                                          | 1000000000                                                                                                                                          |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change |              p-value |
 |         ||      old |      new |        ||      old |      new |        |                      |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 | 10a     ||    33.14 |    33.36 |   +1%˄ ||    30.03 |    29.86 |   -1%˄ | (run time too short) |
-| 10b     ||    21.05 |    23.24 |  +10%˄ ||    47.14 |    42.77 |   -9%˄ | (run time too short) |
 | 10c     ||   105.51 |   105.57 |   +0%˄ ||     9.46 |     9.46 |   -0%˄ | (run time too short) |
-| 11a     ||    18.42 |    20.64 |  +12%˄ ||    53.86 |    48.07 |  -11%˄ | (run time too short) |
-| 11b     ||    14.00 |    15.03 |   +7%˄ ||    70.76 |    65.86 |   -7%˄ | (run time too short) |
+| 11c     ||    27.21 |    23.52 |  -14%˄ ||    36.53 |    42.26 |  +16%˄ | (run time too short) |
-| 11d     ||    31.60 |    33.56 |   +6%˄ ||    31.48 |    29.64 |   -6%˄ | (run time too short) |
 | 12a     ||    58.92 |    57.30 |   -3%˄ ||    16.93 |    17.40 |   +3%˄ | (run time too short) |
-| 12b     ||    23.70 |    27.33 |  +15%˄ ||    41.92 |    36.38 |  -13%˄ | (run time too short) |
 | 12c     ||    89.87 |    88.93 |   -1%˄ ||    11.10 |    11.22 |   +1%˄ | (run time too short) |
 | 13a     ||   121.71 |   121.93 |   +0%˄ ||     8.20 |     8.19 |   -0%˄ | (run time too short) |
+| 13b     ||    82.69 |    79.07 |   -4%˄ ||    12.07 |    12.62 |   +5%˄ | (run time too short) |
-| 13c     ||    26.42 |    29.77 |  +13%˄ ||    37.62 |    33.41 |  -11%˄ | (run time too short) |
-| 13d     ||   297.37 |   318.41 |   +7%˄ ||     3.36 |     3.14 |   -7%˄ | (run time too short) |
 | 14a     ||    62.04 |    62.07 |   +0%˄ ||    16.08 |    16.08 |   -0%˄ | (run time too short) |
 | 14b     ||    39.79 |    40.27 |   +1%˄ ||    25.05 |    24.76 |   -1%˄ | (run time too short) |
 | 14c     ||   116.11 |   113.97 |   -2%˄ ||     8.60 |     8.76 |   +2%˄ | (run time too short) |
-| 15a     ||    28.81 |    32.03 |  +11%˄ ||    34.55 |    31.07 |  -10%˄ | (run time too short) |
-| 15b     ||    26.43 |    28.25 |   +7%˄ ||    37.64 |    35.22 |   -6%˄ | (run time too short) |
-| 15c     ||    27.68 |    29.62 |   +7%˄ ||    35.91 |    33.59 |   -6%˄ | (run time too short) |
+| 15d     ||    32.71 |    27.58 |  -16%˄ ||    30.42 |    36.08 |  +19%˄ | (run time too short) |
-| 16a     ||    62.02 |    70.93 |  +14%˄ ||    16.08 |    14.07 |  -13%˄ | (run time too short) |
-| 16b     ||   804.39 |   924.40 |  +15%˄ ||     1.24 |     1.08 |  -13%˄ | (run time too short) |
-| 16c     ||   165.34 |   176.37 |   +7%˄ ||     6.04 |     5.66 |   -6%˄ | (run time too short) |
-| 16d     ||   142.87 |   149.88 |   +5%˄ ||     6.99 |     6.66 |   -5%˄ | (run time too short) |
 | 17a     ||   236.36 |   243.69 |   +3%˄ ||     4.23 |     4.10 |   -3%˄ | (run time too short) |
 | 17b     ||   219.82 |   220.92 |   +0%˄ ||     4.55 |     4.52 |   -1%˄ | (run time too short) |
 | 17c     ||   194.81 |   198.86 |   +2%˄ ||     5.13 |     5.02 |   -2%˄ | (run time too short) |
 | 17d     ||   180.27 |   186.86 |   +4%˄ ||     5.54 |     5.35 |   -4%˄ | (run time too short) |
-| 17e     ||   497.75 |   556.92 |  +12%˄ ||     2.01 |     1.80 |  -11%˄ | (run time too short) |
-| 17f     ||   314.82 |   343.24 |   +9%˄ ||     3.17 |     2.91 |   -8%˄ | (run time too short) |
-| 18a     ||    59.85 |    68.17 |  +14%˄ ||    16.67 |    14.63 |  -12%˄ | (run time too short) |
 | 18b     ||    57.51 |    58.41 |   +2%˄ ||    17.34 |    17.08 |   -2%˄ | (run time too short) |
 | 18c     ||    91.56 |    88.08 |   -4%˄ ||    10.90 |    11.33 |   +4%˄ | (run time too short) |
 | 19a     ||   109.50 |   108.69 |   -1%˄ ||     9.12 |     9.19 |   +1%˄ | (run time too short) |
 | 19b     ||    75.55 |    78.05 |   +3%˄ ||    13.22 |    12.79 |   -3%˄ | (run time too short) |
 | 19c     ||   122.07 |   122.11 |   +0%˄ ||     8.18 |     8.18 |   -0%˄ | (run time too short) |
-| 19d     ||   415.55 |   463.15 |  +11%˄ ||     2.41 |     2.16 |  -10%˄ | (run time too short) |
-| 1a      ||    11.83 |    13.41 |  +13%˄ ||    83.56 |    73.69 |  -12%˄ | (run time too short) |
-| 1b      ||     6.58 |     7.13 |   +8%˄ ||   148.39 |   137.23 |   -8%˄ | (run time too short) |
-| 1c      ||     7.37 |     7.99 |   +8%˄ ||   133.02 |   122.74 |   -8%˄ | (run time too short) |
-| 1d      ||    10.20 |    11.20 |  +10%˄ ||    96.72 |    88.08 |   -9%˄ | (run time too short) |
 | 20a     ||    78.67 |    80.40 |   +2%˄ ||    12.69 |    12.42 |   -2%˄ | (run time too short) |
 | 20b     ||    60.33 |    60.86 |   +1%˄ ||    16.55 |    16.40 |   -1%˄ | (run time too short) |
 | 20c     ||    72.91 |    74.61 |   +2%˄ ||    13.68 |    13.37 |   -2%˄ | (run time too short) |
 | 21a     ||    25.55 |    26.50 |   +4%˄ ||    38.89 |    37.53 |   -4%˄ | (run time too short) |
-| 21b     ||    23.73 |    27.25 |  +15%˄ ||    41.87 |    36.49 |  -13%˄ | (run time too short) |
-| 21c     ||    28.00 |    29.59 |   +6%˄ ||    35.54 |    33.63 |   -5%˄ | (run time too short) |
 | 22a     ||    65.49 |    64.92 |   -1%˄ ||    15.23 |    15.36 |   +1%˄ | (run time too short) |
 | 22b     ||    55.67 |    56.48 |   +1%˄ ||    17.92 |    17.67 |   -1%˄ | (run time too short) |
 | 22c     ||   130.29 |   128.76 |   -1%˄ ||     7.66 |     7.75 |   +1%˄ | (run time too short) |
 | 22d     ||   198.53 |   198.05 |   -0%˄ ||     5.03 |     5.04 |   +0%˄ | (run time too short) |
-| 23a     ||    24.40 |    26.58 |   +9%˄ ||    40.74 |    37.41 |   -8%˄ | (run time too short) |
-| 23b     ||    29.99 |    35.34 |  +18%˄ ||    33.22 |    28.18 |  -15%˄ | (run time too short) |
-| 23c     ||    26.04 |    27.92 |   +7%˄ ||    38.20 |    35.64 |   -7%˄ | (run time too short) |
 | 24a     ||    66.73 |    65.90 |   -1%˄ ||    14.95 |    15.15 |   +1%˄ | (run time too short) |
 | 24b     ||    57.63 |    56.52 |   -2%˄ ||    17.32 |    17.66 |   +2%˄ | (run time too short) |
+| 25a     ||    61.00 |    58.28 |   -4%˄ ||    16.35 |    17.12 |   +5%˄ | (run time too short) |
-| 25b     ||    36.29 |    40.72 |  +12%˄ ||    27.43 |    24.46 |  -11%˄ | (run time too short) |
 | 25c     ||   140.79 |   139.24 |   -1%˄ ||     7.09 |     7.17 |   +1%˄ | (run time too short) |
-| 26a     ||    86.93 |   100.09 |  +15%˄ ||    11.48 |     9.97 |  -13%˄ | (run time too short) |
-| 26b     ||    72.96 |    84.27 |  +16%˄ ||    13.68 |    11.84 |  -13%˄ | (run time too short) |
 | 26c     ||   123.25 |   124.50 |   +1%˄ ||     8.10 |     8.02 |   -1%˄ | (run time too short) |
-| 27a     ||    28.50 |    32.02 |  +12%˄ ||    34.91 |    31.07 |  -11%˄ | (run time too short) |
-| 27b     ||    22.74 |    28.14 |  +24%˄ ||    43.75 |    35.34 |  -19%˄ | (run time too short) |
-| 27c     ||    27.25 |    30.50 |  +12%˄ ||    36.50 |    32.63 |  -11%˄ | (run time too short) |
 | 28a     ||   114.05 |   111.72 |   -2%˄ ||     8.76 |     8.94 |   +2%˄ | (run time too short) |
 | 28b     ||    32.92 |    33.21 |   +1%˄ ||    30.26 |    30.01 |   -1%˄ | (run time too short) |
 | 28c     ||   107.43 |   105.30 |   -2%˄ ||     9.29 |     9.49 |   +2%˄ | (run time too short) |
 | 29a     ||    63.17 |    65.23 |   +3%˄ ||    15.80 |    15.29 |   -3%˄ | (run time too short) |
 | 29b     ||    67.77 |    68.24 |   +1%˄ ||    14.74 |    14.64 |   -1%˄ | (run time too short) |
 | 29c     ||    65.80 |    67.72 |   +3%˄ ||    15.16 |    14.73 |   -3%˄ | (run time too short) |
-| 2a      ||    30.83 |    33.33 |   +8%˄ ||    32.26 |    29.84 |   -8%˄ | (run time too short) |
-| 2b      ||    27.75 |    30.85 |  +11%˄ ||    35.85 |    32.24 |  -10%˄ | (run time too short) |
-| 2c      ||    22.61 |    25.53 |  +13%˄ ||    43.93 |    38.91 |  -11%˄ | (run time too short) |
+| 2d      ||    50.82 |    38.74 |  -24%˄ ||    19.60 |    25.71 |  +31%˄ | (run time too short) |
 | 30a     ||    51.70 |    53.01 |   +3%˄ ||    19.28 |    18.81 |   -2%˄ | (run time too short) |
-| 30b     ||    43.18 |    49.30 |  +14%˄ ||    23.07 |    20.21 |  -12%˄ | (run time too short) |
+| 30c     ||   106.06 |   101.32 |   -4%˄ ||     9.41 |     9.86 |   +5%˄ | (run time too short) |
-| 31a     ||    40.46 |    43.91 |   +9%˄ ||    24.63 |    22.69 |   -8%˄ | (run time too short) |
-| 31b     ||    37.70 |    41.05 |   +9%˄ ||    26.41 |    24.27 |   -8%˄ | (run time too short) |
-| 31c     ||    44.99 |    47.97 |   +7%˄ ||    22.16 |    20.78 |   -6%˄ | (run time too short) |
-| 32a     ||    13.00 |    14.33 |  +10%˄ ||    76.01 |    69.12 |   -9%˄ | (run time too short) |
-| 32b     ||    35.80 |    37.83 |   +6%˄ ||    27.81 |    26.31 |   -5%˄ | (run time too short) |
-| 33a     ||    17.86 |    19.16 |   +7%˄ ||    55.45 |    51.78 |   -7%˄ | (run time too short) |
-| 33b     ||    14.80 |    16.72 |  +13%˄ ||    66.99 |    59.25 |  -12%˄ | (run time too short) |
-| 33c     ||    24.66 |    28.05 |  +14%˄ ||    40.33 |    35.45 |  -12%˄ | (run time too short) |
-| 3a      ||    33.64 |    37.57 |  +12%˄ ||    29.58 |    26.49 |  -10%˄ | (run time too short) |
-| 3b      ||     9.79 |    10.98 |  +12%˄ ||   100.54 |    89.89 |  -11%˄ | (run time too short) |
 | 3c      ||    64.63 |    63.55 |   -2%˄ ||    15.43 |    15.69 |   +2%˄ | (run time too short) |
 | 4a      ||    34.87 |    35.11 |   +1%˄ ||    28.56 |    28.35 |   -1%˄ | (run time too short) |
-| 4b      ||     8.76 |     9.51 |   +9%˄ ||   112.18 |   103.54 |   -8%˄ | (run time too short) |
 | 4c      ||    43.23 |    43.87 |   +1%˄ ||    23.05 |    22.71 |   -2%˄ | (run time too short) |
-| 5a      ||    32.93 |    34.82 |   +6%˄ ||    30.21 |    28.59 |   -5%˄ | (run time too short) |
-| 5b      ||    25.07 |    26.58 |   +6%˄ ||    39.64 |    37.40 |   -6%˄ | (run time too short) |
+| 5c      ||    53.57 |    51.02 |   -5%˄ ||    18.61 |    19.54 |   +5%˄ | (run time too short) |
-| 6a      ||    41.45 |    47.44 |  +14%˄ ||    24.03 |    21.01 |  -13%˄ | (run time too short) |
-| 6b      ||    57.29 |    67.15 |  +17%˄ ||    17.41 |    14.85 |  -15%˄ | (run time too short) |
-| 6c      ||    39.75 |    46.06 |  +16%˄ ||    25.05 |    21.63 |  -14%˄ | (run time too short) |
 | 6d      ||   179.09 |   183.47 |   +2%˄ ||     5.58 |     5.45 |   -2%˄ | (run time too short) |
-| 6e      ||    40.61 |    48.56 |  +20%˄ ||    24.53 |    20.53 |  -16%˄ | (run time too short) |
-| 6f      ||   405.66 |   438.27 |   +8%˄ ||     2.46 |     2.28 |   -7%˄ | (run time too short) |
-| 7a      ||    46.84 |    55.13 |  +18%˄ ||    21.28 |    18.09 |  -15%˄ | (run time too short) |
-| 7b      ||    42.91 |    49.63 |  +16%˄ ||    23.22 |    20.09 |  -14%˄ | (run time too short) |
-| 7c      ||   116.38 |   121.65 |   +5%˄ ||     8.58 |     8.21 |   -4%˄ | (run time too short) |
 | 8a      ||    33.52 |    32.94 |   -2%˄ ||    29.74 |    30.27 |   +2%˄ | (run time too short) |
 | 8b      ||    20.33 |    20.66 |   +2%˄ ||    49.03 |    48.24 |   -2%˄ | (run time too short) |
-| 8c      ||   701.04 |   769.50 |  +10%˄ ||     1.43 |     1.30 |   -9%˄ | (run time too short) |
 | 8d      ||   230.55 |   240.26 |   +4%˄ ||     4.33 |     4.16 |   -4%˄ | (run time too short) |
 | 9a      ||   104.48 |   103.13 |   -1%˄ ||     9.56 |     9.68 |   +1%˄ | (run time too short) |
 | 9b      ||    75.59 |    74.73 |   -1%˄ ||    13.20 |    13.36 |   +1%˄ | (run time too short) |
+| 9c      ||   115.02 |   107.29 |   -7%˄ ||     8.68 |     9.31 |   +7%˄ | (run time too short) |
-| 9d      ||   293.28 |   318.19 |   +8%˄ ||     3.41 |     3.14 |   -8%˄ | (run time too short) |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
-| Sum     || 10478.51 | 11076.93 |   +6%  ||          |          |        |                      |
-| Geomean ||          |          |        ||          |          |   -5%  |                      |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 |   Notes || ˄ Execution stopped due to max runs reached                                         |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkJoinOrder - multi-threaded, shuffled, 28 clients, 28 cores**
<details>
<summary>
Sum of avg. item runtimes: -2%
 ||
Geometric mean of throughput changes: +2%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Daniel.Lindner/hyrise/clang20-release/benchmark_all_results/hyriseBenchmarkJoinOrder_42a0a16abc91e7288ee71f123842740cff2a7bc2_mt.json | /home/Daniel.Lindner/hyrise/clang20-release/benchmark_all_results/hyriseBenchmarkJoinOrder_ba0e82d3e88c4b7f26dd9f9f44b58ed5437ae1d6_mt.json |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 42a0a16abc91e7288ee71f123842740cff2a7bc2-dirty                                                                                              | ba0e82d3e88c4b7f26dd9f9f44b58ed5437ae1d6-dirty                                                                                              |
 |  benchmark_mode               | Shuffled                                                                                                                                    | Shuffled                                                                                                                                    |
 |  build_type                   | release                                                                                                                                     | release                                                                                                                                     |
 |  chunk_indexes                | False                                                                                                                                       | False                                                                                                                                       |
 |  chunk_size                   | 65535                                                                                                                                       | 65535                                                                                                                                       |
 |  clients                      | 28                                                                                                                                          | 28                                                                                                                                          |
 |  compiler                     | clang 20.1.2                                                                                                                                | clang 20.1.2                                                                                                                                |
 |  cores                        | 28                                                                                                                                          | 28                                                                                                                                          |
 |  data_preparation_cores       | 0                                                                                                                                           | 0                                                                                                                                           |
 |  date                         | 2026-08-13 12:44:17                                                                                                                         | 2026-08-17 15:16:17                                                                                                                         |
 |  encoding                     | {'default': 'Automatic'}                                                                                                                    | {'default': 'Automatic'}                                                                                                                    |
 |  max_duration                 | 1200000000000                                                                                                                               | 1200000000000                                                                                                                               |
 |  max_runs                     | -1                                                                                                                                          | -1                                                                                                                                          |
 |  time_unit                    | ns                                                                                                                                          | ns                                                                                                                                          |
 |  using_scheduler              | True                                                                                                                                        | True                                                                                                                                        |
 |  utilized_cores_per_numa_node | [0, 0, 28]                                                                                                                                  | [0, 0, 28]                                                                                                                                  |
 |  verify                       | False                                                                                                                                       | False                                                                                                                                       |
 |  warmup_duration              | 0                                                                                                                                           | 0                                                                                                                                           |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |      new |        ||      old |      new |        |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
+| 10a     ||   184.16 |   158.52 |  -14%  ||     0.84 |     0.85 |   +2%  |  0.0576 |
+| 10b     ||    86.15 |    80.90 |   -6%  ||     0.83 |     0.85 |   +2%  |  0.5304 |
+| 10c     ||   400.81 |   378.36 |   -6%  ||     0.83 |     0.85 |   +2%  |  0.2449 |
-| 11a     ||    58.75 |    72.48 |  +23%  ||     0.83 |     0.85 |   +2%  |  0.1177 |
-| 11b     ||    58.65 |    79.10 |  +35%  ||     0.83 |     0.85 |   +2%  |  0.0740 |
+| 11c     ||    80.16 |    66.25 |  -17%  ||     0.83 |     0.85 |   +2%  |  0.0674 |
 | 11d     ||    72.83 |    70.60 |   -3%  ||     0.83 |     0.85 |   +2%  |  0.7724 |
 | 12a     ||   288.36 |   298.55 |   +4%  ||     0.83 |     0.85 |   +2%  |  0.6330 |
+| 12b     ||    70.75 |    64.18 |   -9%  ||     0.83 |     0.85 |   +2%  |  0.3713 |
+| 12c     ||   389.43 |   370.67 |   -5%  ||     0.83 |     0.85 |   +2%  |  0.3918 |
 | 13a     ||   434.66 |   425.62 |   -2%  ||     0.83 |     0.85 |   +2%  |  0.6972 |
+| 13b     ||   317.78 |   291.98 |   -8%  ||     0.83 |     0.85 |   +2%  |  0.2098 |
+| 13c     ||   109.85 |    89.31 |  -19%  ||     0.83 |     0.85 |   +2%  |  0.0322 |
 | 13d     ||   745.19 |   741.03 |   -1%  ||     0.83 |     0.85 |   +2%  |  0.8679 |
 | 14a     ||   350.85 |   341.85 |   -3%  ||     0.83 |     0.85 |   +2%  |  0.6864 |
 | 14b     ||   204.71 |   197.41 |   -4%  ||     0.83 |     0.85 |   +2%  |  0.6658 |
 | 14c     ||   460.50 |   445.21 |   -3%  ||     0.83 |     0.85 |   +2%  |  0.5437 |
+| 15a     ||    99.43 |    90.55 |   -9%  ||     0.83 |     0.85 |   +2%  |  0.3350 |
+| 15b     ||   105.26 |    98.27 |   -7%  ||     0.84 |     0.85 |   +2%  |  0.5248 |
 | 15c     ||   125.05 |   124.52 |   -0%  ||     0.83 |     0.85 |   +2%  |  0.9688 |
+| 15d     ||   107.67 |   101.41 |   -6%  ||     0.83 |     0.85 |   +2%  |  0.5135 |
 | 16a     ||   230.84 |   235.79 |   +2%  ||     0.83 |     0.85 |   +2%  |  0.7841 |
 | 16b     ||  1771.57 |  1800.51 |   +2%  ||     0.83 |     0.85 |   +2%  |  0.3507 |
+| 16c     ||   530.10 |   495.56 |   -7%  ||     0.83 |     0.85 |   +2%  |  0.1360 |
+| 16d     ||   501.13 |   452.79 |  -10%  ||     0.83 |     0.85 |   +2%  |  0.0381 |
 | 17a     ||   667.57 |   672.60 |   +1%  ||     0.83 |     0.85 |   +2%  |  0.8480 |
+| 17b     ||   527.22 |   490.05 |   -7%  ||     0.83 |     0.85 |   +2%  |  0.0927 |
 | 17c     ||   460.57 |   470.90 |   +2%  ||     0.83 |     0.85 |   +2%  |  0.6366 |
 | 17d     ||   445.40 |   450.04 |   +1%  ||     0.83 |     0.85 |   +2%  |  0.8084 |
 | 17e     ||  1173.73 |  1172.93 |   -0%  ||     0.83 |     0.85 |   +2%  |  0.9737 |
 | 17f     ||   824.17 |   857.38 |   +4%  ||     0.83 |     0.85 |   +2%  |  0.2118 |
 | 18a     ||   167.33 |   166.05 |   -1%  ||     0.83 |     0.85 |   +2%  |  0.9064 |
-| 18b     ||   226.09 |   242.11 |   +7%  ||     0.83 |     0.85 |   +2%  |  0.3782 |
 | 18c     ||   396.80 |   399.76 |   +1%  ||     0.83 |     0.85 |   +2%  |  0.9046 |
 | 19a     ||   371.39 |   369.78 |   -0%  ||     0.83 |     0.85 |   +2%  |  0.9341 |
 | 19b     ||   284.35 |   290.74 |   +2%  ||     0.83 |     0.85 |   +2%  |  0.7081 |
 | 19c     ||   444.75 |   457.26 |   +3%  ||     0.83 |     0.85 |   +2%  |  0.6059 |
-| 19d     ||   934.05 |   986.46 |   +6%  ||     0.83 |     0.85 |   +2%  |  0.0434 |
+| 1a      ||    48.06 |    37.73 |  -21%  ||     0.83 |     0.85 |   +2%  |  0.2796 |
+| 1b      ||    42.73 |    36.62 |  -14%  ||     0.83 |     0.85 |   +2%  |  0.4012 |
+| 1c      ||    56.98 |    51.28 |  -10%  ||     0.84 |     0.85 |   +2%  |  0.5810 |
+| 1d      ||    45.30 |    32.59 |  -28%  ||     0.83 |     0.85 |   +2%  |  0.0650 |
+| 20a     ||   354.19 |   312.71 |  -12%  ||     0.83 |     0.85 |   +2%  |  0.0333 |
+| 20b     ||   304.70 |   260.88 |  -14%  ||     0.83 |     0.85 |   +2%  |  0.0170 |
+| 20c     ||   276.00 |   242.36 |  -12%  ||     0.83 |     0.85 |   +2%  |  0.0341 |
 | 21a     ||   113.14 |   110.98 |   -2%  ||     0.84 |     0.85 |   +2%  |  0.8704 |
+| 21b     ||    99.61 |    94.61 |   -5%  ||     0.83 |     0.85 |   +2%  |  0.6432 |
+| 21c     ||   129.31 |   117.03 |   -9%  ||     0.83 |     0.85 |   +2%  |  0.3697 |
+| 22a     ||   375.14 |   325.93 |  -13%  ||     0.83 |     0.85 |   +2%  |  0.0266 |
+| 22b     ||   325.04 |   291.68 |  -10%  ||     0.83 |     0.85 |   +2%  |  0.0992 |
 | 22c     ||   492.11 |   510.03 |   +4%  ||     0.83 |     0.85 |   +2%  |  0.4784 |
 | 22d     ||   687.63 |   698.53 |   +2%  ||     0.83 |     0.85 |   +2%  |  0.7173 |
+| 23a     ||   129.78 |   116.99 |  -10%  ||     0.83 |     0.85 |   +2%  |  0.3291 |
+| 23b     ||    99.53 |    88.29 |  -11%  ||     0.83 |     0.85 |   +2%  |  0.2273 |
 | 23c     ||   146.24 |   145.29 |   -1%  ||     0.83 |     0.85 |   +2%  |  0.9504 |
+| 24a     ||   272.47 |   259.81 |   -5%  ||     0.83 |     0.85 |   +2%  |  0.5070 |
+| 24b     ||   226.82 |   202.68 |  -11%  ||     0.83 |     0.85 |   +2%  |  0.1352 |
 | 25a     ||   281.95 |   274.55 |   -3%  ||     0.83 |     0.85 |   +2%  |  0.7155 |
+| 25b     ||   149.09 |   120.03 |  -19%  ||     0.83 |     0.85 |   +2%  |  0.0486 |
 | 25c     ||   566.65 |   565.95 |   -0%  ||     0.83 |     0.85 |   +2%  |  0.9777 |
-| 26a     ||   283.13 |   300.13 |   +6%  ||     0.83 |     0.85 |   +2%  |  0.3401 |
 | 26b     ||   199.12 |   192.92 |   -3%  ||     0.83 |     0.85 |   +2%  |  0.7002 |
 | 26c     ||   410.14 |   411.69 |   +0%  ||     0.83 |     0.85 |   +2%  |  0.9304 |
+| 27a     ||   120.72 |   102.35 |  -15%  ||     0.83 |     0.85 |   +2%  |  0.1482 |
 | 27b     ||    97.54 |   100.01 |   +3%  ||     0.83 |     0.85 |   +2%  |  0.8091 |
+| 27c     ||   117.23 |   110.56 |   -6%  ||     0.83 |     0.85 |   +2%  |  0.5966 |
-| 28a     ||   475.71 |   500.02 |   +5%  ||     0.83 |     0.85 |   +2%  |  0.3648 |
+| 28b     ||   180.28 |   154.58 |  -14%  ||     0.83 |     0.85 |   +2%  |  0.0868 |
+| 28c     ||   459.51 |   430.77 |   -6%  ||     0.83 |     0.85 |   +2%  |  0.2014 |
+| 29a     ||   218.76 |   186.76 |  -15%  ||     0.83 |     0.85 |   +2%  |  0.0324 |
+| 29b     ||   304.28 |   280.20 |   -8%  ||     0.83 |     0.85 |   +2%  |  0.1630 |
 | 29c     ||   256.37 |   256.85 |   +0%  ||     0.84 |     0.85 |   +2%  |  0.9802 |
+| 2a      ||    94.61 |    84.73 |  -10%  ||     0.83 |     0.85 |   +2%  |  0.2630 |
 | 2b      ||    90.21 |    87.54 |   -3%  ||     0.83 |     0.85 |   +2%  |  0.7798 |
+| 2c      ||    88.85 |    66.33 |  -25%  ||     0.83 |     0.85 |   +2%  |  0.0216 |
+| 2d      ||   204.30 |   187.87 |   -8%  ||     0.83 |     0.85 |   +2%  |  0.2753 |
 | 30a     ||   217.21 |   223.54 |   +3%  ||     0.83 |     0.85 |   +2%  |  0.7335 |
+| 30b     ||   207.84 |   198.07 |   -5%  ||     0.83 |     0.85 |   +2%  |  0.5534 |
 | 30c     ||   426.30 |   418.55 |   -2%  ||     0.83 |     0.85 |   +2%  |  0.7287 |
 | 31a     ||   148.09 |   154.49 |   +4%  ||     0.83 |     0.85 |   +2%  |  0.6416 |
 | 31b     ||   140.50 |   138.68 |   -1%  ||     0.84 |     0.85 |   +2%  |  0.8935 |
-| 31c     ||   173.28 |   182.26 |   +5%  ||     0.83 |     0.85 |   +2%  |  0.6014 |
 | 32a     ||    36.06 |    35.90 |   -0%  ||     0.83 |     0.85 |   +2%  |  0.9749 |
 | 32b     ||   108.28 |   109.12 |   +1%  ||     0.83 |     0.85 |   +2%  |  0.9438 |
+| 33a     ||   111.95 |   103.85 |   -7%  ||     0.83 |     0.85 |   +2%  |  0.5624 |
+| 33b     ||    84.02 |    74.47 |  -11%  ||     0.83 |     0.85 |   +2%  |  0.3481 |
-| 33c     ||   132.74 |   139.70 |   +5%  ||     0.83 |     0.85 |   +2%  |  0.6360 |
+| 3a      ||   186.51 |   171.76 |   -8%  ||     0.83 |     0.85 |   +2%  |  0.4224 |
-| 3b      ||    50.77 |    58.83 |  +16%  ||     0.83 |     0.85 |   +2%  |  0.3263 |
-| 3c      ||   282.69 |   300.13 |   +6%  ||     0.83 |     0.85 |   +2%  |  0.4059 |
 | 4a      ||   200.91 |   208.82 |   +4%  ||     0.83 |     0.85 |   +2%  |  0.5672 |
+| 4b      ||    47.77 |    45.58 |   -5%  ||     0.83 |     0.85 |   +2%  |  0.7331 |
 | 4c      ||   271.81 |   279.42 |   +3%  ||     0.83 |     0.85 |   +2%  |  0.6899 |
 | 5a      ||   138.96 |   137.44 |   -1%  ||     0.83 |     0.85 |   +2%  |  0.9214 |
-| 5b      ||   106.69 |   124.45 |  +17%  ||     0.83 |     0.85 |   +2%  |  0.0998 |
+| 5c      ||   209.46 |   194.55 |   -7%  ||     0.83 |     0.85 |   +2%  |  0.3679 |
+| 6a      ||   140.78 |   112.43 |  -20%  ||     0.83 |     0.85 |   +2%  |  0.0181 |
+| 6b      ||   149.88 |   138.21 |   -8%  ||     0.83 |     0.85 |   +2%  |  0.3395 |
+| 6c      ||   110.64 |    98.37 |  -11%  ||     0.83 |     0.85 |   +2%  |  0.1752 |
+| 6d      ||   426.63 |   404.02 |   -5%  ||     0.83 |     0.85 |   +2%  |  0.2567 |
 | 6e      ||   124.49 |   118.90 |   -4%  ||     0.83 |     0.85 |   +2%  |  0.5734 |
 | 6f      ||   847.23 |   812.16 |   -4%  ||     0.83 |     0.85 |   +2%  |  0.0974 |
+| 7a      ||   150.08 |   132.02 |  -12%  ||     0.83 |     0.85 |   +2%  |  0.1151 |
+| 7b      ||   148.30 |   138.78 |   -6%  ||     0.83 |     0.85 |   +2%  |  0.4444 |
 | 7c      ||   415.42 |   405.65 |   -2%  ||     0.83 |     0.85 |   +2%  |  0.6254 |
+| 8a      ||   128.57 |   113.77 |  -12%  ||     0.84 |     0.85 |   +2%  |  0.1598 |
-| 8b      ||   114.41 |   120.92 |   +6%  ||     0.83 |     0.85 |   +2%  |  0.5919 |
-| 8c      ||  1440.43 |  1539.89 |   +7%  ||     0.83 |     0.85 |   +2%  |  0.0019 |
 | 8d      ||   668.22 |   653.26 |   -2%  ||     0.83 |     0.85 |   +2%  |  0.5772 |
 | 9a      ||   370.07 |   370.82 |   +0%  ||     0.83 |     0.85 |   +2%  |  0.9726 |
-| 9b      ||   294.44 |   309.96 |   +5%  ||     0.83 |     0.85 |   +2%  |  0.4698 |
-| 9c      ||   384.00 |   413.35 |   +8%  ||     0.83 |     0.85 |   +2%  |  0.1914 |
 | 9d      ||   775.03 |   768.80 |   -1%  ||     0.83 |     0.85 |   +2%  |  0.8152 |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Sum     || 33501.73 | 32898.30 |   -2%  ||          |          |        |         |
 | Geomean ||          |          |        ||          |          |   +2%  |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkStarSchema - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -1%
 ||
Geometric mean of throughput changes: +9%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---+----------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter               | /home/Daniel.Lindner/hyrise/clang20-release/benchmark_all_results/hyriseBenchmarkStarSchema_42a0a16abc91e7288ee71f123842740cff2a7bc2_st.json | /home/Daniel.Lindner/hyrise/clang20-release/benchmark_all_results/hyriseBenchmarkStarSchema_ba0e82d3e88c4b7f26dd9f9f44b58ed5437ae1d6_st.json |
 +-------------------------+----------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH               | 42a0a16abc91e7288ee71f123842740cff2a7bc2-dirty                                                                                               | ba0e82d3e88c4b7f26dd9f9f44b58ed5437ae1d6-dirty                                                                                               |
 |  benchmark_mode         | Ordered                                                                                                                                      | Ordered                                                                                                                                      |
 |  build_type             | release                                                                                                                                      | release                                                                                                                                      |
 |  chunk_indexes          | False                                                                                                                                        | False                                                                                                                                        |
 |  chunk_size             | 65535                                                                                                                                        | 65535                                                                                                                                        |
 |  clients                | 1                                                                                                                                            | 1                                                                                                                                            |
 |  compiler               | clang 20.1.2                                                                                                                                 | clang 20.1.2                                                                                                                                 |
 |  cores                  | 0                                                                                                                                            | 0                                                                                                                                            |
 |  data_preparation_cores | 0                                                                                                                                            | 0                                                                                                                                            |
 |  date                   | 2026-08-13 13:04:37                                                                                                                          | 2026-08-17 15:36:36                                                                                                                          |
 |  encoding               | {'default': 'Automatic'}                                                                                                                     | {'default': 'Automatic'}                                                                                                                     |
 |  max_duration           | 60000000000                                                                                                                                  | 60000000000                                                                                                                                  |
 |  max_runs               | 50                                                                                                                                           | 50                                                                                                                                           |
 |  scale_factor           | 10.0                                                                                                                                         | 10.0                                                                                                                                         |
 |  time_unit              | ns                                                                                                                                           | ns                                                                                                                                           |
 |  using_scheduler        | False                                                                                                                                        | False                                                                                                                                        |
 |  verify                 | False                                                                                                                                        | False                                                                                                                                        |
 |  warmup_duration        | 1000000000                                                                                                                                   | 1000000000                                                                                                                                   |
 +-------------------------+----------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |         ||      old |     new |        ||      old |      new |        |                      |
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
+| 1.1     ||   322.95 |  306.01 |   -5%˄ ||     3.10 |     3.27 |   +6%˄ | (run time too short) |
 | 1.2     ||   199.37 |  197.85 |   -1%˄ ||     5.02 |     5.05 |   +1%˄ | (run time too short) |
 | 1.3     ||   196.35 |  192.77 |   -2%˄ ||     5.09 |     5.19 |   +2%˄ | (run time too short) |
+| 2.1     ||   465.74 |  428.99 |   -8%˄ ||     2.15 |     2.33 |   +9%˄ | (run time too short) |
+| 2.2     ||   220.88 |  191.37 |  -13%˄ ||     4.53 |     5.23 |  +15%˄ | (run time too short) |
+| 2.3     ||   131.59 |   96.26 |  -27%˄ ||     7.60 |    10.39 |  +37%˄ | (run time too short) |
-| 3.1     ||  2843.92 | 2912.70 |   +2%  ||     0.35 |     0.33 |   -5%  | (run time too short) |
+| 3.2     ||   250.96 |  233.14 |   -7%˄ ||     3.98 |     4.29 |   +8%˄ | (run time too short) |
+| 3.3     ||   136.01 |  110.08 |  -19%˄ ||     7.35 |     9.08 |  +24%˄ | (run time too short) |
+| 3.4     ||   130.56 |  105.02 |  -20%˄ ||     7.66 |     9.52 |  +24%˄ | (run time too short) |
 | 4.1     ||  2573.43 | 2657.22 |   +3%  ||     0.38 |     0.37 |   -4%  | (run time too short) |
 | 4.2     ||   802.32 |  793.08 |   -1%˄ ||     1.25 |     1.26 |   +1%˄ | (run time too short) |
+| 4.3     ||   220.84 |  201.56 |   -9%˄ ||     4.53 |     4.96 |  +10%˄ | (run time too short) |
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
 | Sum     ||  8494.92 | 8426.04 |   -1%  ||          |          |        |                      |
+| Geomean ||          |         |        ||          |          |   +9%  |                      |
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
 |   Notes || ˄ Execution stopped due to max runs reached                                        |
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkStarSchema - multi-threaded, ordered, 1 client, 28 cores**
<details>
<summary>
Sum of avg. item runtimes: -3%
 ||
Geometric mean of throughput changes: -2%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Daniel.Lindner/hyrise/clang20-release/benchmark_all_results/hyriseBenchmarkStarSchema_42a0a16abc91e7288ee71f123842740cff2a7bc2_mt_ordered.json | /home/Daniel.Lindner/hyrise/clang20-release/benchmark_all_results/hyriseBenchmarkStarSchema_ba0e82d3e88c4b7f26dd9f9f44b58ed5437ae1d6_mt_ordered.json |
 +-------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 42a0a16abc91e7288ee71f123842740cff2a7bc2-dirty                                                                                                       | ba0e82d3e88c4b7f26dd9f9f44b58ed5437ae1d6-dirty                                                                                                       |
 |  benchmark_mode               | Ordered                                                                                                                                              | Ordered                                                                                                                                              |
 |  build_type                   | release                                                                                                                                              | release                                                                                                                                              |
 |  chunk_indexes                | False                                                                                                                                                | False                                                                                                                                                |
 |  chunk_size                   | 65535                                                                                                                                                | 65535                                                                                                                                                |
 |  clients                      | 1                                                                                                                                                    | 1                                                                                                                                                    |
 |  compiler                     | clang 20.1.2                                                                                                                                         | clang 20.1.2                                                                                                                                         |
 |  cores                        | 28                                                                                                                                                   | 28                                                                                                                                                   |
 |  data_preparation_cores       | 0                                                                                                                                                    | 0                                                                                                                                                    |
 |  date                         | 2026-08-13 13:09:55                                                                                                                                  | 2026-08-17 15:41:34                                                                                                                                  |
 |  encoding                     | {'default': 'Automatic'}                                                                                                                             | {'default': 'Automatic'}                                                                                                                             |
 |  max_duration                 | 60000000000                                                                                                                                          | 60000000000                                                                                                                                          |
 |  max_runs                     | 50                                                                                                                                                   | 50                                                                                                                                                   |
 |  scale_factor                 | 10.0                                                                                                                                                 | 10.0                                                                                                                                                 |
 |  time_unit                    | ns                                                                                                                                                   | ns                                                                                                                                                   |
 |  using_scheduler              | True                                                                                                                                                 | True                                                                                                                                                 |
 |  utilized_cores_per_numa_node | [0, 0, 28]                                                                                                                                           | [0, 0, 28]                                                                                                                                           |
 |  verify                       | False                                                                                                                                                | False                                                                                                                                                |
 |  warmup_duration              | 1000000000                                                                                                                                           | 1000000000                                                                                                                                           |
 +-------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |         ||      old |     new |        ||      old |      new |        |                      |
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
+| 1.1     ||   110.19 |  104.38 |   -5%˄ ||     9.06 |     9.57 |   +6%˄ | (run time too short) |
-| 1.2     ||    78.24 |   85.15 |   +9%˄ ||    12.75 |    11.72 |   -8%˄ | (run time too short) |
-| 1.3     ||    72.63 |   79.57 |  +10%˄ ||    13.74 |    12.54 |   -9%˄ | (run time too short) |
+| 2.1     ||   401.36 |  379.87 |   -5%˄ ||     2.49 |     2.63 |   +6%˄ | (run time too short) |
+| 2.2     ||   175.89 |  160.73 |   -9%˄ ||     5.68 |     6.22 |   +9%˄ | (run time too short) |
-| 2.3     ||    76.10 |   86.75 |  +14%˄ ||    13.11 |    11.50 |  -12%˄ | (run time too short) |
+| 3.1     ||   578.65 |  479.30 |  -17%˄ ||     1.73 |     2.09 |  +21%˄ | (run time too short) |
 | 3.2     ||   194.07 |  192.32 |   -1%˄ ||     5.15 |     5.20 |   +1%˄ | (run time too short) |
-| 3.3     ||    98.21 |  108.86 |  +11%˄ ||    10.16 |     9.17 |  -10%˄ | (run time too short) |
-| 3.4     ||    91.31 |  105.14 |  +15%˄ ||    10.94 |     9.50 |  -13%˄ | (run time too short) |
+| 4.1     ||   299.05 |  276.78 |   -7%˄ ||     3.34 |     3.61 |   +8%˄ | (run time too short) |
 | 4.2     ||   369.81 |  381.42 |   +3%˄ ||     2.70 |     2.62 |   -3%˄ | (run time too short) |
-| 4.3     ||   156.60 |  176.65 |  +13%˄ ||     6.38 |     5.65 |  -11%˄ | (run time too short) |
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
 | Sum     ||  2702.11 | 2616.92 |   -3%  ||          |          |        |                      |
 | Geomean ||          |         |        ||          |          |   -2%  |                      |
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
 |   Notes || ˄ Execution stopped due to max runs reached                                        |
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkStarSchema - multi-threaded, shuffled, 28 clients, 28 cores**
<details>
<summary>
Sum of avg. item runtimes: +6%
 ||
Geometric mean of throughput changes: -5%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+----------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Daniel.Lindner/hyrise/clang20-release/benchmark_all_results/hyriseBenchmarkStarSchema_42a0a16abc91e7288ee71f123842740cff2a7bc2_mt.json | /home/Daniel.Lindner/hyrise/clang20-release/benchmark_all_results/hyriseBenchmarkStarSchema_ba0e82d3e88c4b7f26dd9f9f44b58ed5437ae1d6_mt.json |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 42a0a16abc91e7288ee71f123842740cff2a7bc2-dirty                                                                                               | ba0e82d3e88c4b7f26dd9f9f44b58ed5437ae1d6-dirty                                                                                               |
 |  benchmark_mode               | Shuffled                                                                                                                                     | Shuffled                                                                                                                                     |
 |  build_type                   | release                                                                                                                                      | release                                                                                                                                      |
 |  chunk_indexes                | False                                                                                                                                        | False                                                                                                                                        |
 |  chunk_size                   | 65535                                                                                                                                        | 65535                                                                                                                                        |
 |  clients                      | 28                                                                                                                                           | 28                                                                                                                                           |
 |  compiler                     | clang 20.1.2                                                                                                                                 | clang 20.1.2                                                                                                                                 |
 |  cores                        | 28                                                                                                                                           | 28                                                                                                                                           |
 |  data_preparation_cores       | 0                                                                                                                                            | 0                                                                                                                                            |
 |  date                         | 2026-08-13 13:12:41                                                                                                                          | 2026-08-17 15:44:15                                                                                                                          |
 |  encoding                     | {'default': 'Automatic'}                                                                                                                     | {'default': 'Automatic'}                                                                                                                     |
 |  max_duration                 | 1200000000000                                                                                                                                | 1200000000000                                                                                                                                |
 |  max_runs                     | -1                                                                                                                                           | -1                                                                                                                                           |
 |  scale_factor                 | 10.0                                                                                                                                         | 10.0                                                                                                                                         |
 |  time_unit                    | ns                                                                                                                                           | ns                                                                                                                                           |
 |  using_scheduler              | True                                                                                                                                         | True                                                                                                                                         |
 |  utilized_cores_per_numa_node | [0, 0, 28]                                                                                                                                   | [0, 0, 28]                                                                                                                                   |
 |  verify                       | False                                                                                                                                        | False                                                                                                                                        |
 |  warmup_duration              | 0                                                                                                                                            | 0                                                                                                                                            |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |      new |        ||      old |      new |        |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
-| 1.1     ||   594.25 |   601.65 |   +1%  ||     2.31 |     2.19 |   -5%  |  0.7026 |
-| 1.2     ||   361.09 |   368.83 |   +2%  ||     2.31 |     2.19 |   -5%  |  0.5451 |
-| 1.3     ||   340.90 |   336.73 |   -1%  ||     2.31 |     2.19 |   -5%  |  0.6941 |
-| 2.1     ||  1117.25 |  1207.31 |   +8%  ||     2.31 |     2.18 |   -5%  |  0.0016 |
-| 2.2     ||   594.76 |   596.06 |   +0%  ||     2.31 |     2.19 |   -5%  |  0.9517 |
+| 2.3     ||   294.29 |   272.42 |   -7%  ||     2.31 |     2.19 |   -5%  |  0.1578 |
-| 3.1     ||  2830.58 |  3156.08 |  +11%  ||     2.30 |     2.18 |   -5%  |  0.0000 |
-| 3.2     ||   636.35 |   694.72 |   +9%  ||     2.31 |     2.19 |   -5%  |  0.0073 |
-| 3.3     ||   319.05 |   333.45 |   +5%  ||     2.31 |     2.19 |   -5%  |  0.4020 |
+| 3.4     ||   333.03 |   286.47 |  -14%  ||     2.31 |     2.19 |   -5%  |  0.0021 |
-| 4.1     ||  2445.18 |  2614.66 |   +7%  ||     2.30 |     2.18 |   -5%  |  0.0000 |
-| 4.2     ||  1695.14 |  1767.52 |   +4%  ||     2.31 |     2.18 |   -5%  |  0.0568 |
-| 4.3     ||   549.73 |   556.99 |   +1%  ||     2.31 |     2.19 |   -5%  |  0.7202 |
 +---------++----------+----------+--------++----------+----------+--------+---------+
-| Sum     || 12111.62 | 12792.90 |   +6%  ||          |          |        |         |
-| Geomean ||          |          |        ||          |          |   -5%  |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
```
</details>