### PR TITLE
Concurrently encode CSV data while loading

### DIFF
--- a/src/lib/import_export/csv/csv_meta.hpp
+++ b/src/lib/import_export/csv/csv_meta.hpp
@@ -14,6 +14,7 @@ struct ColumnMeta {
   std::string type;
 
   bool nullable = false;
+  bool is_unique = false;  // Used for encoding decisions during CSV loading.
 };
 
 // Strategies on how to deal with unquoted null strings ("...,Null,...") in CSV files:

--- a/src/lib/import_export/csv/csv_parser.cpp
+++ b/src/lib/import_export/csv/csv_parser.cpp
@@ -10,6 +10,7 @@
 #include <list>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -24,6 +25,7 @@
 #include "scheduler/job_task.hpp"
 #include "storage/chunk.hpp"
 #include "storage/chunk_encoder.hpp"
+#include "storage/encoding_type.hpp"
 #include "storage/mvcc_data.hpp"
 #include "storage/segment_encoding_utils.hpp"
 #include "storage/table.hpp"

--- a/src/lib/import_export/csv/csv_parser.cpp
+++ b/src/lib/import_export/csv/csv_parser.cpp
@@ -24,7 +24,6 @@
 #include "scheduler/job_task.hpp"
 #include "storage/chunk.hpp"
 #include "storage/chunk_encoder.hpp"
-#include "storage/constraints/constraint_utils.hpp"
 #include "storage/mvcc_data.hpp"
 #include "storage/segment_encoding_utils.hpp"
 #include "storage/table.hpp"
@@ -41,9 +40,18 @@ std::shared_ptr<Table> CsvParser::parse(const std::string& filename, const CsvMe
   const auto table = _create_table_from_meta(chunk_size, csv_meta);
   const auto column_count = table->column_count();
 
+  auto unique_column_ids = std::vector<ColumnID>{};
+
+  for (auto column_id = ColumnID{0}; column_id < csv_meta.columns.size(); ++column_id) {
+    const auto column_meta = csv_meta.columns[column_id];
+    if (column_meta.is_unique) {
+      unique_column_ids.push_back(column_id);
+    }
+  }
+
   const auto table_column_types = table->column_data_types();
   const auto chunk_encoding_spec =
-      auto_select_chunk_encoding_spec(table_column_types, unique_columns(table), target_encoding);
+      auto_select_chunk_encoding_spec(table_column_types, unique_column_ids, target_encoding);
 
   auto csvfile = std::ifstream{filename};
 

--- a/src/lib/import_export/csv/csv_parser.cpp
+++ b/src/lib/import_export/csv/csv_parser.cpp
@@ -9,7 +9,6 @@
 #include <ios>
 #include <list>
 #include <memory>
-#include <mutex>
 #include <optional>
 #include <string>
 #include <string_view>

--- a/src/lib/import_export/csv/csv_parser.cpp
+++ b/src/lib/import_export/csv/csv_parser.cpp
@@ -23,7 +23,10 @@
 #include "scheduler/abstract_task.hpp"
 #include "scheduler/job_task.hpp"
 #include "storage/chunk.hpp"
+#include "storage/chunk_encoder.hpp"
+#include "storage/constraints/constraint_utils.hpp"
 #include "storage/mvcc_data.hpp"
+#include "storage/segment_encoding_utils.hpp"
 #include "storage/table.hpp"
 #include "storage/table_column_definition.hpp"
 #include "types.hpp"
@@ -33,8 +36,14 @@
 namespace hyrise {
 
 std::shared_ptr<Table> CsvParser::parse(const std::string& filename, const CsvMeta& csv_meta,
-                                        const ChunkOffset chunk_size) {
+                                        const ChunkOffset chunk_size,
+                                        const std::optional<EncodingType>& target_encoding) {
   const auto table = _create_table_from_meta(chunk_size, csv_meta);
+  const auto column_count = table->column_count();
+
+  const auto table_column_types = table->column_data_types();
+  const auto chunk_encoding_spec =
+      auto_select_chunk_encoding_spec(table_column_types, unique_columns(table), target_encoding);
 
   auto csvfile = std::ifstream{filename};
 
@@ -71,7 +80,6 @@ std::shared_ptr<Table> CsvParser::parse(const std::string& filename, const CsvMe
   auto segments_by_chunks = std::list<Segments>{};
   auto tasks = std::vector<std::shared_ptr<AbstractTask>>{};
   auto field_ends = std::vector<size_t>{};
-  auto append_chunk_mutex = std::mutex{};
   const auto escaped_linebreak =
       std::string(1, csv_meta.config.delimiter_escape) + std::string(1, csv_meta.config.delimiter);
   while (_find_fields_in_chunk(content_view, *table, field_ends, csv_meta)) {
@@ -86,11 +94,16 @@ std::shared_ptr<Table> CsvParser::parse(const std::string& filename, const CsvMe
     content_view = content_view.substr(field_ends.back() + 1);
 
     // Create and start parsing task to fill chunk
-    tasks.emplace_back(std::make_shared<JobTask>([relevant_content, field_ends = std::move(field_ends), &table,
-                                                  &segments, &csv_meta, &escaped_linebreak, &append_chunk_mutex]() {
-      _parse_into_chunk(relevant_content, field_ends, *table, segments, csv_meta, escaped_linebreak,
-                        append_chunk_mutex);
-    }));
+    tasks.emplace_back(
+        std::make_shared<JobTask>([relevant_content, field_ends = std::move(field_ends), &table, &segments, &csv_meta,
+                                   &escaped_linebreak, &table_column_types, &chunk_encoding_spec, column_count]() {
+          _parse_into_chunk(relevant_content, field_ends, *table, segments, csv_meta, escaped_linebreak);
+
+          for (auto column_id = ColumnID{0}; column_id < column_count; ++column_id) {
+            segments[column_id] = ChunkEncoder::encode_segment(segments[column_id], table_column_types[column_id],
+                                                               chunk_encoding_spec[column_id]);
+          }
+        }));
     tasks.back()->schedule();
     field_ends = std::vector<size_t>{};
   }
@@ -185,7 +198,7 @@ bool CsvParser::_find_fields_in_chunk(std::string_view csv_content, const Table&
 
 size_t CsvParser::_parse_into_chunk(std::string_view csv_chunk, const std::vector<size_t>& field_ends,
                                     const Table& table, Segments& segments, const CsvMeta& meta,
-                                    const std::string& escaped_linebreak, std::mutex& append_chunk_mutex) {
+                                    const std::string& escaped_linebreak) {
   // For each csv column, create a CsvConverter which builds up a ValueSegment.
   const auto column_count = table.column_count();
   const auto row_count = ChunkOffset{static_cast<ChunkOffset::base_type>(field_ends.size() / column_count)};
@@ -230,7 +243,6 @@ size_t CsvParser::_parse_into_chunk(std::string_view csv_chunk, const std::vecto
 
   // Transform the field_offsets to segments and add segments to chunk.
   {
-    const auto lock = std::lock_guard<std::mutex>{append_chunk_mutex};
     for (auto& converter : converters) {
       segments.push_back(converter->finish());
     }

--- a/src/lib/import_export/csv/csv_parser.hpp
+++ b/src/lib/import_export/csv/csv_parser.hpp
@@ -31,7 +31,8 @@ class CsvParser {
    * @returns             The table that was created from the csv file.
    */
   static std::shared_ptr<Table> parse(const std::string& filename, const CsvMeta& csv_meta,
-                                      const ChunkOffset chunk_size = Chunk::DEFAULT_SIZE);
+                                      const ChunkOffset chunk_size = Chunk::DEFAULT_SIZE,
+                                      const std::optional<EncodingType>& target_encoding = std::nullopt);
   static std::shared_ptr<Table> create_table_from_meta_file(const std::string& filename,
                                                             const ChunkOffset chunk_size = Chunk::DEFAULT_SIZE);
 
@@ -59,8 +60,7 @@ class CsvParser {
    * @returns               The number of rows in the chunk
    */
   static size_t _parse_into_chunk(std::string_view csv_chunk, const std::vector<size_t>& field_ends, const Table& table,
-                                  Segments& segments, const CsvMeta& meta, const std::string& escaped_linebreak,
-                                  std::mutex& append_chunk_mutex);
+                                  Segments& segments, const CsvMeta& meta, const std::string& escaped_linebreak);
 
   /*
    * @param field The field that needs to be modified to be RFC 4180 compliant.

--- a/src/lib/import_export/csv/csv_parser.hpp
+++ b/src/lib/import_export/csv/csv_parser.hpp
@@ -1,11 +1,13 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
 
 #include "import_export/csv/csv_meta.hpp"
+#include "storage/encoding_type.hpp"
 
 namespace hyrise {
 

--- a/src/lib/operators/import.cpp
+++ b/src/lib/operators/import.cpp
@@ -48,7 +48,7 @@ const std::string& Import::name() const {
 }
 
 std::shared_ptr<const Table> Import::_on_execute() {
-  // Check if file exists before giving it to the parser
+  // Check if file exists before giving it to the parser.
   auto file = std::ifstream{filename};
   Assert(file.is_open(), std::format("Import: Could not find file '{}'.", filename));
   file.close();
@@ -75,7 +75,8 @@ std::shared_ptr<const Table> Import::_on_execute() {
           std::cerr << "Warning: Ignoring " << meta_filename << " because table " << _tablename << " already exists.\n";
         }
 
-        const auto& column_definitions = Hyrise::get().storage_manager.get_table(_tablename)->column_definitions();
+        const auto& existing_table = Hyrise::get().storage_manager.get_table(_tablename);
+        const auto& column_definitions = existing_table->column_definitions();
         const auto column_count = column_definitions.size();
 
         csv_meta.columns.resize(column_count);
@@ -83,6 +84,10 @@ std::shared_ptr<const Table> Import::_on_execute() {
           csv_meta.columns[column_id].name = column_definitions[column_id].name;
           csv_meta.columns[column_id].type = data_type_to_string.left.at(column_definitions[column_id].data_type);
           csv_meta.columns[column_id].nullable = column_definitions[column_id].nullable;
+        }
+
+        for (const auto unique_column_id : unique_columns(existing_table)) {
+          csv_meta.columns[unique_column_id].is_unique = true;
         }
       } else if (meta_file_exists) {
         csv_meta = process_csv_meta_file(meta_filename);
@@ -97,7 +102,7 @@ std::shared_ptr<const Table> Import::_on_execute() {
       table = load_table(filename, _chunk_size);
 
       const auto chunk_encoding_spec =
-          auto_select_chunk_encoding_spec(table->column_data_types(), unique_columns(table), _target_encoding);
+          auto_select_chunk_encoding_spec(table->column_data_types(), {}, _target_encoding);
       // .tlb files are mostly used for testing and thus small. In case larger files are frequently loaded, consider
       // parallelizing chunk encoding.
       ChunkEncoder::encode_all_chunks(table, chunk_encoding_spec);
@@ -114,8 +119,8 @@ std::shared_ptr<const Table> Import::_on_execute() {
   }
 
   if (!Hyrise::get().storage_manager.has_table(_tablename)) {
-    // We create statistics when tables are added to the storage manager. As statistics can be expensive to create
-    // and their creation benefits from dictionary encoding, we add the tables after they are encoded.
+    // We create statistics when tables are added to the storage manager. As statistics can be expensive to create and
+    // their creation benefits from dictionary encoding, we add the tables after they are encoded.
     Hyrise::get().storage_manager.add_table(_tablename, table);
     return nullptr;
   }

--- a/src/lib/operators/import.cpp
+++ b/src/lib/operators/import.cpp
@@ -81,11 +81,18 @@ std::shared_ptr<const Table> Import::_on_execute() {
         Fail("Cannot load table from csv. No table definition source found.");
       }
 
-      table = CsvParser::parse(filename, csv_meta, _chunk_size);
+      table = CsvParser::parse(filename, csv_meta, _chunk_size, _target_encoding);
       break;
     }
     case FileType::Tbl: {
       table = load_table(filename, _chunk_size);
+
+      const auto chunk_encoding_spec =
+        auto_select_chunk_encoding_spec(table->column_data_types(), unique_columns(table), _target_encoding);
+      // .tlb files are mostly used for testing and thus small. In case larger files are frequently loaded, consider
+      // parallelizing chunk encoding.
+      ChunkEncoder::encode_all_chunks(table, chunk_encoding_spec);
+
       break;
     }
     case FileType::Binary: {
@@ -97,24 +104,12 @@ std::shared_ptr<const Table> Import::_on_execute() {
     }
   }
 
-  // For binary files, the default is the encoding of the file.
-  if (_file_type != FileType::Binary) {
-    auto chunk_encoding_spec = ChunkEncodingSpec{};
-    const auto column_count = table->column_count();
-    chunk_encoding_spec.reserve(column_count);
-
-    for (auto column_id = ColumnID{0}; column_id < column_count; ++column_id) {
-      // If a target encoding is specified and supported, use it. Otherwise, select the encoding automatically.
-      const auto column_data_type = table->column_data_type(column_id);
-      if (_target_encoding && encoding_supports_data_type(*_target_encoding, column_data_type)) {
-        chunk_encoding_spec.emplace_back(*_target_encoding);
-      } else {
-        chunk_encoding_spec.emplace_back(
-            auto_select_segment_encoding_spec(column_data_type, column_is_unique(table, column_id)));
-      }
-    }
-    ChunkEncoder::encode_all_chunks(table, chunk_encoding_spec);
-  }
+  /**
+   * Notes on the file type-dependent encoding:
+   *   - TBL: Encoding is done sequentially after reading the file, using the automatic encoding selection.
+   *   - CSV: Encoding is done in parallel to reading the file, using the automatic encoding selection.
+   *   - Binary: Binary data is stored encoded, as default we thus use the encoding of the binary files.
+   */
 
   if (!Hyrise::get().storage_manager.has_table(_tablename)) {
     // We create statistics when tables are added to the storage manager. As statistics can be expensive to create
@@ -135,8 +130,8 @@ std::shared_ptr<const Table> Import::_on_execute() {
     existing_table->append_chunk(chunk->segments(), chunk->mvcc_data());
   }
 
-  table->set_table_statistics(TableStatistics::from_table(*table));
-  generate_chunk_pruning_statistics(table);
+  existing_table->set_table_statistics(TableStatistics::from_table(*existing_table));
+  generate_chunk_pruning_statistics(existing_table);
 
   // We must match ImportNode::output_expressions.
   return nullptr;

--- a/src/lib/operators/import.cpp
+++ b/src/lib/operators/import.cpp
@@ -55,6 +55,15 @@ std::shared_ptr<const Table> Import::_on_execute() {
 
   auto table = std::shared_ptr<Table>{};
 
+  /**
+   * Notes on the file type-dependent encoding:
+   *   - TBL: Encoding is done sequentially after reading the file, using the automatic encoding selection and the
+   *          optional target encoding.
+   *   - CSV: Encoding is done in parallel to reading the file, using the automatic encoding selection and the optional
+   *          target encoding.
+   *   - Binary: Binary data is stored encoded. By default, we use the encoding of the binary files.
+   */
+
   switch (_file_type) {
     case FileType::Csv: {
       auto csv_meta = CsvMeta{};
@@ -103,13 +112,6 @@ std::shared_ptr<const Table> Import::_on_execute() {
       Fail("File type should have been determined previously.");
     }
   }
-
-  /**
-   * Notes on the file type-dependent encoding:
-   *   - TBL: Encoding is done sequentially after reading the file, using the automatic encoding selection.
-   *   - CSV: Encoding is done in parallel to reading the file, using the automatic encoding selection.
-   *   - Binary: Binary data is stored encoded, as default we thus use the encoding of the binary files.
-   */
 
   if (!Hyrise::get().storage_manager.has_table(_tablename)) {
     // We create statistics when tables are added to the storage manager. As statistics can be expensive to create

--- a/src/lib/operators/import.cpp
+++ b/src/lib/operators/import.cpp
@@ -88,7 +88,7 @@ std::shared_ptr<const Table> Import::_on_execute() {
       table = load_table(filename, _chunk_size);
 
       const auto chunk_encoding_spec =
-        auto_select_chunk_encoding_spec(table->column_data_types(), unique_columns(table), _target_encoding);
+          auto_select_chunk_encoding_spec(table->column_data_types(), unique_columns(table), _target_encoding);
       // .tlb files are mostly used for testing and thus small. In case larger files are frequently loaded, consider
       // parallelizing chunk encoding.
       ChunkEncoder::encode_all_chunks(table, chunk_encoding_spec);

--- a/src/lib/storage/chunk_encoder.cpp
+++ b/src/lib/storage/chunk_encoder.cpp
@@ -175,7 +175,7 @@ void ChunkEncoder::encode_all_chunks(const std::shared_ptr<Table>& table,
   const auto chunk_count = static_cast<size_t>(table->chunk_count());
   Assert(chunk_encoding_specs.size() == chunk_count, "Number of encoding specs must match table’s chunk count.");
 
-  for (ChunkID chunk_id{0}; chunk_id < chunk_count; ++chunk_id) {
+  for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
     const auto chunk = table->get_chunk(chunk_id);
     Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
@@ -191,7 +191,7 @@ void ChunkEncoder::encode_all_chunks(const std::shared_ptr<Table>& table,
   const auto& column_types = table->column_data_types();
 
   const auto chunk_count = table->chunk_count();
-  for (ChunkID chunk_id{0}; chunk_id < chunk_count; ++chunk_id) {
+  for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
     const auto chunk = table->get_chunk(chunk_id);
     Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
@@ -204,7 +204,7 @@ void ChunkEncoder::encode_all_chunks(const std::shared_ptr<Table>& table,
   const auto& column_types = table->column_data_types();
 
   const auto chunk_count = table->chunk_count();
-  for (ChunkID chunk_id{0}; chunk_id < chunk_count; ++chunk_id) {
+  for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
     const auto chunk = table->get_chunk(chunk_id);
     Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 

--- a/src/lib/storage/segment_encoding_utils.cpp
+++ b/src/lib/storage/segment_encoding_utils.cpp
@@ -95,9 +95,9 @@ ChunkEncodingSpec auto_select_chunk_encoding_spec(const std::vector<DataType>& t
     }
 
     if (target_encoding && encoding_supports_data_type(*target_encoding, types[column_id])) {
-      chunk_encoding_spec.push_back(SegmentEncodingSpec{*target_encoding});
+      chunk_encoding_spec.emplace_back(*target_encoding);
     } else {
-      chunk_encoding_spec.push_back(auto_select_segment_encoding_spec(types[column_id], segment_values_are_unique));
+      chunk_encoding_spec.emplace_back(auto_select_segment_encoding_spec(types[column_id], segment_values_are_unique));
     }
   }
   return chunk_encoding_spec;

--- a/src/lib/storage/segment_encoding_utils.cpp
+++ b/src/lib/storage/segment_encoding_utils.cpp
@@ -81,7 +81,8 @@ VectorCompressionType parent_vector_compression_type(const CompressedVectorType 
 }
 
 ChunkEncodingSpec auto_select_chunk_encoding_spec(const std::vector<DataType>& types,
-                                                  const std::vector<ColumnID>& unique_columns) {
+                                                  const std::vector<ColumnID>& unique_columns,
+                                                  const std::optional<EncodingType>& target_encoding) {
   const auto column_count = types.size();
   auto chunk_encoding_spec = ChunkEncodingSpec{};
   chunk_encoding_spec.reserve(column_count);
@@ -92,7 +93,12 @@ ChunkEncodingSpec auto_select_chunk_encoding_spec(const std::vector<DataType>& t
     if (segment_values_are_unique) {
       ++unique_columns_iter;
     }
-    chunk_encoding_spec.push_back(auto_select_segment_encoding_spec(types[column_id], segment_values_are_unique));
+
+    if (target_encoding && encoding_supports_data_type(*target_encoding, types[column_id])) {
+      chunk_encoding_spec.push_back(SegmentEncodingSpec{*target_encoding});
+    } else {
+      chunk_encoding_spec.push_back(auto_select_segment_encoding_spec(types[column_id], segment_values_are_unique));
+    }
   }
   return chunk_encoding_spec;
 }

--- a/src/lib/storage/segment_encoding_utils.hpp
+++ b/src/lib/storage/segment_encoding_utils.hpp
@@ -32,12 +32,14 @@ SegmentEncodingSpec get_segment_encoding_spec(const std::shared_ptr<const Abstra
 VectorCompressionType parent_vector_compression_type(const CompressedVectorType compressed_vector_type);
 
 /**
- * Selects and encoding for a column based on its data type and whether its values are guaranteed to be unique.
+ * Selects an encoding for a column based on its data type and whether its values are guaranteed to be unique. If a
+ * target encoding is provided and applicable, it takes precedence over the automatic encoding selection.
  * For more details, see #2696. This PR includes a comparison of different encoding strategies:
  * https://github.com/hyrise/hyrise/pull/2696#pullrequestreview-3087933111
  */
 ChunkEncodingSpec auto_select_chunk_encoding_spec(const std::vector<DataType>& types,
-                                                  const std::vector<ColumnID>& unique_columns);
+                                                  const std::vector<ColumnID>& unique_columns,
+                                                  const std::optional<EncodingType>& target_encoding = std::nullopt);
 SegmentEncodingSpec auto_select_segment_encoding_spec(const DataType type,
                                                       const bool segment_values_are_unique = false);
 

--- a/src/test/lib/storage/iterables_test.cpp
+++ b/src/test/lib/storage/iterables_test.cpp
@@ -439,6 +439,7 @@ TEST_F(IterablesTest, ValueSegmentIteratorForEach) {
 
   const auto segment = chunk->get_segment(ColumnID{0});
   const auto int_segment = std::dynamic_pointer_cast<const ValueSegment<int32_t>>(segment);
+  ASSERT_TRUE(int_segment);
 
   const auto iterable = ValueSegmentIterable<int>{*int_segment};
 


### PR DESCRIPTION
Our CSV loading performance is bad. Mostly as we encode each chunk single-threaded.

This PR changes the behaviour for CSV files where chunks are processed in parallel already anyways.
For TBL files, we keep everything as is as those are mostly small and used in tests.

I'll post benchmark numbers later.